### PR TITLE
Update Mods.txt

### DIFF
--- a/EngineLayer/Mods/Mods.txt
+++ b/EngineLayer/Mods/Mods.txt
@@ -229,17 +229,23 @@ PP   Anywhere.
 MT   Mod
 CF   H-2 S-1
 //
-ID   Didehydro
-TG   Y or S
-PP   Anywhere.
-MT   Mod
-CF   H-2
-//
-ID   Didehydrobutyrine
-TG   T or S
+ID   Dehydroalanine from Serine
+TG   S
 PP   Anywhere.
 MT   Mod
 CF   H-2 O-1
+//
+ID   Dehydrobutyrine
+TG   T
+PP   Anywhere.
+MT   Mod
+CF   H-2 O-1
+//
+ID   Didehydro
+TG   Y
+PP   Anywhere.
+MT   Mod
+CF   H-2
 //
 ID   Formylation
 TG   X


### PR DESCRIPTION
I made the following changes for the following reasons.   I made these edits and tried it.  It didn't crash MM.

There is a "didehydro" modification (H-2), that is allowed on S and Y in MM "Mods" group. It should not be allowed on S b/c that would make a reactive aldehyde, which would react with something else before mass spec anyway. And I looked around and could not find any examples of didehydro PTM on S. Please remove that option, but leave it there for Y, which is a valid PTM.

Also, need to clean up terminology on some "dehydro" entries in Mods group.
Currently, there is "didehydrobutyrine" on S and T.
Delete the "di" part and split into 2 entries:
It should be "Dehydrobutyrine" on T.
And "Dehydroalanine from Serine" on S.
Both are H-2 O-1.
Note that there is another related PTM that has a correct entry: "Dehydroalanine from Cysteine" on C. That is H-2 S-1. (i.e. dehydroalanine can be created in 2 ways. from C or S, but there is a diff mass loss to get there, so that is why 2 entries are needed).