### PR TITLE
Update mzLib to fix crash with old calibrated files, split substitutions by nucleotide difference, add mods

### DIFF
--- a/CMD/CMD.csproj
+++ b/CMD/CMD.csproj
@@ -40,8 +40,8 @@
     <LangVersion>default</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Chemistry, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\Chemistry.dll</HintPath>
+    <Reference Include="Chemistry, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\Chemistry.dll</HintPath>
     </Reference>
     <Reference Include="FlashLFQ, Version=1.0.101.0, Culture=neutral, processorArchitecture=AMD64">
       <HintPath>..\packages\FlashLFQ.0.1.92\lib\net451\FlashLFQ.dll</HintPath>
@@ -49,23 +49,23 @@
     <Reference Include="FluentCommandLineParser, Version=1.4.3.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\FluentCommandLineParser.1.4.3\lib\net35\FluentCommandLineParser.dll</HintPath>
     </Reference>
-    <Reference Include="ManagedThermoHelperLayer, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\ManagedThermoHelperLayer.dll</HintPath>
+    <Reference Include="ManagedThermoHelperLayer, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\ManagedThermoHelperLayer.dll</HintPath>
     </Reference>
-    <Reference Include="MassSpectrometry, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\MassSpectrometry.dll</HintPath>
+    <Reference Include="MassSpectrometry, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\MassSpectrometry.dll</HintPath>
     </Reference>
     <Reference Include="MathNet.Numerics, Version=3.20.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MathNet.Numerics.3.20.0\lib\net40\MathNet.Numerics.dll</HintPath>
     </Reference>
-    <Reference Include="mzIdentML, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\mzIdentML.dll</HintPath>
+    <Reference Include="mzIdentML, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\mzIdentML.dll</HintPath>
     </Reference>
-    <Reference Include="MzLibUtil, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\MzLibUtil.dll</HintPath>
+    <Reference Include="MzLibUtil, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\MzLibUtil.dll</HintPath>
     </Reference>
-    <Reference Include="MzML, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\MzML.dll</HintPath>
+    <Reference Include="MzML, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\MzML.dll</HintPath>
     </Reference>
     <Reference Include="NetSerializer, Version=4.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\NetSerializer.4.1.0\lib\net45\NetSerializer.dll</HintPath>
@@ -74,22 +74,22 @@
     <Reference Include="Nett, Version=0.7.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Nett.0.7.0\lib\Net40\Nett.dll</HintPath>
     </Reference>
-    <Reference Include="pepXML, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\pepXML.dll</HintPath>
+    <Reference Include="pepXML, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\pepXML.dll</HintPath>
     </Reference>
-    <Reference Include="Proteomics, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\Proteomics.dll</HintPath>
+    <Reference Include="Proteomics, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\Proteomics.dll</HintPath>
     </Reference>
-    <Reference Include="Spectra, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\Spectra.dll</HintPath>
+    <Reference Include="Spectra, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\Spectra.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="Thermo, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\Thermo.dll</HintPath>
+    <Reference Include="Thermo, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\Thermo.dll</HintPath>
     </Reference>
-    <Reference Include="UsefulProteomicsDatabases, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\UsefulProteomicsDatabases.dll</HintPath>
+    <Reference Include="UsefulProteomicsDatabases, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\UsefulProteomicsDatabases.dll</HintPath>
     </Reference>
     <Reference Include="Zlib.Portable, Version=1.11.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Zlib.Portable.1.11.0\lib\portable-net4+sl5+wp8+win8+wpa81+MonoTouch+MonoAndroid\Zlib.Portable.dll</HintPath>
@@ -122,12 +122,12 @@
     <PreBuildEvent>
     </PreBuildEvent>
   </PropertyGroup>
-  <Import Project="..\packages\mzLib.1.0.226\build\mzLib.targets" Condition="Exists('..\packages\mzLib.1.0.226\build\mzLib.targets')" />
+  <Import Project="..\packages\mzLib.1.0.227\build\mzLib.targets" Condition="Exists('..\packages\mzLib.1.0.227\build\mzLib.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\mzLib.1.0.226\build\mzLib.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\mzLib.1.0.226\build\mzLib.targets'))" />
+    <Error Condition="!Exists('..\packages\mzLib.1.0.227\build\mzLib.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\mzLib.1.0.227\build\mzLib.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/CMD/packages.config
+++ b/CMD/packages.config
@@ -3,7 +3,7 @@
   <package id="FlashLFQ" version="0.1.92" targetFramework="net451" />
   <package id="FluentCommandLineParser" version="1.4.3" targetFramework="net451" />
   <package id="MathNet.Numerics" version="3.20.0" targetFramework="net451" />
-  <package id="mzLib" version="1.0.226" targetFramework="net451" />
+  <package id="mzLib" version="1.0.227" targetFramework="net451" />
   <package id="NetSerializer" version="4.1.0" targetFramework="net451" />
   <package id="Nett" version="0.7.0" targetFramework="net451" />
   <package id="Zlib.Portable" version="1.11.0" targetFramework="net451" />

--- a/EngineLayer/EngineLayer.csproj
+++ b/EngineLayer/EngineLayer.csproj
@@ -39,49 +39,49 @@
     <LangVersion>default</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Chemistry, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\Chemistry.dll</HintPath>
+    <Reference Include="Chemistry, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\Chemistry.dll</HintPath>
     </Reference>
     <Reference Include="FlashLFQ, Version=1.0.101.0, Culture=neutral, processorArchitecture=AMD64">
       <HintPath>..\packages\FlashLFQ.0.1.92\lib\net451\FlashLFQ.dll</HintPath>
     </Reference>
-    <Reference Include="ManagedThermoHelperLayer, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\ManagedThermoHelperLayer.dll</HintPath>
+    <Reference Include="ManagedThermoHelperLayer, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\ManagedThermoHelperLayer.dll</HintPath>
     </Reference>
-    <Reference Include="MassSpectrometry, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\MassSpectrometry.dll</HintPath>
+    <Reference Include="MassSpectrometry, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\MassSpectrometry.dll</HintPath>
     </Reference>
     <Reference Include="MathNet.Numerics, Version=3.20.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MathNet.Numerics.3.20.0\lib\net40\MathNet.Numerics.dll</HintPath>
     </Reference>
-    <Reference Include="mzIdentML, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\mzIdentML.dll</HintPath>
+    <Reference Include="mzIdentML, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\mzIdentML.dll</HintPath>
     </Reference>
-    <Reference Include="MzLibUtil, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\MzLibUtil.dll</HintPath>
+    <Reference Include="MzLibUtil, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\MzLibUtil.dll</HintPath>
     </Reference>
-    <Reference Include="MzML, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\MzML.dll</HintPath>
+    <Reference Include="MzML, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\MzML.dll</HintPath>
     </Reference>
-    <Reference Include="pepXML, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\pepXML.dll</HintPath>
+    <Reference Include="pepXML, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\pepXML.dll</HintPath>
     </Reference>
-    <Reference Include="Proteomics, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\Proteomics.dll</HintPath>
+    <Reference Include="Proteomics, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\Proteomics.dll</HintPath>
     </Reference>
-    <Reference Include="Spectra, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\Spectra.dll</HintPath>
+    <Reference Include="Spectra, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\Spectra.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
     </Reference>
-    <Reference Include="Thermo, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\Thermo.dll</HintPath>
+    <Reference Include="Thermo, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\Thermo.dll</HintPath>
     </Reference>
-    <Reference Include="UsefulProteomicsDatabases, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\UsefulProteomicsDatabases.dll</HintPath>
+    <Reference Include="UsefulProteomicsDatabases, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\UsefulProteomicsDatabases.dll</HintPath>
     </Reference>
     <Reference Include="Zlib.Portable, Version=1.11.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Zlib.Portable.1.11.0\lib\portable-net4+sl5+wp8+win8+wpa81+MonoTouch+MonoAndroid\Zlib.Portable.dll</HintPath>
@@ -237,12 +237,12 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\mzLib.1.0.226\build\mzLib.targets" Condition="Exists('..\packages\mzLib.1.0.226\build\mzLib.targets')" />
+  <Import Project="..\packages\mzLib.1.0.227\build\mzLib.targets" Condition="Exists('..\packages\mzLib.1.0.227\build\mzLib.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\mzLib.1.0.226\build\mzLib.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\mzLib.1.0.226\build\mzLib.targets'))" />
+    <Error Condition="!Exists('..\packages\mzLib.1.0.227\build\mzLib.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\mzLib.1.0.227\build\mzLib.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/EngineLayer/Mods/Mods.txt
+++ b/EngineLayer/Mods/Mods.txt
@@ -60,7 +60,7 @@ MT   Mod
 CF   O2
 //
 ID   Oxidation
-TG   Y or W or P or F or D or E or V or H
+TG   Y or W or P or F or D or E or V or H or K or N or R or C
 PP   Anywhere.
 MT   Mod
 CF   O1
@@ -392,8 +392,8 @@ PP   Anywhere.
 NL   H0 or H30 C16 O1
 CF   H30 C16 O1
 //
-ID   Topaquinone
-TG   Y
+ID   Quinone
+TG   Y or W
 MT   Mod
 PP   Anywhere.
 CF   H-2 O2 

--- a/EngineLayer/Mods/Mods.txt
+++ b/EngineLayer/Mods/Mods.txt
@@ -54,7 +54,7 @@ MT   Metal
 CF   H-1 Na1
 //
 ID   Dioxidation
-TG   W or P
+TG   W or P or R or K or M or F or Y or C
 PP   Anywhere.
 MT   Mod
 CF   O2

--- a/EngineLayer/Mods/Mods.txt
+++ b/EngineLayer/Mods/Mods.txt
@@ -23,6 +23,30 @@ PP   Anywhere.
 MT   Mod
 CF   H-3 N-1
 //
+ID   Propionamide
+TG   C or K
+PP   Anywhere.
+MT   Mod
+CF   H5 C3 N1 O1
+//
+ID   Propionamide
+TG   X
+PP   Peptide N-terminal.
+MT   PeptideTermMod
+CF   H5 C3 N1 O1
+//
+ID   Carboxymethylation
+TG   X
+PP   Peptide N-terminal.
+MT   PeptideTermMod
+CF   H2 C2 O2
+//
+ID   Carboxymethylation
+TG   C or K or W
+PP   Anywhere.
+MT   Mod
+CF   H2 C2 O2
+//
 ID   Sodium
 TG   D or E
 PP   Anywhere.
@@ -52,12 +76,6 @@ TG   X
 PP   Peptide N-terminal.
 MT   PeptideTermMod
 CF   H3 C2 N1 O1
-//
-ID   Carboxymethyl
-TG   C
-PP   Anywhere.
-MT   Mod
-CF   H2 C2 O2
 //
 ID   Carboxylation
 TG   K or D or E

--- a/EngineLayer/Mods/substitutions.txt
+++ b/EngineLayer/Mods/substitutions.txt
@@ -1,2160 +1,2268 @@
 Amino Acid Substitutions
 ID   W->G
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   W
 CF   C-9H-7N-1
 //
 ID   W->A
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   W
 CF   C-8H-5N-1
 //
 ID   Y->G
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   Y
 CF   C-7H-6O-1
 //
 ID   R->G
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   R
 CF   C-4H-9N-3
 //
 ID   W->S
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   W
 CF   C-8H-5N-1O
 //
 ID   Y->A
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   Y
 CF   C-6H-4O-1
 //
 ID   F->G
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   F
 CF   C-7H-6
 //
 ID   W->P
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   W
 CF   C-6H-3N-1
 //
 ID   W->V
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   W
 CF   C-6H-1N-1
 //
 ID   R->A
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   R
 CF   C-3H-7N-3
 //
 ID   W->T
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   W
 CF   C-7H-3N-1O
 //
 ID   W->C
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   W
 CF   C-8H-5N-1S
 //
 ID   H->G
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   H
 CF   C-4H-4N-2
 //
 ID   F->A
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   F
 CF   C-6H-4
 //
 ID   Y->S
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   Y
 CF   C-6H-4
 //
 ID   M->G
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   M
 CF   C-3H-6S-1
 //
-ID   W->Xle
-MT   uniprotUnobservedSubstitution
+ID   W->I
+MT   2+ nucleotide substitution
+PP   Anywhere.
+TG   W
+CF   C-5HN-1
+//
+ID   W->L
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   W
 CF   C-5HN-1
 //
 ID   W->N
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   W
 CF   C-7H-4O
 //
 ID   E->G
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   E
 CF   C-3H-4O-2
 //
 ID   K->G
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   K
 CF   C-4H-9N-1
 //
 ID   W->D
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   W
 CF   C-7H-5N-1O2
 //
 ID   Q->G
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   Q
 CF   C-3H-5N-1O-1
 //
 ID   R->S
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   R
 CF   C-3H-7N-3O
 //
 ID   H->A
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   H
 CF   C-3H-2N-2
 //
 ID   Y->P
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   Y
 CF   C-4H-2O-1
 //
 ID   Y->V
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   Y
 CF   C-4O-1
 //
 ID   Y->T
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   Y
 CF   C-5H-2
 //
 ID   Y->C
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   Y
 CF   C-6H-4O-1S
 //
 ID   F->S
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   F
 CF   C-6H-4O
 //
 ID   M->A
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   M
 CF   C-2H-4S-1
 //
 ID   R->P
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   R
 CF   C-1H-5N-3
 //
 ID   W->Q
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   W
 CF   C-6H-2O
 //
 ID   D->G
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   D
 CF   C-2H-2O-2
 //
 ID   E->A
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   E
 CF   C-2H-2O-2
 //
 ID   W->K
-MT   uniprotUnobservedSubstitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   W
 CF   C-5H2
 //
 ID   K->A
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   K
 CF   C-3H-7N-1
 //
 ID   W->E
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   W
 CF   C-6H-3N-1O2
 //
 ID   R->V
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   R
 CF   C-1H-3N-3
 //
 ID   N->G
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   N
 CF   C-2H-3N-1O-1
 //
 ID   Q->A
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   Q
 CF   C-2H-3N-1O-1
 //
 ID   I->G
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   I
 CF   C-4H-8
 //
 ID   L->G
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   L
 CF   C-4H-8
 //
 ID   R->T
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   R
 CF   C-2H-5N-3O
 //
 ID   W->M
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   W
 CF   C-6H-1N-1S
 //
 ID   R->C
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   R
 CF   C-3H-7N-3S
 //
 ID   H->S
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   H
 CF   C-3H-2N-2O
 //
 ID   F->P
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   F
 CF   C-4H-2
 //
-ID   Y->Xle
-MT   uniprotUnobservedSubstitution
+ID   Y->I
+MT   2+ nucleotide substitution
+PP   Anywhere.
+TG   Y
+CF   C-3H2O-1
+//
+ID   Y->L
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   Y
 CF   C-3H2O-1
 //
 ID   W->H
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   W
 CF   C-5H-3N
 //
 ID   Y->N
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   Y
 CF   C-5H-3N
 //
 ID   Y->D
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   Y
 CF   C-5H-4O
 //
 ID   F->V
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   F
 CF   C-4
 //
 ID   F->T
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   F
 CF   C-5H-2O
 //
 ID   C->G
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   C
 CF   C-1H-2S-1
 //
 ID   F->C
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   F
 CF   C-6H-4S
 //
 ID   T->G
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   T
 CF   C-2H-4O-1
 //
 ID   M->S
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   M
 CF   C-2H-4OS-1
 //
 ID   D->A
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   D
 CF   C-1O-2
 //
-ID   R->Xle
-MT   uniprotUnobservedSubstitution
+ID   R->I
+MT   1 nucleotide substitution
+PP   Anywhere.
+TG   R
+CF   H-1N-3
+//
+ID   R->L
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   R
 CF   H-1N-3
 //
 ID   N->A
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   N
 CF   C-1H-1N-1O-1
 //
 ID   R->N
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   R
 CF   C-2H-6N-2O
 //
 ID   I->A
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   I
 CF   C-3H-6
 //
 ID   L->A
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   L
 CF   C-3H-6
 //
 ID   V->G
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   V
 CF   C-3H-6
 //
 ID   E->S
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   E
 CF   C-2H-2O-1
 //
 ID   R->D
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   R
 CF   C-2H-7N-3O2
 //
 ID   K->S
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   K
 CF   C-3H-7N-1O
 //
 ID   Q->S
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   Q
 CF   C-2H-3N-1
 //
 ID   P->G
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   P
 CF   C-3H-4
 //
 ID   H->P
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   H
 CF   C-1N-2
 //
 ID   W->F
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   W
 CF   C-2H-1N-1
 //
 ID   H->V
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   H
 CF   C-1H2N-2
 //
 ID   H->T
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   H
 CF   C-2N-2O
 //
 ID   Y->Q
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   Y
 CF   C-4H-1N
 //
 ID   Y->K
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   Y
 CF   C-3H3NO-1
 //
 ID   H->C
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   H
 CF   C-3H-2N-2S
 //
 ID   Y->E
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   Y
 CF   C-4H-2O
 //
 ID   M->P
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   M
 CF   H-2S-1
 //
-ID   F->Xle
-MT   uniprotUnobservedSubstitution
+ID   F->I
+MT   1 nucleotide substitution
+PP   Anywhere.
+TG   F
+CF   C-3H2
+//
+ID   F->L
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   F
 CF   C-3H2
 //
 ID   F->N
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   F
 CF   C-5H-3NO
 //
 ID   F->D
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   F
 CF   C-5H-4O2
 //
 ID   Y->M
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   Y
 CF   C-4O-1S
 //
 ID   E->P
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   E
 CF   O-2
 //
 ID   C->A
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   C
 CF   S-1
 //
 ID   M->V
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   M
 CF   S-1
 //
 ID   K->P
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   K
 CF   C-1H-5N-1
 //
 ID   Q->P
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   Q
 CF   H-1N-1O-1
 //
 ID   S->G
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   S
 CF   C-1H-2O-1
 //
 ID   T->A
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   T
 CF   C-1H-2O-1
 //
 ID   M->T
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   M
 CF   C-1H-2OS-1
 //
 ID   W->R
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   W
 CF   C-5H2N2
 //
 ID   E->V
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   E
 CF   H2O-2
 //
 ID   K->V
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   K
 CF   C-1H-3N-1
 //
 ID   Q->V
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   Q
 CF   HN-1O-1
 //
 ID   R->Q
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   R
 CF   C-1H-4N-2O
 //
 ID   M->C
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   M
 CF   C-2H-4
 //
 ID   V->A
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   V
 CF   C-2H-4
 //
 ID   R->K
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   R
 CF   N-2
 //
 ID   D->S
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   D
 CF   C-1O-1
 //
 ID   E->T
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   E
 CF   C-1O-1
 //
 ID   R->E
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   R
 CF   C-1H-5N-3O2
 //
 ID   K->T
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   K
 CF   C-2H-5N-1O
 //
 ID   N->S
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   N
 CF   C-1H-1N-1
 //
 ID   Q->T
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   Q
 CF   C-1H-1N-1
 //
 ID   I->S
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   I
 CF   C-3H-6O
 //
 ID   L->S
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   L
 CF   C-3H-6O
 //
 ID   E->C
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   E
 CF   C-2H-2O-2S
 //
 ID   P->A
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   P
 CF   C-2H-2
 //
 ID   Y->H
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   Y
 CF   C-3H-2N2O-1
 //
 ID   K->C
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   K
 CF   C-3H-7N-1S
 //
 ID   R->M
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   R
 CF   C-1H-3N-3S
 //
 ID   Q->C
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   Q
 CF   C-2H-3N-1O-1S
 //
-ID   H->Xle
-MT   uniprotUnobservedSubstitution
+ID   H->I
+MT   2+ nucleotide substitution
+PP   Anywhere.
+TG   H
+CF   H4N-2
+//
+ID   H->L
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   H
 CF   H4N-2
 //
 ID   H->N
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   H
 CF   C-2H-1N-1O
 //
 ID   W->Y
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   W
 CF   C-2H-1N-1O
 //
 ID   H->D
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   H
 CF   C-2H-2N-2O2
 //
 ID   R->H
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   R
 CF   H-5N-1
 //
 ID   F->Q
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   F
 CF   C-4H-1NO
 //
 ID   F->K
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   F
 CF   C-3H3N
 //
 ID   F->E
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   F
 CF   C-4H-2O2
 //
 ID   D->P
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   D
 CF   CH2O-2
 //
-ID   M->Xle
-MT   uniprotUnobservedSubstitution
+ID   M->I
+MT   1 nucleotide substitution
+PP   Anywhere.
+TG   M
+CF   CH2S-1
+//
+ID   M->L
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   M
 CF   CH2S-1
 //
 ID   M->N
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   M
 CF   C-1H-3NOS-1
 //
 ID   N->P
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   N
 CF   CHN-1O-1
 //
 ID   I->P
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   I
 CF   C-1H-4
 //
 ID   L->P
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   L
 CF   C-1H-4
 //
 ID   F->M
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   F
 CF   C-4S
 //
 ID   M->D
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   M
 CF   C-1H-4O2S-1
 //
 ID   S->A
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   S
 CF   O-1
 //
 ID   Y->F
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   Y
 CF   O-1
 //
 ID   C->S
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   C
 CF   OS-1
 //
 ID   D->V
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   D
 CF   CH4O-2
 //
-ID   E->Xle
-MT   uniprotUnobservedSubstitution
+ID   E->I
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   E
 CF   CH4O-2
 //
-ID   K->Xle
-MT   uniprotUnobservedSubstitution
+ID   E->L
+MT   2+ nucleotide substitution
+PP   Anywhere.
+TG   E
+CF   CH4O-2
+//
+ID   K->I
+MT   1 nucleotide substitution
+PP   Anywhere.
+TG   K
+CF   H-1N-1
+//
+ID   K->L
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   K
 CF   H-1N-1
 //
 ID   E->N
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   E
 CF   C-1H-1NO-1
 //
 ID   N->V
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   N
 CF   CH3N-1O-1
 //
-ID   Q->Xle
-MT   uniprotUnobservedSubstitution
+ID   Q->I
+MT   2+ nucleotide substitution
+PP   Anywhere.
+TG   Q
+CF   CH3N-1O-1
+//
+ID   Q->L
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   Q
 CF   CH3N-1O-1
 //
 ID   K->N
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   K
 CF   C-2H-6O
 //
 ID   A->G
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   A
 CF   C-1H-2
 //
 ID   E->D
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   E
 CF   C-1H-2
 //
 ID   I->V
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   I
 CF   C-1H-2
 //
 ID   L->V
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   L
 CF   C-1H-2
 //
 ID   Q->N
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   Q
 CF   C-1H-2
 //
 ID   T->S
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   T
 CF   C-1H-2
 //
 ID   D->T
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   D
 CF   H2O-1
 //
 ID   K->D
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   K
 CF   C-2H-7N-1O2
 //
 ID   Q->D
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   Q
 CF   C-1H-3N-1O
 //
 ID   N->T
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   N
 CF   HN-1
 //
 ID   I->T
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   I
 CF   C-2H-4O
 //
 ID   L->T
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   L
 CF   C-2H-4O
 //
 ID   V->S
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   V
 CF   C-2H-4O
 //
 ID   D->C
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   D
 CF   C-1O-2S
 //
 ID   N->C
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   N
 CF   C-1H-1N-1O-1S
 //
 ID   I->C
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   I
 CF   C-3H-6S
 //
 ID   L->C
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   L
 CF   C-3H-6S
 //
 ID   P->S
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   P
 CF   C-2H-2O
 //
 ID   F->H
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   F
 CF   C-3H-2N2
 //
 ID   R->F
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   R
 CF   C3H-3N-3
 //
 ID   H->Q
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   H
 CF   C-1HN-1O
 //
 ID   H->K
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   H
 CF   H5N-1
 //
 ID   H->E
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   H
 CF   C-1N-2O2
 //
 ID   Y->R
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   Y
 CF   C-3H3N3O-1
 //
 ID   H->M
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   H
 CF   C-1H2N-2S
 //
 ID   C->P
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   C
 CF   C2H2S-1
 //
 ID   T->P
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   T
 CF   CO-1
 //
 ID   C->V
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   C
 CF   C2H4S-1
 //
 ID   M->Q
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   M
 CF   H-1NOS-1
 //
 ID   M->K
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   M
 CF   CH3NS-1
 //
 ID   V->P
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   V
 CF   H-2
 //
 ID   M->E
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   M
 CF   H-2O2S-1
 //
 ID   T->V
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   T
 CF   CH2O-1
 //
 ID   C->T
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   C
 CF   CH2OS-1
 //
-ID   D->Xle
-MT   uniprotUnobservedSubstitution
+ID   D->I
+MT   2+ nucleotide substitution
+PP   Anywhere.
+TG   D
+CF   C2H6O-2
+//
+ID   D->L
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   D
 CF   C2H6O-2
 //
 ID   D->N
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   D
 CF   HNO-1
 //
 ID   E->Q
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   E
 CF   HNO-1
 //
-ID   N->Xle
-MT   uniprotUnobservedSubstitution
+ID   N->I
+MT   1 nucleotide substitution
+PP   Anywhere.
+TG   N
+CF   C2H5N-1O-1
+//
+ID   N->L
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   N
 CF   C2H5N-1O-1
 //
 ID   E->K
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   E
 CF   CH5NO-2
 //
 ID   K->Q
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   K
 CF   C-1H-4O
 //
 ID   Q->K
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   Q
 CF   CH4O-1
 //
 ID   K->E
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   K
 CF   C-1H-5N-1O2
 //
 ID   I->N
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   I
 CF   C-2H-5NO
 //
 ID   L->N
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   L
 CF   C-2H-5NO
 //
 ID   N->D
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   N
 CF   H-1N-1O
 //
 ID   Q->E
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   Q
 CF   H-1N-1O
 //
 ID   I->D
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   I
 CF   C-2H-6O2
 //
 ID   L->D
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   L
 CF   C-2H-6O2
 //
 ID   T->C
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   T
 CF   C-1H-2O-1S
 //
 ID   V->T
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   V
 CF   C-1H-2O
 //
 ID   E->M
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   E
 CF   H2O-2S
 //
 ID   P->V
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   P
 CF   H2
 //
 ID   K->M
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   K
 CF   C-1H-3N-1S
 //
 ID   Q->M
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   Q
 CF   HN-1O-1S
 //
 ID   V->C
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   V
 CF   C-2H-4S
 //
 ID   P->T
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   P
 CF   C-1O
 //
 ID   P->C
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   P
 CF   C-2H-2S
 //
 ID   M->H
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   M
 CF   CH-2N2S-1
 //
 ID   R->Y
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   R
 CF   C3H-3N-3O
 //
 ID   E->H
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   E
 CF   CN2O-2
 //
 ID   K->H
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   K
 CF   H-5N
 //
 ID   Q->H
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   Q
 CF   CH-1NO-1
 //
 ID   F->R
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   F
 CF   C-3H3N3
 //
 ID   H->F
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   H
 CF   C3H2N-2
 //
 ID   S->P
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   S
 CF   C2H2O-1
 //
-ID   C->Xle
-MT   uniprotUnobservedSubstitution
+ID   C->I
+MT   2+ nucleotide substitution
+PP   Anywhere.
+TG   C
+CF   C3H6S-1
+//
+ID   C->L
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   C
 CF   C3H6S-1
 //
 ID   C->N
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   C
 CF   CHNOS-1
 //
 ID   C->D
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   C
 CF   CO2S-1
 //
 ID   S->V
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   S
 CF   C2H4O-1
 //
-ID   T->Xle
-MT   uniprotUnobservedSubstitution
+ID   T->I
+MT   1 nucleotide substitution
+PP   Anywhere.
+TG   T
+CF   C2H4O-1
+//
+ID   T->L
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   T
 CF   C2H4O-1
 //
 ID   T->N
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   T
 CF   H-1N
 //
 ID   D->Q
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   D
 CF   CH3NO-1
 //
 ID   D->K
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   D
 CF   C2H7NO-2
 //
 ID   T->D
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   T
 CF   H-2O
 //
 ID   D->E
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   D
 CF   CH2
 //
 ID   G->A
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   G
 CF   CH2
 //
 ID   N->Q
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   N
 CF   CH2
 //
 ID   S->T
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   S
 CF   CH2
 //
-ID   V->Xle
-MT   uniprotUnobservedSubstitution
+ID   V->I
+MT   1 nucleotide substitution
+PP   Anywhere.
+TG   V
+CF   CH2
+//
+ID   V->L
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   V
 CF   CH2
 //
 ID   N->K
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   N
 CF   C2H6O-1
 //
 ID   I->Q
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   I
 CF   C-1H-3NO
 //
 ID   L->Q
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   L
 CF   C-1H-3NO
 //
 ID   V->N
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   V
 CF   C-1H-3NO
 //
 ID   N->E
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   N
 CF   CHN-1O
 //
 ID   I->K
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   I
 CF   HN
 //
 ID   L->K
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   L
 CF   HN
 //
 ID   I->E
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   I
 CF   C-1H-4O2
 //
 ID   L->E
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   L
 CF   C-1H-4O2
 //
 ID   V->D
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   V
 CF   C-1H-4O2
 //
 ID   S->C
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   S
 CF   O-1S
 //
 ID   A->S
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   A
 CF   O
 //
 ID   F->Y
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   F
 CF   O
 //
 ID   D->M
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   D
 CF   CH4O-2S
 //
 ID   M->F
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   M
 CF   C4S-1
 //
-ID   P->Xle
-MT   uniprotUnobservedSubstitution
+ID   P->I
+MT   2+ nucleotide substitution
+PP   Anywhere.
+TG   P
+CF   CH4
+//
+ID   P->L
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   P
 CF   CH4
 //
 ID   P->N
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   P
 CF   C-1H-1NO
 //
 ID   N->M
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   N
 CF   CH3N-1O-1S
 //
 ID   I->M
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   I
 CF   C-1H-2S
 //
 ID   L->M
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   L
 CF   C-1H-2S
 //
 ID   P->D
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   P
 CF   C-1H-2O2
 //
 ID   E->F
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   E
 CF   C4H2O-2
 //
 ID   K->F
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   K
 CF   C3H-3N-1
 //
 ID   Q->F
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   Q
 CF   C4HN-1O-1
 //
 ID   H->R
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   H
 CF   H5N
 //
 ID   D->H
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   D
 CF   C2H2N2O-2
 //
 ID   N->H
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   N
 CF   C2HNO-1
 //
 ID   Y->W
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   Y
 CF   C2HNO-1
 //
 ID   I->H
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   I
 CF   H-4N2
 //
 ID   L->H
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   L
 CF   H-4N2
 //
 ID   C->Q
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   C
 CF   C2H3NOS-1
 //
 ID   M->R
-MT   substitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   M
 CF   CH3N3S-1
 //
 ID   C->K
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   C
 CF   C3H7NS-1
 //
 ID   H->Y
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   H
 CF   C3H2N-2O
 //
 ID   A->P
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   A
 CF   C2H2
 //
 ID   C->E
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   C
 CF   C2H2O2S-1
 //
-ID   S->Xle
-MT   uniprotUnobservedSubstitution
+ID   S->I
+MT   1 nucleotide substitution
+PP   Anywhere.
+TG   S
+CF   C3H6O-1
+//
+ID   S->L
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   S
 CF   C3H6O-1
 //
 ID   S->N
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   S
 CF   CHN
 //
 ID   T->Q
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   T
 CF   CHN
 //
 ID   T->K
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   T
 CF   C2H5NO-1
 //
 ID   E->R
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   E
 CF   CH5N3O-2
 //
 ID   S->D
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   S
 CF   CO
 //
 ID   T->E
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   T
 CF   CO
 //
 ID   K->R
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   K
 CF   N2
 //
 ID   A->V
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   A
 CF   C2H4
 //
 ID   C->M
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   C
 CF   C2H4
 //
 ID   Q->R
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   Q
 CF   CH4N2O-1
 //
 ID   V->Q
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   V
 CF   H-1NO
 //
 ID   V->K
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   V
 CF   CH3N
 //
 ID   V->E
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   V
 CF   H-2O2
 //
 ID   R->W
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   R
 CF   C5H-2N-2
 //
 ID   T->M
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   T
 CF   CH2O-1S
 //
 ID   A->T
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   A
 CF   CH2O
 //
 ID   G->S
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   G
 CF   CH2O
 //
 ID   P->Q
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   P
 CF   HNO
 //
 ID   P->K
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   P
 CF   CH5N
 //
 ID   A->C
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   A
 CF   S
 //
 ID   V->M
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   V
 CF   S
 //
 ID   P->E
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   P
 CF   O2
 //
 ID   M->Y
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   M
 CF   C4OS-1
 //
 ID   D->F
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   D
 CF   C5H4O-2
 //
 ID   N->F
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   N
 CF   C5H3N-1O-1
 //
 ID   I->F
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   I
 CF   C3H-2
 //
 ID   L->F
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   L
 CF   C3H-2
 //
 ID   P->M
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   P
 CF   H2S
 //
 ID   E->Y
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   E
 CF   C4H2O-1
 //
 ID   C->H
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   C
 CF   C3H2N2S-1
 //
 ID   K->Y
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   K
 CF   C3H-3N-1O
 //
 ID   Q->Y
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   Q
 CF   C4HN-1
 //
 ID   T->H
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   T
 CF   C2N2O-1
 //
 ID   V->H
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   V
 CF   CH-2N2
 //
 ID   F->W
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   F
 CF   C2HN
 //
 ID   P->H
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   P
 CF   CN2
 //
 ID   G->P
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   G
 CF   C3H4
 //
 ID   S->Q
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   S
 CF   C2H3N
 //
 ID   S->K
-MT   uniprotUnobservedSubstitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   S
 CF   C3H7NO-1
 //
 ID   D->R
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   D
 CF   C2H7N3O-2
 //
 ID   S->E
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   S
 CF   C2H2O
 //
-ID   A->Xle
-MT   uniprotUnobservedSubstitution
+ID   A->I
+MT   2+ nucleotide substitution
+PP   Anywhere.
+TG   A
+CF   C3H6
+//
+ID   A->L
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   A
 CF   C3H6
 //
 ID   G->V
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   G
 CF   C3H6
 //
 ID   N->R
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   N
 CF   C2H6N2O-1
 //
 ID   A->N
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   A
 CF   CHNO
 //
 ID   I->R
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   I
 CF   HN3
 //
 ID   L->R
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   L
 CF   HN3
 //
 ID   A->D
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   A
 CF   CO2
 //
 ID   S->M
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   S
 CF   C2H4O-1S
 //
 ID   G->T
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   G
 CF   C2H4O
 //
 ID   C->F
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   C
 CF   C6H4S-1
 //
 ID   G->C
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   G
 CF   CH2S
 //
 ID   T->F
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   T
 CF   C5H2O-1
 //
 ID   V->F
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   V
 CF   C4
 //
 ID   D->Y
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   D
 CF   C5H4O-1
 //
 ID   H->W
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   H
 CF   C5H3N-1
 //
 ID   N->Y
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   N
 CF   C5H3N-1
 //
 ID   I->Y
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   I
 CF   C3H-2O
 //
 ID   L->Y
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   L
 CF   C3H-2O
 //
 ID   P->F
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   P
 CF   C4H2
 //
 ID   S->H
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   S
 CF   C3H2N2O-1
 //
 ID   C->R
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   C
 CF   C3H7N3S-1
 //
 ID   M->W
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   M
 CF   C6HNS-1
 //
 ID   T->R
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   T
 CF   C2H5N3O-1
 //
-ID   G->Xle
-MT   uniprotUnobservedSubstitution
+ID   G->I
+MT   2+ nucleotide substitution
+PP   Anywhere.
+TG   G
+CF   C4H8
+//
+ID   G->L
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   G
 CF   C4H8
 //
 ID   A->Q
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   A
 CF   C2H3NO
 //
 ID   G->N
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   G
 CF   C2H3NO
 //
 ID   V->R
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   V
 CF   CH3N3
 //
 ID   E->W
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   E
 CF   C6H3NO-2
 //
 ID   A->K
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   A
 CF   C3H7N
 //
 ID   K->W
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   K
 CF   C5H-2
 //
 ID   A->E
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   A
 CF   C2H2O2
 //
 ID   G->D
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   G
 CF   C2H2O2
 //
 ID   Q->W
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   Q
 CF   C6H2O-1
 //
 ID   P->R
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   P
 CF   CH5N3
 //
 ID   A->M
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   A
 CF   C2H4S
 //
 ID   S->F
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   S
 CF   C6H4O-1
 //
 ID   C->Y
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   C
 CF   C6H4OS-1
 //
 ID   T->Y
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   T
 CF   C5H2
 //
 ID   V->Y
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   V
 CF   C4O
 //
 ID   P->Y
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   P
 CF   C4H2O
 //
 ID   A->H
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   A
 CF   C3H2N2
 //
 ID   S->R
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   S
 CF   C3H7N3O-1
 //
 ID   G->Q
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   G
 CF   C3H5NO
 //
 ID   D->W
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   D
 CF   C7H5NO-2
 //
 ID   G->K
-MT   uniprotUnobservedSubstitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   G
 CF   C4H9N
 //
 ID   G->E
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   G
 CF   C3H4O2
 //
 ID   N->W
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   N
 CF   C7H4O-1
 //
 ID   I->W
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   I
 CF   C5H-1N
 //
 ID   L->W
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   L
 CF   C5H-1N
 //
 ID   G->M
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   G
 CF   C3H6S
 //
 ID   A->F
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   A
 CF   C6H4
 //
 ID   S->Y
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   S
 CF   C6H4
 //
 ID   G->H
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   G
 CF   C4H4N2
 //
 ID   C->W
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   C
 CF   C8H5NS-1
 //
 ID   T->W
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   T
 CF   C7H3NO-1
 //
 ID   A->R
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   A
 CF   C3H7N3
 //
 ID   V->W
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   V
 CF   C6HN
 //
 ID   P->W
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   P
 CF   C6H3N
 //
 ID   G->F
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   G
 CF   C7H6
 //
 ID   A->Y
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   A
 CF   C6H4O
 //
 ID   S->W
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   S
 CF   C8H5NO-1
 //
 ID   G->R
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   G
 CF   C4H9N3
 //
 ID   G->Y
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   G
 CF   C7H6O
 //
 ID   A->W
-MT   uniprotUnobservedSubstitution
+MT   2+ nucleotide substitution
 PP   Anywhere.
 TG   A
 CF   C8H5N
 //
 ID   G->W
-MT   substitution
+MT   1 nucleotide substitution
 PP   Anywhere.
 TG   G
 CF   C9H7N

--- a/EngineLayer/Mods/substitutions.txt
+++ b/EngineLayer/Mods/substitutions.txt
@@ -6,13 +6,13 @@ TG   W
 CF   C-9H-7N-1
 //
 ID   W->A
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   W
 CF   C-8H-5N-1
 //
 ID   Y->G
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   Y
 CF   C-7H-6O-1
@@ -30,37 +30,37 @@ TG   W
 CF   C-8H-5N-1O
 //
 ID   Y->A
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   Y
 CF   C-6H-4O-1
 //
 ID   F->G
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   F
 CF   C-7H-6
 //
 ID   W->P
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   W
 CF   C-6H-3N-1
 //
 ID   W->V
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   W
 CF   C-6H-1N-1
 //
 ID   R->A
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   R
 CF   C-3H-7N-3
 //
 ID   W->T
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   W
 CF   C-7H-3N-1O
@@ -72,13 +72,13 @@ TG   W
 CF   C-8H-5N-1S
 //
 ID   H->G
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   H
 CF   C-4H-4N-2
 //
 ID   F->A
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   F
 CF   C-6H-4
@@ -90,19 +90,19 @@ TG   Y
 CF   C-6H-4
 //
 ID   M->G
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   M
 CF   C-3H-6S-1
 //
 ID   W->Xle
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   W
 CF   C-5HN-1
 //
 ID   W->N
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   W
 CF   C-7H-4O
@@ -114,19 +114,19 @@ TG   E
 CF   C-3H-4O-2
 //
 ID   K->G
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   K
 CF   C-4H-9N-1
 //
 ID   W->D
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   W
 CF   C-7H-5N-1O2
 //
 ID   Q->G
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   Q
 CF   C-3H-5N-1O-1
@@ -138,25 +138,25 @@ TG   R
 CF   C-3H-7N-3O
 //
 ID   H->A
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   H
 CF   C-3H-2N-2
 //
 ID   Y->P
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   Y
 CF   C-4H-2O-1
 //
 ID   Y->V
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   Y
 CF   C-4O-1
 //
 ID   Y->T
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   Y
 CF   C-5H-2
@@ -174,7 +174,7 @@ TG   F
 CF   C-6H-4O
 //
 ID   M->A
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   M
 CF   C-2H-4S-1
@@ -186,7 +186,7 @@ TG   R
 CF   C-1H-5N-3
 //
 ID   W->Q
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   W
 CF   C-6H-2O
@@ -204,49 +204,49 @@ TG   E
 CF   C-2H-2O-2
 //
 ID   W->K
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   W
 CF   C-5H2
 //
 ID   K->A
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   K
 CF   C-3H-7N-1
 //
 ID   W->E
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   W
 CF   C-6H-3N-1O2
 //
 ID   R->V
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   R
 CF   C-1H-3N-3
 //
 ID   N->G
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   N
 CF   C-2H-3N-1O-1
 //
 ID   Q->A
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   Q
 CF   C-2H-3N-1O-1
 //
 ID   I->G
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   I
 CF   C-4H-8
 //
 ID   L->G
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   L
 CF   C-4H-8
@@ -258,7 +258,7 @@ TG   R
 CF   C-2H-5N-3O
 //
 ID   W->M
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   W
 CF   C-6H-1N-1S
@@ -270,25 +270,25 @@ TG   R
 CF   C-3H-7N-3S
 //
 ID   H->S
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   H
 CF   C-3H-2N-2O
 //
 ID   F->P
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   F
 CF   C-4H-2
 //
 ID   Y->Xle
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   Y
 CF   C-3H2O-1
 //
 ID   W->H
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   W
 CF   C-5H-3N
@@ -312,7 +312,7 @@ TG   F
 CF   C-4
 //
 ID   F->T
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   F
 CF   C-5H-2O
@@ -330,13 +330,13 @@ TG   F
 CF   C-6H-4S
 //
 ID   T->G
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   T
 CF   C-2H-4O-1
 //
 ID   M->S
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   M
 CF   C-2H-4OS-1
@@ -348,31 +348,31 @@ TG   D
 CF   C-1O-2
 //
 ID   R->Xle
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   R
 CF   H-1N-3
 //
 ID   N->A
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   N
 CF   C-1H-1N-1O-1
 //
 ID   R->N
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   R
 CF   C-2H-6N-2O
 //
 ID   I->A
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   I
 CF   C-3H-6
 //
 ID   L->A
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   L
 CF   C-3H-6
@@ -384,31 +384,31 @@ TG   V
 CF   C-3H-6
 //
 ID   E->S
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   E
 CF   C-2H-2O-1
 //
 ID   R->D
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   R
 CF   C-2H-7N-3O2
 //
 ID   K->S
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   K
 CF   C-3H-7N-1O
 //
 ID   Q->S
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   Q
 CF   C-2H-3N-1
 //
 ID   P->G
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   P
 CF   C-3H-4
@@ -420,85 +420,85 @@ TG   H
 CF   C-1N-2
 //
 ID   W->F
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   W
 CF   C-2H-1N-1
 //
 ID   H->V
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   H
 CF   C-1H2N-2
 //
 ID   H->T
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   H
 CF   C-2N-2O
 //
 ID   Y->Q
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   Y
 CF   C-4H-1N
 //
 ID   Y->K
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   Y
 CF   C-3H3NO-1
 //
 ID   H->C
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   H
 CF   C-3H-2N-2S
 //
 ID   Y->E
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   Y
 CF   C-4H-2O
 //
 ID   M->P
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   M
 CF   H-2S-1
 //
 ID   F->Xle
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   F
 CF   C-3H2
 //
 ID   F->N
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   F
 CF   C-5H-3NO
 //
 ID   F->D
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   F
 CF   C-5H-4O2
 //
 ID   Y->M
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   Y
 CF   C-4O-1S
 //
 ID   E->P
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   E
 CF   O-2
 //
 ID   C->A
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   C
 CF   S-1
@@ -510,7 +510,7 @@ TG   M
 CF   S-1
 //
 ID   K->P
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   K
 CF   C-1H-5N-1
@@ -552,13 +552,13 @@ TG   E
 CF   H2O-2
 //
 ID   K->V
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   K
 CF   C-1H-3N-1
 //
 ID   Q->V
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   Q
 CF   HN-1O-1
@@ -570,7 +570,7 @@ TG   R
 CF   C-1H-4N-2O
 //
 ID   M->C
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   M
 CF   C-2H-4
@@ -588,19 +588,19 @@ TG   R
 CF   N-2
 //
 ID   D->S
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   D
 CF   C-1O-1
 //
 ID   E->T
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   E
 CF   C-1O-1
 //
 ID   R->E
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   R
 CF   C-1H-5N-3O2
@@ -618,7 +618,7 @@ TG   N
 CF   C-1H-1N-1
 //
 ID   Q->T
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   Q
 CF   C-1H-1N-1
@@ -636,7 +636,7 @@ TG   L
 CF   C-3H-6O
 //
 ID   E->C
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   E
 CF   C-2H-2O-2S
@@ -654,7 +654,7 @@ TG   Y
 CF   C-3H-2N2O-1
 //
 ID   K->C
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   K
 CF   C-3H-7N-1S
@@ -666,13 +666,13 @@ TG   R
 CF   C-1H-3N-3S
 //
 ID   Q->C
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   Q
 CF   C-2H-3N-1O-1S
 //
 ID   H->Xle
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   H
 CF   H4N-2
@@ -684,7 +684,7 @@ TG   H
 CF   C-2H-1N-1O
 //
 ID   W->Y
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   W
 CF   C-2H-1N-1O
@@ -702,49 +702,49 @@ TG   R
 CF   H-5N-1
 //
 ID   F->Q
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   F
 CF   C-4H-1NO
 //
 ID   F->K
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   F
 CF   C-3H3N
 //
 ID   F->E
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   F
 CF   C-4H-2O2
 //
 ID   D->P
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   D
 CF   CH2O-2
 //
 ID   M->Xle
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   M
 CF   CH2S-1
 //
 ID   M->N
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   M
 CF   C-1H-3NOS-1
 //
 ID   N->P
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   N
 CF   CHN-1O-1
 //
 ID   I->P
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   I
 CF   C-1H-4
@@ -756,13 +756,13 @@ TG   L
 CF   C-1H-4
 //
 ID   F->M
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   F
 CF   C-4S
 //
 ID   M->D
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   M
 CF   C-1H-4O2S-1
@@ -792,31 +792,31 @@ TG   D
 CF   CH4O-2
 //
 ID   E->Xle
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   E
 CF   CH4O-2
 //
 ID   K->Xle
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   K
 CF   H-1N-1
 //
 ID   E->N
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   E
 CF   C-1H-1NO-1
 //
 ID   N->V
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   N
 CF   CH3N-1O-1
 //
 ID   Q->Xle
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   Q
 CF   CH3N-1O-1
@@ -852,7 +852,7 @@ TG   L
 CF   C-1H-2
 //
 ID   Q->N
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   Q
 CF   C-1H-2
@@ -864,19 +864,19 @@ TG   T
 CF   C-1H-2
 //
 ID   D->T
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   D
 CF   H2O-1
 //
 ID   K->D
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   K
 CF   C-2H-7N-1O2
 //
 ID   Q->D
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   Q
 CF   C-1H-3N-1O
@@ -894,37 +894,37 @@ TG   I
 CF   C-2H-4O
 //
 ID   L->T
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   L
 CF   C-2H-4O
 //
 ID   V->S
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   V
 CF   C-2H-4O
 //
 ID   D->C
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   D
 CF   C-1O-2S
 //
 ID   N->C
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   N
 CF   C-1H-1N-1O-1S
 //
 ID   I->C
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   I
 CF   C-3H-6S
 //
 ID   L->C
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   L
 CF   C-3H-6S
@@ -936,13 +936,13 @@ TG   P
 CF   C-2H-2O
 //
 ID   F->H
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   F
 CF   C-3H-2N2
 //
 ID   R->F
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   R
 CF   C3H-3N-3
@@ -954,31 +954,31 @@ TG   H
 CF   C-1HN-1O
 //
 ID   H->K
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   H
 CF   H5N-1
 //
 ID   H->E
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   H
 CF   C-1N-2O2
 //
 ID   Y->R
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   Y
 CF   C-3H3N3O-1
 //
 ID   H->M
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   H
 CF   C-1H2N-2S
 //
 ID   C->P
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   C
 CF   C2H2S-1
@@ -990,13 +990,13 @@ TG   T
 CF   CO-1
 //
 ID   C->V
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   C
 CF   C2H4S-1
 //
 ID   M->Q
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   M
 CF   H-1NOS-1
@@ -1008,31 +1008,31 @@ TG   M
 CF   CH3NS-1
 //
 ID   V->P
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   V
 CF   H-2
 //
 ID   M->E
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   M
 CF   H-2O2S-1
 //
 ID   T->V
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   T
 CF   CH2O-1
 //
 ID   C->T
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   C
 CF   CH2OS-1
 //
 ID   D->Xle
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   D
 CF   C2H6O-2
@@ -1050,7 +1050,7 @@ TG   E
 CF   HNO-1
 //
 ID   N->Xle
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   N
 CF   C2H5N-1O-1
@@ -1086,7 +1086,7 @@ TG   I
 CF   C-2H-5NO
 //
 ID   L->N
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   L
 CF   C-2H-5NO
@@ -1104,37 +1104,37 @@ TG   Q
 CF   H-1N-1O
 //
 ID   I->D
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   I
 CF   C-2H-6O2
 //
 ID   L->D
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   L
 CF   C-2H-6O2
 //
 ID   T->C
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   T
 CF   C-1H-2O-1S
 //
 ID   V->T
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   V
 CF   C-1H-2O
 //
 ID   E->M
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   E
 CF   H2O-2S
 //
 ID   P->V
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   P
 CF   H2
@@ -1146,13 +1146,13 @@ TG   K
 CF   C-1H-3N-1S
 //
 ID   Q->M
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   Q
 CF   HN-1O-1S
 //
 ID   V->C
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   V
 CF   C-2H-4S
@@ -1164,31 +1164,31 @@ TG   P
 CF   C-1O
 //
 ID   P->C
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   P
 CF   C-2H-2S
 //
 ID   M->H
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   M
 CF   CH-2N2S-1
 //
 ID   R->Y
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   R
 CF   C3H-3N-3O
 //
 ID   E->H
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   E
 CF   CN2O-2
 //
 ID   K->H
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   K
 CF   H-5N
@@ -1200,13 +1200,13 @@ TG   Q
 CF   CH-1NO-1
 //
 ID   F->R
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   F
 CF   C-3H3N3
 //
 ID   H->F
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   H
 CF   C3H2N-2
@@ -1218,31 +1218,31 @@ TG   S
 CF   C2H2O-1
 //
 ID   C->Xle
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   C
 CF   C3H6S-1
 //
 ID   C->N
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   C
 CF   CHNOS-1
 //
 ID   C->D
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   C
 CF   CO2S-1
 //
 ID   S->V
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   S
 CF   C2H4O-1
 //
 ID   T->Xle
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   T
 CF   C2H4O-1
@@ -1254,19 +1254,19 @@ TG   T
 CF   H-1N
 //
 ID   D->Q
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   D
 CF   CH3NO-1
 //
 ID   D->K
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   D
 CF   C2H7NO-2
 //
 ID   T->D
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   T
 CF   H-2O
@@ -1284,7 +1284,7 @@ TG   G
 CF   CH2
 //
 ID   N->Q
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   N
 CF   CH2
@@ -1296,7 +1296,7 @@ TG   S
 CF   CH2
 //
 ID   V->Xle
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   V
 CF   CH2
@@ -1308,7 +1308,7 @@ TG   N
 CF   C2H6O-1
 //
 ID   I->Q
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   I
 CF   C-1H-3NO
@@ -1320,13 +1320,13 @@ TG   L
 CF   C-1H-3NO
 //
 ID   V->N
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   V
 CF   C-1H-3NO
 //
 ID   N->E
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   N
 CF   CHN-1O
@@ -1338,19 +1338,19 @@ TG   I
 CF   HN
 //
 ID   L->K
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   L
 CF   HN
 //
 ID   I->E
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   I
 CF   C-1H-4O2
 //
 ID   L->E
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   L
 CF   C-1H-4O2
@@ -1380,31 +1380,31 @@ TG   F
 CF   O
 //
 ID   D->M
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   D
 CF   CH4O-2S
 //
 ID   M->F
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   M
 CF   C4S-1
 //
 ID   P->Xle
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   P
 CF   CH4
 //
 ID   P->N
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   P
 CF   C-1H-1NO
 //
 ID   N->M
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   N
 CF   CH3N-1O-1S
@@ -1422,25 +1422,25 @@ TG   L
 CF   C-1H-2S
 //
 ID   P->D
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   P
 CF   C-1H-2O2
 //
 ID   E->F
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   E
 CF   C4H2O-2
 //
 ID   K->F
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   K
 CF   C3H-3N-1
 //
 ID   Q->F
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   Q
 CF   C4HN-1O-1
@@ -1464,13 +1464,13 @@ TG   N
 CF   C2HNO-1
 //
 ID   Y->W
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   Y
 CF   C2HNO-1
 //
 ID   I->H
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   I
 CF   H-4N2
@@ -1482,7 +1482,7 @@ TG   L
 CF   H-4N2
 //
 ID   C->Q
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   C
 CF   C2H3NOS-1
@@ -1494,7 +1494,7 @@ TG   M
 CF   CH3N3S-1
 //
 ID   C->K
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   C
 CF   C3H7NS-1
@@ -1512,13 +1512,13 @@ TG   A
 CF   C2H2
 //
 ID   C->E
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   C
 CF   C2H2O2S-1
 //
 ID   S->Xle
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   S
 CF   C3H6O-1
@@ -1530,7 +1530,7 @@ TG   S
 CF   CHN
 //
 ID   T->Q
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   T
 CF   CHN
@@ -1542,19 +1542,19 @@ TG   T
 CF   C2H5NO-1
 //
 ID   E->R
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   E
 CF   CH5N3O-2
 //
 ID   S->D
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   S
 CF   CO
 //
 ID   T->E
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   T
 CF   CO
@@ -1572,7 +1572,7 @@ TG   A
 CF   C2H4
 //
 ID   C->M
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   C
 CF   C2H4
@@ -1584,13 +1584,13 @@ TG   Q
 CF   CH4N2O-1
 //
 ID   V->Q
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   V
 CF   H-1NO
 //
 ID   V->K
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   V
 CF   CH3N
@@ -1632,13 +1632,13 @@ TG   P
 CF   HNO
 //
 ID   P->K
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   P
 CF   CH5N
 //
 ID   A->C
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   A
 CF   S
@@ -1650,25 +1650,25 @@ TG   V
 CF   S
 //
 ID   P->E
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   P
 CF   O2
 //
 ID   M->Y
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   M
 CF   C4OS-1
 //
 ID   D->F
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   D
 CF   C5H4O-2
 //
 ID   N->F
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   N
 CF   C5H3N-1O-1
@@ -1686,49 +1686,49 @@ TG   L
 CF   C3H-2
 //
 ID   P->M
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   P
 CF   H2S
 //
 ID   E->Y
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   E
 CF   C4H2O-1
 //
 ID   C->H
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   C
 CF   C3H2N2S-1
 //
 ID   K->Y
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   K
 CF   C3H-3N-1O
 //
 ID   Q->Y
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   Q
 CF   C4HN-1
 //
 ID   T->H
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   T
 CF   C2N2O-1
 //
 ID   V->H
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   V
 CF   CH-2N2
 //
 ID   F->W
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   F
 CF   C2HN
@@ -1740,37 +1740,37 @@ TG   P
 CF   CN2
 //
 ID   G->P
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   G
 CF   C3H4
 //
 ID   S->Q
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   S
 CF   C2H3N
 //
 ID   S->K
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   S
 CF   C3H7NO-1
 //
 ID   D->R
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   D
 CF   C2H7N3O-2
 //
 ID   S->E
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   S
 CF   C2H2O
 //
 ID   A->Xle
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   A
 CF   C3H6
@@ -1782,13 +1782,13 @@ TG   G
 CF   C3H6
 //
 ID   N->R
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   N
 CF   C2H6N2O-1
 //
 ID   A->N
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   A
 CF   CHNO
@@ -1812,13 +1812,13 @@ TG   A
 CF   CO2
 //
 ID   S->M
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   S
 CF   C2H4O-1S
 //
 ID   G->T
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   G
 CF   C2H4O
@@ -1836,7 +1836,7 @@ TG   G
 CF   CH2S
 //
 ID   T->F
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   T
 CF   C5H2O-1
@@ -1854,7 +1854,7 @@ TG   D
 CF   C5H4O-1
 //
 ID   H->W
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   H
 CF   C5H3N-1
@@ -1866,25 +1866,25 @@ TG   N
 CF   C5H3N-1
 //
 ID   I->Y
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   I
 CF   C3H-2O
 //
 ID   L->Y
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   L
 CF   C3H-2O
 //
 ID   P->F
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   P
 CF   C4H2
 //
 ID   S->H
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   S
 CF   C3H2N2O-1
@@ -1896,7 +1896,7 @@ TG   C
 CF   C3H7N3S-1
 //
 ID   M->W
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   M
 CF   C6HNS-1
@@ -1908,43 +1908,43 @@ TG   T
 CF   C2H5N3O-1
 //
 ID   G->Xle
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   G
 CF   C4H8
 //
 ID   A->Q
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   A
 CF   C2H3NO
 //
 ID   G->N
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   G
 CF   C2H3NO
 //
 ID   V->R
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   V
 CF   CH3N3
 //
 ID   E->W
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   E
 CF   C6H3NO-2
 //
 ID   A->K
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   A
 CF   C3H7N
 //
 ID   K->W
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   K
 CF   C5H-2
@@ -1962,7 +1962,7 @@ TG   G
 CF   C2H2O2
 //
 ID   Q->W
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   Q
 CF   C6H2O-1
@@ -1974,7 +1974,7 @@ TG   P
 CF   CH5N3
 //
 ID   A->M
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   A
 CF   C2H4S
@@ -1992,25 +1992,25 @@ TG   C
 CF   C6H4OS-1
 //
 ID   T->Y
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   T
 CF   C5H2
 //
 ID   V->Y
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   V
 CF   C4O
 //
 ID   P->Y
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   P
 CF   C4H2O
 //
 ID   A->H
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   A
 CF   C3H2N2
@@ -2022,19 +2022,19 @@ TG   S
 CF   C3H7N3O-1
 //
 ID   G->Q
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   G
 CF   C3H5NO
 //
 ID   D->W
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   D
 CF   C7H5NO-2
 //
 ID   G->K
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   G
 CF   C4H9N
@@ -2046,13 +2046,13 @@ TG   G
 CF   C3H4O2
 //
 ID   N->W
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   N
 CF   C7H4O-1
 //
 ID   I->W
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   I
 CF   C5H-1N
@@ -2064,13 +2064,13 @@ TG   L
 CF   C5H-1N
 //
 ID   G->M
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   G
 CF   C3H6S
 //
 ID   A->F
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   A
 CF   C6H4
@@ -2082,7 +2082,7 @@ TG   S
 CF   C6H4
 //
 ID   G->H
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   G
 CF   C4H4N2
@@ -2094,37 +2094,37 @@ TG   C
 CF   C8H5NS-1
 //
 ID   T->W
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   T
 CF   C7H3NO-1
 //
 ID   A->R
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   A
 CF   C3H7N3
 //
 ID   V->W
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   V
 CF   C6HN
 //
 ID   P->W
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   P
 CF   C6H3N
 //
 ID   G->F
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   G
 CF   C7H6
 //
 ID   A->Y
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   A
 CF   C6H4O
@@ -2142,13 +2142,13 @@ TG   G
 CF   C4H9N3
 //
 ID   G->Y
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   G
 CF   C7H6O
 //
 ID   A->W
-MT   substitution
+MT   uniprotUnobservedSubstitution
 PP   Anywhere.
 TG   A
 CF   C8H5N

--- a/EngineLayer/packages.config
+++ b/EngineLayer/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="FlashLFQ" version="0.1.92" targetFramework="net451" />
   <package id="MathNet.Numerics" version="3.20.0" targetFramework="net451" />
-  <package id="mzLib" version="1.0.226" targetFramework="net451" />
+  <package id="mzLib" version="1.0.227" targetFramework="net451" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net451" />
   <package id="Zlib.Portable" version="1.11.0" targetFramework="net451" />
 </packages>

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -45,52 +45,52 @@
     <ApplicationIcon>MMnice.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Chemistry, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\Chemistry.dll</HintPath>
+    <Reference Include="Chemistry, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\Chemistry.dll</HintPath>
     </Reference>
     <Reference Include="FlashLFQ, Version=1.0.101.0, Culture=neutral, processorArchitecture=AMD64">
       <HintPath>..\packages\FlashLFQ.0.1.92\lib\net451\FlashLFQ.dll</HintPath>
     </Reference>
-    <Reference Include="ManagedThermoHelperLayer, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\ManagedThermoHelperLayer.dll</HintPath>
+    <Reference Include="ManagedThermoHelperLayer, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\ManagedThermoHelperLayer.dll</HintPath>
     </Reference>
-    <Reference Include="MassSpectrometry, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\MassSpectrometry.dll</HintPath>
+    <Reference Include="MassSpectrometry, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\MassSpectrometry.dll</HintPath>
     </Reference>
     <Reference Include="MathNet.Numerics, Version=3.20.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MathNet.Numerics.3.20.0\lib\net40\MathNet.Numerics.dll</HintPath>
     </Reference>
-    <Reference Include="mzIdentML, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\mzIdentML.dll</HintPath>
+    <Reference Include="mzIdentML, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\mzIdentML.dll</HintPath>
     </Reference>
-    <Reference Include="MzLibUtil, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\MzLibUtil.dll</HintPath>
+    <Reference Include="MzLibUtil, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\MzLibUtil.dll</HintPath>
     </Reference>
-    <Reference Include="MzML, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\MzML.dll</HintPath>
+    <Reference Include="MzML, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\MzML.dll</HintPath>
     </Reference>
     <Reference Include="Nett, Version=0.7.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Nett.0.7.0\lib\Net40\Nett.dll</HintPath>
     </Reference>
-    <Reference Include="pepXML, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\pepXML.dll</HintPath>
+    <Reference Include="pepXML, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\pepXML.dll</HintPath>
     </Reference>
-    <Reference Include="Proteomics, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\Proteomics.dll</HintPath>
+    <Reference Include="Proteomics, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\Proteomics.dll</HintPath>
     </Reference>
-    <Reference Include="Spectra, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\Spectra.dll</HintPath>
+    <Reference Include="Spectra, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\Spectra.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>
-    <Reference Include="Thermo, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\Thermo.dll</HintPath>
+    <Reference Include="Thermo, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\Thermo.dll</HintPath>
     </Reference>
-    <Reference Include="UsefulProteomicsDatabases, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\UsefulProteomicsDatabases.dll</HintPath>
+    <Reference Include="UsefulProteomicsDatabases, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\UsefulProteomicsDatabases.dll</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
@@ -219,12 +219,12 @@
     <Resource Include="MMnice.ico" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\mzLib.1.0.226\build\mzLib.targets" Condition="Exists('..\packages\mzLib.1.0.226\build\mzLib.targets')" />
+  <Import Project="..\packages\mzLib.1.0.227\build\mzLib.targets" Condition="Exists('..\packages\mzLib.1.0.227\build\mzLib.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\mzLib.1.0.226\build\mzLib.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\mzLib.1.0.226\build\mzLib.targets'))" />
+    <Error Condition="!Exists('..\packages\mzLib.1.0.227\build\mzLib.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\mzLib.1.0.227\build\mzLib.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/GUI/packages.config
+++ b/GUI/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="FlashLFQ" version="0.1.92" targetFramework="net451" />
   <package id="MathNet.Numerics" version="3.20.0" targetFramework="net451" />
-  <package id="mzLib" version="1.0.226" targetFramework="net451" />
+  <package id="mzLib" version="1.0.227" targetFramework="net451" />
   <package id="Nett" version="0.7.0" targetFramework="net451" />
   <package id="Zlib.Portable" version="1.11.0" targetFramework="net451" />
 </packages>

--- a/TaskLayer/TaskLayer.csproj
+++ b/TaskLayer/TaskLayer.csproj
@@ -39,29 +39,29 @@
     <LangVersion>default</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Chemistry, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\Chemistry.dll</HintPath>
+    <Reference Include="Chemistry, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\Chemistry.dll</HintPath>
     </Reference>
     <Reference Include="FlashLFQ, Version=1.0.101.0, Culture=neutral, processorArchitecture=AMD64">
       <HintPath>..\packages\FlashLFQ.0.1.92\lib\net451\FlashLFQ.dll</HintPath>
     </Reference>
-    <Reference Include="ManagedThermoHelperLayer, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\ManagedThermoHelperLayer.dll</HintPath>
+    <Reference Include="ManagedThermoHelperLayer, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\ManagedThermoHelperLayer.dll</HintPath>
     </Reference>
-    <Reference Include="MassSpectrometry, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\MassSpectrometry.dll</HintPath>
+    <Reference Include="MassSpectrometry, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\MassSpectrometry.dll</HintPath>
     </Reference>
     <Reference Include="MathNet.Numerics, Version=3.20.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MathNet.Numerics.3.20.0\lib\net40\MathNet.Numerics.dll</HintPath>
     </Reference>
-    <Reference Include="mzIdentML, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\mzIdentML.dll</HintPath>
+    <Reference Include="mzIdentML, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\mzIdentML.dll</HintPath>
     </Reference>
-    <Reference Include="MzLibUtil, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\MzLibUtil.dll</HintPath>
+    <Reference Include="MzLibUtil, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\MzLibUtil.dll</HintPath>
     </Reference>
-    <Reference Include="MzML, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\MzML.dll</HintPath>
+    <Reference Include="MzML, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\MzML.dll</HintPath>
     </Reference>
     <Reference Include="NetSerializer, Version=4.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\NetSerializer.4.1.0\lib\net45\NetSerializer.dll</HintPath>
@@ -70,23 +70,23 @@
     <Reference Include="Nett, Version=0.7.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Nett.0.7.0\lib\Net40\Nett.dll</HintPath>
     </Reference>
-    <Reference Include="pepXML, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\pepXML.dll</HintPath>
+    <Reference Include="pepXML, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\pepXML.dll</HintPath>
     </Reference>
-    <Reference Include="Proteomics, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\Proteomics.dll</HintPath>
+    <Reference Include="Proteomics, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\Proteomics.dll</HintPath>
     </Reference>
-    <Reference Include="Spectra, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\Spectra.dll</HintPath>
+    <Reference Include="Spectra, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\Spectra.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
-    <Reference Include="Thermo, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\Thermo.dll</HintPath>
+    <Reference Include="Thermo, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\Thermo.dll</HintPath>
     </Reference>
-    <Reference Include="UsefulProteomicsDatabases, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\UsefulProteomicsDatabases.dll</HintPath>
+    <Reference Include="UsefulProteomicsDatabases, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\UsefulProteomicsDatabases.dll</HintPath>
     </Reference>
     <Reference Include="Zlib.Portable, Version=1.11.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Zlib.Portable.1.11.0\lib\portable-net4+sl5+wp8+win8+wpa81+MonoTouch+MonoAndroid\Zlib.Portable.dll</HintPath>
@@ -126,12 +126,12 @@
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\mzLib.1.0.226\build\mzLib.targets" Condition="Exists('..\packages\mzLib.1.0.226\build\mzLib.targets')" />
+  <Import Project="..\packages\mzLib.1.0.227\build\mzLib.targets" Condition="Exists('..\packages\mzLib.1.0.227\build\mzLib.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\mzLib.1.0.226\build\mzLib.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\mzLib.1.0.226\build\mzLib.targets'))" />
+    <Error Condition="!Exists('..\packages\mzLib.1.0.227\build\mzLib.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\mzLib.1.0.227\build\mzLib.targets'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/TaskLayer/packages.config
+++ b/TaskLayer/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="FlashLFQ" version="0.1.92" targetFramework="net451" />
   <package id="MathNet.Numerics" version="3.20.0" targetFramework="net451" />
-  <package id="mzLib" version="1.0.226" targetFramework="net451" />
+  <package id="mzLib" version="1.0.227" targetFramework="net451" />
   <package id="NetSerializer" version="4.1.0" targetFramework="net451" />
   <package id="Nett" version="0.7.0" targetFramework="net451" />
   <package id="Zlib.Portable" version="1.11.0" targetFramework="net451" />

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -41,29 +41,29 @@
     <LangVersion>default</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Chemistry, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\Chemistry.dll</HintPath>
+    <Reference Include="Chemistry, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\Chemistry.dll</HintPath>
     </Reference>
     <Reference Include="FlashLFQ, Version=1.0.101.0, Culture=neutral, processorArchitecture=AMD64">
       <HintPath>..\packages\FlashLFQ.0.1.92\lib\net451\FlashLFQ.dll</HintPath>
     </Reference>
-    <Reference Include="ManagedThermoHelperLayer, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\ManagedThermoHelperLayer.dll</HintPath>
+    <Reference Include="ManagedThermoHelperLayer, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\ManagedThermoHelperLayer.dll</HintPath>
     </Reference>
-    <Reference Include="MassSpectrometry, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\MassSpectrometry.dll</HintPath>
+    <Reference Include="MassSpectrometry, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\MassSpectrometry.dll</HintPath>
     </Reference>
     <Reference Include="MathNet.Numerics, Version=3.20.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MathNet.Numerics.3.20.0\lib\net40\MathNet.Numerics.dll</HintPath>
     </Reference>
-    <Reference Include="mzIdentML, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\mzIdentML.dll</HintPath>
+    <Reference Include="mzIdentML, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\mzIdentML.dll</HintPath>
     </Reference>
-    <Reference Include="MzLibUtil, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\MzLibUtil.dll</HintPath>
+    <Reference Include="MzLibUtil, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\MzLibUtil.dll</HintPath>
     </Reference>
-    <Reference Include="MzML, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\MzML.dll</HintPath>
+    <Reference Include="MzML, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\MzML.dll</HintPath>
     </Reference>
     <Reference Include="Nett, Version=0.7.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Nett.0.7.0\lib\Net40\Nett.dll</HintPath>
@@ -71,22 +71,22 @@
     <Reference Include="nunit.framework, Version=3.8.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.8.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="pepXML, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\pepXML.dll</HintPath>
+    <Reference Include="pepXML, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\pepXML.dll</HintPath>
     </Reference>
-    <Reference Include="Proteomics, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\Proteomics.dll</HintPath>
+    <Reference Include="Proteomics, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\Proteomics.dll</HintPath>
     </Reference>
-    <Reference Include="Spectra, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\Spectra.dll</HintPath>
+    <Reference Include="Spectra, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\Spectra.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="Thermo, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\Thermo.dll</HintPath>
+    <Reference Include="Thermo, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\Thermo.dll</HintPath>
     </Reference>
-    <Reference Include="UsefulProteomicsDatabases, Version=1.0.226.0, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\packages\mzLib.1.0.226\lib\UsefulProteomicsDatabases.dll</HintPath>
+    <Reference Include="UsefulProteomicsDatabases, Version=1.0.227.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\packages\mzLib.1.0.227\lib\UsefulProteomicsDatabases.dll</HintPath>
     </Reference>
     <Reference Include="Zlib.Portable, Version=1.11.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Zlib.Portable.1.11.0\lib\portable-net4+sl5+wp8+win8+wpa81+MonoTouch+MonoAndroid\Zlib.Portable.dll</HintPath>
@@ -161,9 +161,9 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.8.0\build\net35\NUnit3TestAdapter.props'))" />
-    <Error Condition="!Exists('..\packages\mzLib.1.0.226\build\mzLib.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\mzLib.1.0.226\build\mzLib.targets'))" />
+    <Error Condition="!Exists('..\packages\mzLib.1.0.227\build\mzLib.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\mzLib.1.0.227\build\mzLib.targets'))" />
   </Target>
-  <Import Project="..\packages\mzLib.1.0.226\build\mzLib.targets" Condition="Exists('..\packages\mzLib.1.0.226\build\mzLib.targets')" />
+  <Import Project="..\packages\mzLib.1.0.227\build\mzLib.targets" Condition="Exists('..\packages\mzLib.1.0.227\build\mzLib.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Test/packages.config
+++ b/Test/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="FlashLFQ" version="0.1.92" targetFramework="net451" />
   <package id="MathNet.Numerics" version="3.20.0" targetFramework="net451" />
-  <package id="mzLib" version="1.0.226" targetFramework="net451" />
+  <package id="mzLib" version="1.0.227" targetFramework="net451" />
   <package id="Nett" version="0.7.0" targetFramework="net451" />
   <package id="NUnit" version="3.8.1" targetFramework="net451" />
   <package id="NUnit3TestAdapter" version="3.8.0" targetFramework="net451" />


### PR DESCRIPTION
* Update Mods.txt

* Update Mods.txt

* Update Mods.txt