### PR TITLE
misc changes

### DIFF
--- a/EngineLayer/GlobalVariables.cs
+++ b/EngineLayer/GlobalVariables.cs
@@ -106,8 +106,8 @@ namespace EngineLayer
 
         public static string CheckLengthOfOutput(string psmString)
         {
-            if (psmString.Length > 32000 && GlobalVariables.GlobalSettings.WriteExcelCompatibleTSVs)
-                return "too long";
+            if (psmString.Length > 32000 && GlobalSettings.WriteExcelCompatibleTSVs)
+                return "Output too long for Excel";
             else
                 return psmString;
         }

--- a/EngineLayer/HistogramAnalysis/Bin.cs
+++ b/EngineLayer/HistogramAnalysis/Bin.cs
@@ -127,7 +127,7 @@ namespace EngineLayer.HistogramAnalysis
             foreach (var hm in ok)
                 if (Math.Abs(hm.Item1 + hm.Item2 - MassShift) <= v && CountTarget < hm.Item3)
                     okk.Add("Combo " + Math.Min(hm.Item1, hm.Item2).ToString("F3", CultureInfo.InvariantCulture) + " and " + Math.Max(hm.Item1, hm.Item2).ToString("F3", CultureInfo.InvariantCulture));
-            Combos = string.Join(" or ", okk);
+            Combos = string.Join("|", okk);
         }
 
         public double ComputeZ(double v)
@@ -143,7 +143,7 @@ namespace EngineLayer.HistogramAnalysis
                 if (hm is ModificationWithMass theMod && Math.Abs(theMod.monoisotopicMass - MassShift) <= v)
                     ok.Add(hm.id);
             }
-            UniprotID = string.Join(" or ", ok);
+            UniprotID = string.Join("|", ok);
         }
 
         public void IdentifyAA(double v)
@@ -169,7 +169,7 @@ namespace EngineLayer.HistogramAnalysis
                     }
                 }
             }
-            AA = string.Join(" or ", ok);
+            AA = string.Join("|", ok);
         }
 
         public void IdentifyUnimodBins(double v)
@@ -187,9 +187,9 @@ namespace EngineLayer.HistogramAnalysis
                     okDiff.Add(theMod.monoisotopicMass - MassShift);
                 }
             }
-            UnimodId = string.Join(" or ", ok);
-            UnimodFormulas = string.Join(" or ", okformula);
-            UnimodDiffs = string.Join(" or ", okDiff);
+            UnimodId = string.Join("|", ok);
+            UnimodFormulas = string.Join("|", okformula);
+            UnimodDiffs = string.Join("|", okDiff);
         }
 
         #endregion Public Methods

--- a/EngineLayer/Neo/PsmTsvLine.cs
+++ b/EngineLayer/Neo/PsmTsvLine.cs
@@ -53,11 +53,11 @@ namespace EngineLayer.Neo
 
         public PsmTsvLine AggregateLine(PsmTsvLine secondary)
         {
-            baseSequence += " or " + secondary.baseSequence;
-            fullSequence += " or " + secondary.fullSequence;
-            accession += " or " + secondary.accession;
-            proteinName += " or " + secondary.proteinName;
-            geneName += " or " + secondary.geneName;
+            baseSequence += "|" + secondary.baseSequence;
+            fullSequence += "|" + secondary.fullSequence;
+            accession += "|" + secondary.accession;
+            proteinName += "|" + secondary.proteinName;
+            geneName += "|" + secondary.geneName;
             return this;
         }
 

--- a/EngineLayer/ProteinParsimony/ProteinGroup.cs
+++ b/EngineLayer/ProteinParsimony/ProteinGroup.cs
@@ -148,8 +148,7 @@ namespace EngineLayer
             sb.Append("\t");
 
             // genes
-            var genes = new HashSet<string>(ListOfProteinsOrderedByAccession.Select(p => p.GeneNames.Select(x => x.Item2).FirstOrDefault()));
-            sb.Append(GlobalVariables.CheckLengthOfOutput(string.Join("|", genes)));
+            sb.Append(GlobalVariables.CheckLengthOfOutput(string.Join("|", ListOfProteinsOrderedByAccession.Select(p => p.GeneNames.Select(x => x.Item2).FirstOrDefault()))));
             sb.Append("\t");
 
             // organisms
@@ -307,7 +306,7 @@ namespace EngineLayer
                 }
             }
 
-            foreach (var protein in Proteins)
+            foreach (var protein in ListOfProteinsOrderedByAccession)
             {
                 HashSet<int> coveredResidues = new HashSet<int>();
 

--- a/EngineLayer/ProteinParsimony/ProteinGroup.cs
+++ b/EngineLayer/ProteinParsimony/ProteinGroup.cs
@@ -21,7 +21,8 @@ namespace EngineLayer
         public ProteinGroup(HashSet<Protein> proteins, HashSet<PeptideWithSetModifications> peptides, HashSet<PeptideWithSetModifications> uniquePeptides)
         {
             Proteins = proteins;
-            ProteinGroupName = string.Join("|", new HashSet<string>(Proteins.Select(p => p.Accession)));
+            ListOfProteinsOrderedByAccession = Proteins.OrderBy(p => p.Accession).ToList();
+            ProteinGroupName = string.Join("|", ListOfProteinsOrderedByAccession.Select(p => p.Accession));
             AllPeptides = peptides;
             UniquePeptides = uniquePeptides;
             AllPsmsBelowOnePercentFDR = new HashSet<Psm>();
@@ -92,6 +93,12 @@ namespace EngineLayer
 
         #endregion Public Properties
 
+        #region Private Properties
+
+        private List<Protein> ListOfProteinsOrderedByAccession;
+
+        #endregion Private Properties
+
         #region Public Methods
 
         public static string GetTabSeparatedHeader(bool fileSpecificHeader)
@@ -135,27 +142,27 @@ namespace EngineLayer
         public override string ToString()
         {
             var sb = new StringBuilder();
+            
             // list of protein accession numbers
             sb.Append(ProteinGroupName);
             sb.Append("\t");
 
             // genes
-            var genes = new HashSet<string>(Proteins.Select(p => p.GeneNames.Select(x => x.Item2).FirstOrDefault()));
+            var genes = new HashSet<string>(ListOfProteinsOrderedByAccession.Select(p => p.GeneNames.Select(x => x.Item2).FirstOrDefault()));
             sb.Append(GlobalVariables.CheckLengthOfOutput(string.Join("|", genes)));
             sb.Append("\t");
 
             // organisms
-            var organisms = new HashSet<string>(Proteins.Select(p => p.Organism));
-            sb.Append(GlobalVariables.CheckLengthOfOutput(string.Join("|", organisms)));
+            sb.Append(GlobalVariables.CheckLengthOfOutput(string.Join("|", ListOfProteinsOrderedByAccession.Select(p => p.Organism).Distinct())));
             sb.Append("\t");
 
             // list of protein names
-            sb.Append(GlobalVariables.CheckLengthOfOutput(string.Join("|", new HashSet<string>(Proteins.Select(p => p.FullName)))));
+            sb.Append(GlobalVariables.CheckLengthOfOutput(string.Join("|", ListOfProteinsOrderedByAccession.Select(p => p.FullName).Distinct())));
             sb.Append("\t");
 
             // list of masses
             IDigestionParams digestionParams = new TDdigest();
-            sb.Append(GlobalVariables.CheckLengthOfOutput(string.Join("|", new HashSet<double>(Proteins.Select(p => p.Digest(digestionParams, new List<ModificationWithMass>(), new List<ModificationWithMass>()).First().MonoisotopicMass)))));
+            sb.Append(GlobalVariables.CheckLengthOfOutput(string.Join("|", ListOfProteinsOrderedByAccession.Select(p => p.Digest(digestionParams, new List<ModificationWithMass>(), new List<ModificationWithMass>()).First().MonoisotopicMass).Distinct())));
             sb.Append("\t");
 
             // number of proteins in group
@@ -164,31 +171,31 @@ namespace EngineLayer
 
             // list of unique peptides
             if (!DisplayModsOnPeptides)
-                sb.Append(GlobalVariables.CheckLengthOfOutput(string.Join("|", new HashSet<string>(UniquePeptides.Select(p => p.BaseSequence)))));
+                sb.Append(GlobalVariables.CheckLengthOfOutput(string.Join("|", UniquePeptides.Select(p => p.BaseSequence).Distinct())));
             else
-                sb.Append(GlobalVariables.CheckLengthOfOutput(string.Join("|", new HashSet<string>(UniquePeptides.Select(p => p.Sequence)))));
+                sb.Append(GlobalVariables.CheckLengthOfOutput(string.Join("|", UniquePeptides.Select(p => p.Sequence).Distinct())));
             sb.Append("\t");
 
             // list of shared peptides
             var SharedPeptides = AllPeptides.Except(UniquePeptides);
             if (!DisplayModsOnPeptides)
-                sb.Append(GlobalVariables.CheckLengthOfOutput(string.Join("|", new HashSet<string>(SharedPeptides.Select(p => p.BaseSequence)))));
+                sb.Append(GlobalVariables.CheckLengthOfOutput(string.Join("|", SharedPeptides.Select(p => p.BaseSequence).Distinct())));
             else
-                sb.Append(GlobalVariables.CheckLengthOfOutput(string.Join("|", new HashSet<string>(SharedPeptides.Select(p => p.Sequence)))));
+                sb.Append(GlobalVariables.CheckLengthOfOutput(string.Join("|", SharedPeptides.Select(p => p.Sequence).Distinct())));
             sb.Append("\t");
 
             // number of peptides
             if (!DisplayModsOnPeptides)
-                sb.Append("" + new HashSet<string>(AllPeptides.Select(p => p.BaseSequence)).Count);
+                sb.Append("" + AllPeptides.Select(p => p.BaseSequence).Distinct().Count());
             else
-                sb.Append("" + new HashSet<string>(AllPeptides.Select(p => p.Sequence)).Count);
+                sb.Append("" + AllPeptides.Select(p => p.Sequence).Distinct().Count());
             sb.Append("\t");
 
             // number of unique peptides
             if (!DisplayModsOnPeptides)
-                sb.Append("" + new HashSet<string>(UniquePeptides.Select(p => p.BaseSequence)).Count);
+                sb.Append("" + UniquePeptides.Select(p => p.BaseSequence).Distinct().Count());
             else
-                sb.Append("" + new HashSet<string>(UniquePeptides.Select(p => p.Sequence)).Count);
+                sb.Append("" + UniquePeptides.Select(p => p.Sequence).Distinct().Count());
             sb.Append("\t");
 
             // sequence coverage percent
@@ -425,7 +432,10 @@ namespace EngineLayer
             this.UniquePeptides.UnionWith(other.UniquePeptides);
             this.AllPsmsBelowOnePercentFDR.UnionWith(other.AllPsmsBelowOnePercentFDR);
             other.ProteinGroupScore = 0;
-            ProteinGroupName = string.Join("|", new HashSet<string>(Proteins.Select(p => p.Accession)));
+
+            ListOfProteinsOrderedByAccession = Proteins.OrderBy(p => p.Accession).ToList();
+
+            ProteinGroupName = string.Join("|", ListOfProteinsOrderedByAccession.Select(p => p.Accession));
         }
 
         public ProteinGroup ConstructSubsetProteinGroup(string fullFilePath)

--- a/EngineLayer/Psm.cs
+++ b/EngineLayer/Psm.cs
@@ -245,7 +245,7 @@ namespace EngineLayer
 
             if (compactPeptides.First().Value.Item2 != null)
             {
-                sb.Append("\t" + TrimStringForExcel(string.Join(" or ", compactPeptides.Select(b => b.Value.Item2.Count.ToString(CultureInfo.InvariantCulture)))));
+                sb.Append("\t" + GlobalVariables.CheckLengthOfOutput(string.Join("|", compactPeptides.Select(b => b.Value.Item2.Count.ToString(CultureInfo.InvariantCulture)))));
                 
                 sb.Append('\t' + Resolve(compactPeptides.SelectMany(b => b.Value.Item2).Select(b => b.BaseSequence)).Item1);
                 sb.Append('\t' + Resolve(compactPeptides.SelectMany(b => b.Value.Item2).Select(b => b.Sequence)).Item1);
@@ -407,11 +407,6 @@ namespace EngineLayer
 
         #region Private Methods
 
-        private static string TrimStringForExcel(string s)
-        {
-            return s.Length > 32000 ? "too many" : s;
-        }
-
         private static (string, ChemicalFormula) Resolve(IEnumerable<IEnumerable<ModificationWithMassAndCf>> enumerable)
         {
             ChemicalFormula f = new ChemicalFormula();
@@ -441,7 +436,7 @@ namespace EngineLayer
             }
             if (!equals)
             {
-                var returnString = GlobalVariables.CheckLengthOfOutput(string.Join(" or ", formulas.Select(b => b.Formula)));
+                var returnString = GlobalVariables.CheckLengthOfOutput(string.Join("|", formulas.Select(b => b.Formula)));
                 return (returnString, null);
             }
             else
@@ -465,7 +460,7 @@ namespace EngineLayer
             }
             if (notEqual)
             {
-                var returnString = GlobalVariables.CheckLengthOfOutput(string.Join(" or ", enumerable.Select(b => string.Join(" ", b.Values.Select(c => c.id).OrderBy(c => c)))));
+                var returnString = GlobalVariables.CheckLengthOfOutput(string.Join("|", enumerable.Select(b => string.Join(" ", b.Values.Select(c => c.id).OrderBy(c => c)))));
                 return new Tuple<string, Dictionary<string, int>>(returnString, null);
             }
             else
@@ -483,7 +478,7 @@ namespace EngineLayer
             }
             else
             {
-                var returnString = GlobalVariables.CheckLengthOfOutput(string.Join(" or ", list.Select(b => b.ToString("F2", CultureInfo.InvariantCulture))));
+                var returnString = GlobalVariables.CheckLengthOfOutput(string.Join("|", list.Select(b => b.ToString("F2", CultureInfo.InvariantCulture))));
                 return  new Tuple<string, double?>(returnString, null);
             }
         }
@@ -497,7 +492,7 @@ namespace EngineLayer
             }
             else
             {
-                var returnString = GlobalVariables.CheckLengthOfOutput(string.Join(" or ", list.Select(b => b.ToString("F5", CultureInfo.InvariantCulture))));
+                var returnString = GlobalVariables.CheckLengthOfOutput(string.Join("|", list.Select(b => b.ToString("F5", CultureInfo.InvariantCulture))));
                 return new Tuple<string, double?>(returnString, null);
             }
         }
@@ -512,7 +507,7 @@ namespace EngineLayer
             }
             else
             {
-                var returnString = GlobalVariables.CheckLengthOfOutput(string.Join(" or ", list.Select(b => b.ToString(CultureInfo.InvariantCulture))));
+                var returnString = GlobalVariables.CheckLengthOfOutput(string.Join("|", list.Select(b => b.ToString(CultureInfo.InvariantCulture))));
                 return new Tuple<string, int?>(returnString, null);
             }
         }
@@ -528,7 +523,7 @@ namespace EngineLayer
             }
             else
             {
-                var returnString = GlobalVariables.CheckLengthOfOutput(string.Join(" or ", list));
+                var returnString = GlobalVariables.CheckLengthOfOutput(string.Join("|", list));
                 return new Tuple<string, string>(returnString, null);
             }
         }

--- a/GUI/MainWindow.xaml
+++ b/GUI/MainWindow.xaml
@@ -141,9 +141,9 @@
                             <Button x:Name="addGPTMDTaskButton" Content="New GPTMD Task" Click="AddGPTMDTaskButton_Click" />
                             <Button x:Name="btnAddCrosslinkSearch" Content="New XL Task" Click="BtnAddCrosslinkSearch_Click" />
                         </StackPanel>
-                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Grid.Row="1">
+                        <!--<StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Grid.Row="1">
                             <Button x:Name="addNeoTaskButton" Content="New Neo Meta-Task" Click="AddNeoTaskButton_Click" />
-                        </StackPanel>
+                        </StackPanel>-->
                         <TreeView x:Name="tasksTreeView" Grid.Row="2" ItemsSource="{Binding}" MouseDoubleClick="TasksTreeView_MouseDoubleClick">
                             <TreeView.Resources>
                                 <HierarchicalDataTemplate DataType="{x:Type local:InRunTask}" ItemsSource="{Binding Children}">

--- a/GUI/MainWindow.xaml.cs
+++ b/GUI/MainWindow.xaml.cs
@@ -381,34 +381,48 @@ namespace MetaMorpheusGUI
                     break;
 
                 case ".toml":
-                    var uhum = Toml.ReadFile(draggedFilePath, MetaMorpheusTask.tomlConfig);
-                    switch (uhum.Get<string>("TaskType"))
+                    var tomlFile = Toml.ReadFile(draggedFilePath, MetaMorpheusTask.tomlConfig);
+                    if (tomlFile.Keys.Contains("PrecursorMassTolerance") && tomlFile.Keys.Contains("ProductMassTolerance") && tomlFile.Keys.Count == 2)
                     {
-                        case "Search":
-                            var ye1 = Toml.ReadFile<SearchTask>(draggedFilePath, MetaMorpheusTask.tomlConfig);
-                            AddTaskToCollection(ye1);
-                            break;
+                        // do nothing; it's a ppm suggested tolerance toml from calibration, this gets read in elsewhere
+                    }
+                    else
+                    {
+                        try
+                        {
+                            switch (tomlFile.Get<string>("TaskType"))
+                            {
+                                case "Search":
+                                    var ye1 = Toml.ReadFile<SearchTask>(draggedFilePath, MetaMorpheusTask.tomlConfig);
+                                    AddTaskToCollection(ye1);
+                                    break;
 
-                        case "Calibrate":
-                            var ye2 = Toml.ReadFile<CalibrationTask>(draggedFilePath, MetaMorpheusTask.tomlConfig);
-                            AddTaskToCollection(ye2);
-                            break;
+                                case "Calibrate":
+                                    var ye2 = Toml.ReadFile<CalibrationTask>(draggedFilePath, MetaMorpheusTask.tomlConfig);
+                                    AddTaskToCollection(ye2);
+                                    break;
 
-                        case "Gptmd":
-                            var ye3 = Toml.ReadFile<GptmdTask>(draggedFilePath, MetaMorpheusTask.tomlConfig);
-                            AddTaskToCollection(ye3);
-                            break;
+                                case "Gptmd":
+                                    var ye3 = Toml.ReadFile<GptmdTask>(draggedFilePath, MetaMorpheusTask.tomlConfig);
+                                    AddTaskToCollection(ye3);
+                                    break;
 
-                        case "XLSearch":
-                            var ye4 = Toml.ReadFile<XLSearchTask>(draggedFilePath, MetaMorpheusTask.tomlConfig);
-                            AddTaskToCollection(ye4);
-                            break;
+                                case "XLSearch":
+                                    var ye4 = Toml.ReadFile<XLSearchTask>(draggedFilePath, MetaMorpheusTask.tomlConfig);
+                                    AddTaskToCollection(ye4);
+                                    break;
 
-                        case "Neo":
-                            var ye5 = Toml.ReadFile<NeoSearchTask>(draggedFilePath, MetaMorpheusTask.tomlConfig);
-                            foreach (MetaMorpheusTask task in NeoLoadTomls.LoadTomls(ye5))
-                                AddTaskToCollection(task);
-                            break;
+                                case "Neo":
+                                    var ye5 = Toml.ReadFile<NeoSearchTask>(draggedFilePath, MetaMorpheusTask.tomlConfig);
+                                    foreach (MetaMorpheusTask task in NeoLoadTomls.LoadTomls(ye5))
+                                        AddTaskToCollection(task);
+                                    break;
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            GuiWarnHandler(null, new StringEventArgs("Could not parse .toml: " + e.Message, null));
+                        }
                     }
                     break;
             }

--- a/GUI/MainWindow.xaml.cs
+++ b/GUI/MainWindow.xaml.cs
@@ -325,21 +325,28 @@ namespace MetaMorpheusGUI
             if (LoadTaskButton.IsEnabled)
             {
                 string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
+
                 if (files != null)
+                {
                     foreach (var draggedFilePath in files)
                     {
                         if (Directory.Exists(draggedFilePath))
+                        {
                             foreach (string file in Directory.EnumerateFiles(draggedFilePath, "*.*", SearchOption.AllDirectories))
                             {
                                 AddAFile(file);
                             }
+                        }
                         else
                         {
                             AddAFile(draggedFilePath);
                         }
+                        dataGridDatafiles.CommitEdit(DataGridEditingUnit.Row, true);
+                        dataGridXMLs.CommitEdit(DataGridEditingUnit.Row, true);
                         dataGridDatafiles.Items.Refresh();
                         dataGridXMLs.Items.Refresh();
                     }
+                }
                 UpdateTaskGuiStuff();
             }
         }

--- a/GUI/MainWindow.xaml.cs
+++ b/GUI/MainWindow.xaml.cs
@@ -688,7 +688,7 @@ namespace MetaMorpheusGUI
                 addGPTMDTaskButton.IsEnabled = false;
                 addSearchTaskButton.IsEnabled = false;
                 btnAddCrosslinkSearch.IsEnabled = false;
-                addNeoTaskButton.IsEnabled = false;
+                //addNeoTaskButton.IsEnabled = false;
 
                 AddXML.IsEnabled = false;
                 ClearXML.IsEnabled = false;
@@ -755,7 +755,7 @@ namespace MetaMorpheusGUI
             addGPTMDTaskButton.IsEnabled = true;
             addSearchTaskButton.IsEnabled = true;
             btnAddCrosslinkSearch.IsEnabled = true;
-            addNeoTaskButton.IsEnabled = true;
+            //addNeoTaskButton.IsEnabled = true;
             ResetTasksButton.IsEnabled = false;
             OutputFolderTextBox.IsEnabled = true;
 

--- a/GUI/MainWindow.xaml.cs
+++ b/GUI/MainWindow.xaml.cs
@@ -231,16 +231,17 @@ namespace MetaMorpheusGUI
         {
             if (rawDataObservableCollection.Any())
             {
-                var MatchingChars =
-                    from len in Enumerable.Range(0, rawDataObservableCollection.Select(b => b.FilePath).Min(s => s.Length)).Reverse()
-                    let possibleMatch = rawDataObservableCollection.Select(b => b.FilePath).First().Substring(0, len)
-                    where rawDataObservableCollection.Select(b => b.FilePath).All(f => f.StartsWith(possibleMatch, StringComparison.Ordinal))
-                    select possibleMatch;
-
-                OutputFolderTextBox.Text = Path.Combine(Path.GetDirectoryName(MatchingChars.First()), @"$DATETIME");
+                // if current output folder is blank and there is a spectra file, use the spectra file's path as the output path
+                if (string.IsNullOrWhiteSpace(OutputFolderTextBox.Text))
+                {
+                    var pathOfFirstSpectraFile = Path.GetDirectoryName(rawDataObservableCollection.First().FilePath);
+                    OutputFolderTextBox.Text = Path.Combine(pathOfFirstSpectraFile, @"$DATETIME");
+                }
+                // else do nothing (do not override if there is a path already there; might clear user-defined path)
             }
             else
             {
+                // no spectra files; clear the output folder from the GUI
                 OutputFolderTextBox.Clear();
             }
         }

--- a/GUI/SearchTaskWindow.xaml
+++ b/GUI/SearchTaskWindow.xaml
@@ -341,15 +341,6 @@
                             </Style>
                         </Expander.Style>
                         <StackPanel>
-                            <GroupBox Header="Filter Options">
-                                <StackPanel Orientation="Horizontal" >
-                                    <TextBox x:Name="asdf" Width="45" Text="0.01sdafasdfasdf" IsEnabled="{Binding IsChecked, ElementName=FilterQvalue}" HorizontalAlignment="Right" VerticalAlignment="Top"  />
-                                    <CheckBox x:Name="FilterQvalue" Content="Filter By q-value" Margin="0,0,583,0" Width="116">
-                                    </CheckBox>
-                                    <Label Content="adgdafgd" Width="144" />
-                                </StackPanel>
-
-                            </GroupBox>
                             <GroupBox Header="Protein Parsimony">
                                 <StackPanel>
                                     <CheckBox x:Name="checkBoxParsimony" Content="Apply protein parsimony and construct protein groups">

--- a/GUI/SearchTaskWindow.xaml.cs
+++ b/GUI/SearchTaskWindow.xaml.cs
@@ -561,11 +561,6 @@ namespace MetaMorpheusGUI
         }
 
         #endregion Private Methods
-
-        private void asdf_TextChanged(object sender, TextChangedEventArgs e)
-        {
-
-        }
     }
 
     public class DataContextForSearchTaskWindow : INotifyPropertyChanged

--- a/TaskLayer/SearchTask/SearchParameters.cs
+++ b/TaskLayer/SearchTask/SearchParameters.cs
@@ -9,12 +9,13 @@ namespace TaskLayer
 
         public SearchParameters()
         {
+            // default search task parameters
             DisposeOfFileWhenDone = true;
             AddCompIons = false;
             DoParsimony = true;
             NoOneHitWonders = false;
             ModPeptidesAreDifferent = true;
-            DoQuantification = false;
+            DoQuantification = true;
             QuantifyPpmTol = 5;
             SearchTarget = true;
             DecoyType = DecoyType.Reverse;

--- a/TaskLayer/SearchTask/SearchTask.cs
+++ b/TaskLayer/SearchTask/SearchTask.cs
@@ -988,18 +988,21 @@ namespace TaskLayer
             // Group and order psms
             Status("Matching peptides to proteins...", taskId);
             Dictionary<CompactPeptideBase, HashSet<PeptideWithSetModifications>> compactPeptideToProteinPeptideMatching = new Dictionary<CompactPeptideBase, HashSet<PeptideWithSetModifications>>();
-            if (SearchParameters.SearchType == SearchType.NonSpecific)
+            if (proteinList.Any())
             {
-                List<List<ProductType>> terminusSeparatedIons = ProductTypeMethod.SeparateIonsByTerminus(ionTypes);
-                MassDiffAcceptor massDiffAcceptor = GetMassDiffAcceptor(CommonParameters.PrecursorMassTolerance, SearchParameters.MassDiffAcceptorType, SearchParameters.CustomMdac);
-                foreach (List<ProductType> terminusSpecificIons in terminusSeparatedIons)
-                    new NonSpecificEnzymeSequencesToActualPeptides(compactPeptideToProteinPeptideMatching, allPsms, proteinList, fixedModifications, variableModifications, terminusSpecificIons, ListOfDigestionParams, massDiffAcceptor, CommonParameters.ReportAllAmbiguity, new List<string> { taskId }).Run();
-            }
-            else
-            {
-                SequencesToActualProteinPeptidesEngine sequencesToActualProteinPeptidesEngine = new SequencesToActualProteinPeptidesEngine(allPsms, proteinList, fixedModifications, variableModifications, ionTypes, ListOfDigestionParams, CommonParameters.ReportAllAmbiguity, new List<string> { taskId });
-                var res = (SequencesToActualProteinPeptidesEngineResults)sequencesToActualProteinPeptidesEngine.Run();
-                compactPeptideToProteinPeptideMatching = res.CompactPeptideToProteinPeptideMatching;
+                if (SearchParameters.SearchType == SearchType.NonSpecific)
+                {
+                    List<List<ProductType>> terminusSeparatedIons = ProductTypeMethod.SeparateIonsByTerminus(ionTypes);
+                    MassDiffAcceptor massDiffAcceptor = GetMassDiffAcceptor(CommonParameters.PrecursorMassTolerance, SearchParameters.MassDiffAcceptorType, SearchParameters.CustomMdac);
+                    foreach (List<ProductType> terminusSpecificIons in terminusSeparatedIons)
+                        new NonSpecificEnzymeSequencesToActualPeptides(compactPeptideToProteinPeptideMatching, allPsms, proteinList, fixedModifications, variableModifications, terminusSpecificIons, ListOfDigestionParams, massDiffAcceptor, CommonParameters.ReportAllAmbiguity, new List<string> { taskId }).Run();
+                }
+                else
+                {
+                    SequencesToActualProteinPeptidesEngine sequencesToActualProteinPeptidesEngine = new SequencesToActualProteinPeptidesEngine(allPsms, proteinList, fixedModifications, variableModifications, ionTypes, ListOfDigestionParams, CommonParameters.ReportAllAmbiguity, new List<string> { taskId });
+                    var res = (SequencesToActualProteinPeptidesEngineResults)sequencesToActualProteinPeptidesEngine.Run();
+                    compactPeptideToProteinPeptideMatching = res.CompactPeptideToProteinPeptideMatching;
+                }
             }
 
             ProteinParsimonyResults proteinAnalysisResults = null;

--- a/TaskLayer/SearchTask/SearchTask.cs
+++ b/TaskLayer/SearchTask/SearchTask.cs
@@ -1110,10 +1110,11 @@ namespace TaskLayer
 
                 // run FlashLFQ
                 var FlashLfqEngine = new FlashLFQEngine(flashLFQIdentifications, SearchParameters.QuantifyPpmTol, 5.0, SearchParameters.MatchBetweenRuns, 5.0, false, 2, false, true, true, GlobalVariables.ElementsLocation);
-                flashLfqResults = FlashLfqEngine.Run();
+                if(flashLFQIdentifications.Any())
+                    flashLfqResults = FlashLfqEngine.Run();
 
                 // get protein intensity back from FlashLFQ
-                if (proteinGroups != null)
+                if (proteinGroups != null && flashLfqResults != null)
                 {
                     Dictionary<string, EngineLayer.ProteinGroup> proteinGroupNameToProteinGroup = new Dictionary<string, EngineLayer.ProteinGroup>();
                     foreach (var proteinGroup in proteinGroups)
@@ -1246,7 +1247,7 @@ namespace TaskLayer
                 }
             }
 
-            if (SearchParameters.DoQuantification)
+            if (SearchParameters.DoQuantification && flashLfqResults != null)
             {
                 foreach (var file in flashLfqResults.peaks)
                     WritePeakQuantificationResultsToTsv(file.Value, OutputFolder, file.Key.filenameWithoutExtension + "_QuantifiedPeaks", new List<string> { taskId, "Individual Spectra Files", file.Key.fullFilePathWithExtension });

--- a/TaskLayer/SearchTask/SearchTask.cs
+++ b/TaskLayer/SearchTask/SearchTask.cs
@@ -1063,6 +1063,7 @@ namespace TaskLayer
                         rawfileinfos.Add(new RawFileInfo(file, myFileManager.LoadFile(file, combinedParams.TopNpeaks, combinedParams.MinRatio, combinedParams.TrimMs1Peaks, combinedParams.TrimMsMsPeaks)));
                     else
                         rawfileinfos.Add(new RawFileInfo(file));
+                    myFileManager.DoneWithFile(file);
                 }
 
                 // get PSMs to pass to FlashLFQ
@@ -1137,7 +1138,7 @@ namespace TaskLayer
                     }
                 }
             }
-
+            
             ReportProgress(new ProgressEventArgs(100, "Done!", new List<string> { taskId, "Individual Spectra Files" }));
 
             if (SearchParameters.DoHistogramAnalysis)

--- a/Test/AddCompIonsTest.cs
+++ b/Test/AddCompIonsTest.cs
@@ -97,7 +97,8 @@ namespace Test
 
             SearchParameters SearchParameters = new SearchParameters
             {
-                MassDiffAcceptorType = MassDiffAcceptorType.Exact
+                MassDiffAcceptorType = MassDiffAcceptorType.Exact,
+                SearchTarget = true,
             };
             CommonParameters CommonParameters = new CommonParameters
             {
@@ -137,6 +138,8 @@ namespace Test
 
             // Single ms2 scan
             Assert.AreEqual(allPsmsArray.Length, allPsmsArray2.Length);
+            Assert.That(allPsmsArray[0] != null);
+            Assert.That(allPsmsArray2[0] != null);
 
             Assert.IsTrue(allPsmsArray2[0].Score > 1);
 

--- a/Test/MyTaskTest.cs
+++ b/Test/MyTaskTest.cs
@@ -60,6 +60,7 @@ namespace Test
                 SearchParameters = new SearchParameters
                 {
                     DoParsimony = true,
+                    SearchTarget = true,
                     SearchType = SearchType.Modern
                 }
             };
@@ -170,6 +171,7 @@ namespace Test
                 SearchParameters = new SearchParameters
                 {
                     DoParsimony = true,
+                    SearchTarget = true,
                     SearchType = SearchType.Modern,
                 }
             };
@@ -398,6 +400,7 @@ namespace Test
                 SearchParameters = new SearchParameters
                 {
                     WritePrunedDatabase = true,
+                    SearchTarget = true,
                     MassDiffAcceptorType = MassDiffAcceptorType.Exact,
                     ModsToWriteSelection = new Dictionary<string, int>
                     {
@@ -507,6 +510,7 @@ namespace Test
                 SearchParameters = new SearchParameters
                 {
                     WritePrunedDatabase = true,
+                    SearchTarget = true,
                     MassDiffAcceptorType = MassDiffAcceptorType.Exact,
                 },
                 CommonParameters = new CommonParameters
@@ -663,6 +667,7 @@ namespace Test
                 SearchParameters = new SearchParameters
                 {
                     WritePrunedDatabase = true,
+                    SearchTarget = true,
                     MassDiffAcceptorType = MassDiffAcceptorType.Exact
                 }
             };

--- a/Test/RobTest.cs
+++ b/Test/RobTest.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using Proteomics;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using TaskLayer;
 
@@ -385,6 +386,28 @@ namespace Test
             f.Run();
 
             Assert.AreEqual("#aa5[resMod,info:occupancy=0.67(2/3)];", proteinGroups.First().ModsInfo[0]);
+        }
+
+        [Test]
+        public static void TestProteinGroupsAccessionOutputOrder()
+        {
+            
+            
+            var p = new HashSet<Protein>();
+            List<Tuple<string, string>> gn = new List<Tuple<string, string>>();
+
+            // make protein B
+            p.Add(new Protein("-----F----*", "B", null, gn, new Dictionary<int, List<Modification>>(), isDecoy: true));
+
+            // make protein A
+            p.Add(new Protein("-----F----**", "A", null, gn, new Dictionary<int, List<Modification>>(), isDecoy: true));
+            
+            // add protein B and A to the protein group
+            ProteinGroup testGroup = new ProteinGroup(p, null, null);
+
+            // test order is AB and not BA
+            Assert.That(testGroup.ProteinGroupName.Equals("A|B"));
+            Assert.That(testGroup.Proteins.First().Accession.Equals("B"));
         }
 
         #endregion Public Methods

--- a/Test/SearchEngineTests.cs
+++ b/Test/SearchEngineTests.cs
@@ -125,6 +125,7 @@ namespace Test
             SearchParameters SearchParameters = new SearchParameters
             {
                 MassDiffAcceptorType = MassDiffAcceptorType.Exact,
+                SearchTarget = true,
             };
             CommonParameters CommonParameters = new CommonParameters
             {
@@ -180,6 +181,7 @@ namespace Test
 
             // Single ms2 scan
             Assert.AreEqual(1, allPsmsArray.Length);
+            Assert.That(allPsmsArray[0] != null);
 
             Assert.IsTrue(allPsmsArray[0].Score > 1);
             Assert.AreEqual(2, allPsmsArray[0].ScanNumber);
@@ -298,7 +300,8 @@ namespace Test
         {
             SearchParameters SearchParameters = new SearchParameters
             {
-                MassDiffAcceptorType = MassDiffAcceptorType.Open
+                MassDiffAcceptorType = MassDiffAcceptorType.Open,
+                SearchTarget = true,
             };
             CommonParameters CommonParameters = new CommonParameters
             {
@@ -339,6 +342,7 @@ namespace Test
 
             // Single ms2 scan
             Assert.AreEqual(1, allPsmsArray.Length);
+            Assert.That(allPsmsArray[0] != null);
 
             Assert.IsTrue(allPsmsArray[0].Score > 1);
             Assert.AreEqual(2, allPsmsArray[0].ScanNumber);
@@ -435,6 +439,7 @@ namespace Test
             SearchParameters SearchParameters = new SearchParameters
             {
                 AddCompIons = true,
+                SearchTarget = true,
                 MassDiffAcceptorType = MassDiffAcceptorType.Exact,
             };
             var dp = new DigestionParams
@@ -496,6 +501,7 @@ namespace Test
 
             //Single ms2 scan
             Assert.AreEqual(1, allPsmsArray.Length);
+            Assert.That(allPsmsArray[0] != null);
 
             Assert.IsTrue(allPsmsArray[0].Score > 4);
             Assert.AreEqual(2, allPsmsArray[0].ScanNumber);


### PR DESCRIPTION
- Change ambiguity delimiter from " or " to "|"
- Quantification enabled by default
- Fixed crash when no PSMs are detected and quantification is enabled
- Arrange proteins within a protein group by alphabetical order of accession number (helps keeps results consistant across searches)
- Temporarily disable Neo button
- Removed unimplemented q-value output filtering from the GUI
- Fixed crash when no proteins are in the protein list (loading a blank fasta might still be buggy)
- Fixed an error in calibration that suggested bad ppm tolerances in the written .toml
- Fix crash when 0 proteins are in the protein list to search
- Fix crash when spectra files from different folders are dragged in to GUI
- Fixed bug where if a output folder was defined in the GUI, adding a new spectra file override what was already present in the output folder text box with the newly added spectra file's folder
- Fixed crashes related to dragging unreadable .toml files into GUI, or ppm-suggestion .toml files resulting from calibration task into GUI
- Fixed crash when adding a database, checking it as contaminant, then adding a spectra file