### PR TITLE
disable ms/ms peak filtering because of major bug in mzlib (#996)

### DIFF
--- a/GUI/SearchTaskWindow.xaml
+++ b/GUI/SearchTaskWindow.xaml
@@ -64,7 +64,7 @@
                                     </StackPanel>
                                 </StackPanel>
                             </GroupBox>
-                            <GroupBox Header="Peak Trimming">
+                            <!--<GroupBox Header="Peak Trimming">
                                 <StackPanel>
                                     <CheckBox x:Name="trimMs1" Content="Trim MS1 Peaks" IsChecked="True" />
                                     <CheckBox x:Name="trimMsMs" Content="Trim MS/MS Peaks" IsChecked="True" />
@@ -77,7 +77,7 @@
                                         <TextBox x:Name="MinRatioCheckBox" Width="45" />
                                     </StackPanel>
                                 </StackPanel>
-                            </GroupBox>
+                            </GroupBox>-->
                             <CheckBox x:Name="disposeOfFilesWhenDone" Content="Dispose of files when done" IsChecked="True" />
                         </StackPanel>
                     </Expander>

--- a/GUI/SearchTaskWindow.xaml.cs
+++ b/GUI/SearchTaskWindow.xaml.cs
@@ -200,10 +200,10 @@ namespace MetaMorpheusGUI
             DeconvolutionMassToleranceInPpmTextBox.Text = task.CommonParameters.DeconvolutionMassTolerance.Value.ToString();
             minScoreAllowed.Text = task.CommonParameters.ScoreCutoff.ToString(CultureInfo.InvariantCulture);
             eValueCheckBox.IsChecked = task.CommonParameters.CalculateEValue;
-            trimMs1.IsChecked = task.CommonParameters.TrimMs1Peaks;
-            trimMsMs.IsChecked = task.CommonParameters.TrimMsMsPeaks;
-            TopNPeaksCheckBox.Text = task.CommonParameters.TopNpeaks.HasValue ? task.CommonParameters.TopNpeaks.Value.ToString(CultureInfo.InvariantCulture) : "";
-            MinRatioCheckBox.Text = task.CommonParameters.MinRatio.HasValue ? task.CommonParameters.MinRatio.Value.ToString(CultureInfo.InvariantCulture) : "";
+            //trimMs1.IsChecked = task.CommonParameters.TrimMs1Peaks;
+            //trimMsMs.IsChecked = task.CommonParameters.TrimMsMsPeaks;
+            //TopNPeaksCheckBox.Text = task.CommonParameters.TopNpeaks.HasValue ? task.CommonParameters.TopNpeaks.Value.ToString(CultureInfo.InvariantCulture) : "";
+            //MinRatioCheckBox.Text = task.CommonParameters.MinRatio.HasValue ? task.CommonParameters.MinRatio.Value.ToString(CultureInfo.InvariantCulture) : "";
 
             OutputFileNameTextBox.Text = task.CommonParameters.TaskDescriptor;
 
@@ -351,10 +351,10 @@ namespace MetaMorpheusGUI
             else
                 CommonParamsToSave.TaskDescriptor = "SearchTask";
 
-            CommonParamsToSave.TrimMs1Peaks = trimMs1.IsChecked.Value;
-            CommonParamsToSave.TrimMsMsPeaks = trimMsMs.IsChecked.Value;
-            CommonParamsToSave.TopNpeaks = int.TryParse(TopNPeaksCheckBox.Text, out int TopNPeak) ? (int?)TopNPeak : null;
-            CommonParamsToSave.MinRatio = double.TryParse(MinRatioCheckBox.Text, out double MinRatio) ? (double?)MinRatio : null;
+            //CommonParamsToSave.TrimMs1Peaks = trimMs1.IsChecked.Value;
+            //CommonParamsToSave.TrimMsMsPeaks = trimMsMs.IsChecked.Value;
+            //CommonParamsToSave.TopNpeaks = int.TryParse(TopNPeaksCheckBox.Text, out int TopNPeak) ? (int?)TopNPeak : null;
+            //CommonParamsToSave.MinRatio = double.TryParse(MinRatioCheckBox.Text, out double MinRatio) ? (double?)MinRatio : null;
 
             if (classicSearchRadioButton.IsChecked.Value)
                 TheTask.SearchParameters.SearchType = SearchType.Classic;

--- a/TaskLayer/SearchTask/MyFileManager.cs
+++ b/TaskLayer/SearchTask/MyFileManager.cs
@@ -53,17 +53,17 @@ namespace TaskLayer
 
         internal IMsDataFile<IMsDataScan<IMzSpectrum<IMzPeak>>> LoadFile(string origDataFile, int? topNpeaks, double? minRatio, bool trimMs1Peaks, bool trimMsMsPeaks)
         {
-            FilteringParams filter = new FilteringParams(topNpeaks, minRatio, 1, trimMs1Peaks, trimMsMsPeaks);
+            //FilteringParams filter = new FilteringParams(topNpeaks, minRatio, 1, trimMs1Peaks, trimMsMsPeaks);
             if (myMsDataFiles.TryGetValue(origDataFile, out IMsDataFile<IMsDataScan<IMzSpectrum<IMzPeak>>> value) && value != null)
                 return value;
             
             // By now know that need to load this file!!!
             lock (fileLoadingLock) // Lock because reading is sequential
                 if (Path.GetExtension(origDataFile).Equals(".mzML", StringComparison.OrdinalIgnoreCase))
-                    myMsDataFiles[origDataFile] = Mzml.LoadAllStaticData(origDataFile, filter);
+                    myMsDataFiles[origDataFile] = Mzml.LoadAllStaticData(origDataFile);
                 else
 #if NETFRAMEWORK
-                    myMsDataFiles[origDataFile] = ThermoStaticData.LoadAllStaticData(origDataFile, filter);
+                    myMsDataFiles[origDataFile] = ThermoStaticData.LoadAllStaticData(origDataFile);
 #else
                     Warn("No capability for reading " + origDataFile);
 #endif


### PR DESCRIPTION
- disable ms/ms peak filtering because of major bug in mzlib (#996)