### PR TITLE
279

### DIFF
--- a/CMD/CMD.csproj
+++ b/CMD/CMD.csproj
@@ -10,15 +10,15 @@
     <PackageReference Include="FluentCommandLineParser" Version="1.4.3" />
     <PackageReference Include="mzLib" Version="1.0.301" />
     <PackageReference Include="Nett" Version="0.8.0" />
-    <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.Containers" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.CrossValidation" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.DecisionTrees" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.GradientBoost" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.InputOutput" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.Metrics" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.Optimization" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.RandomForest" Version="0.26.8.1" />
+    <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.Containers" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.CrossValidation" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.DecisionTrees" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.GradientBoost" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.InputOutput" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.Metrics" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.Optimization" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.RandomForest" Version="0.26.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EngineLayer/ClassicSearch/ClassicSearchEngine.cs
+++ b/EngineLayer/ClassicSearch/ClassicSearchEngine.cs
@@ -94,7 +94,8 @@ namespace EngineLayer.ClassicSearch
                                 double scanPrecursorMass = scan.theScan.PrecursorMass;
 
                                 var thisScore = CalculatePeptideScore(scan.theScan.TheScan, commonParameters.ProductMassTolerance, productMasses, scanPrecursorMass, dissociationTypes, addCompIons, 0);
-                                bool meetsScoreCutoff = thisScore > commonParameters.ScoreCutoff;
+
+                                bool meetsScoreCutoff = thisScore >= commonParameters.ScoreCutoff;
                                 bool scoreImprovement = peptideSpectralMatches[scan.scanIndex] == null || (thisScore - peptideSpectralMatches[scan.scanIndex].RunnerUpScore) > -PeptideSpectralMatch.tolForScoreDifferentiation;
 
                                 // this is thread-safe because even if the score improves from another thread writing to this PSM,
@@ -115,7 +116,7 @@ namespace EngineLayer.ClassicSearch
 
                                         if (commonParameters.CalculateEValue)
                                         {
-                                            peptideSpectralMatches[scan.scanIndex].AddThisScoreToScoreDistribution(thisScore);
+                                            peptideSpectralMatches[scan.scanIndex].AllScores.Add(thisScore);
                                         }
                                     }
                                 }

--- a/EngineLayer/EngineLayer.csproj
+++ b/EngineLayer/EngineLayer.csproj
@@ -10,15 +10,15 @@
     <PackageReference Include="mzLib" Version="1.0.301" />
     <PackageReference Include="Nett" Version="0.8.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
-    <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.Containers" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.CrossValidation" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.DecisionTrees" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.GradientBoost" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.InputOutput" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.Metrics" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.Optimization" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.RandomForest" Version="0.26.8.1" />
+    <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.Containers" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.CrossValidation" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.DecisionTrees" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.GradientBoost" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.InputOutput" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.Metrics" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.Optimization" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.RandomForest" Version="0.26.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EngineLayer/FdrAnalysis/FdrInfo.cs
+++ b/EngineLayer/FdrAnalysis/FdrInfo.cs
@@ -12,7 +12,7 @@
         public double QValueNotch { get; set; }
         public bool CalculateEValue { get; set; }
         public double MaximumLikelihood { get; set; }
-        public decimal EValue { get; set; }
+        public double EValue { get; set; }
         public double EScore { get; set; }
 
         #endregion Public Properties

--- a/EngineLayer/ModernSearch/ModernSearchEngine.cs
+++ b/EngineLayer/ModernSearch/ModernSearchEngine.cs
@@ -112,10 +112,10 @@ namespace EngineLayer.ModernSearch
                         var thisScore = CalculatePeptideScore(scan.TheScan, CommonParameters.ProductMassTolerance, productMasses, scanPrecursorMass, dissociationTypes, addCompIons, 0);
                         int notch = massDiffAcceptor.Accepts(scan.PrecursorMass, compactPeptide.MonoisotopicMassIncludingFixedMods);
 
-                        bool meetsScoreCutoff = thisScore > CommonParameters.ScoreCutoff;
+                        bool meetsScoreCutoff = thisScore >= CommonParameters.ScoreCutoff;
                         bool scoreImprovement = peptideSpectralMatches[i] == null || (thisScore - peptideSpectralMatches[i].RunnerUpScore) > -PeptideSpectralMatch.tolForScoreDifferentiation;
 
-                        if (meetsScoreCutoff && scoreImprovement)
+                        if (meetsScoreCutoff && scoreImprovement || CommonParameters.CalculateEValue)
                         {
                             if (peptideSpectralMatches[i] == null)
                             {
@@ -125,11 +125,11 @@ namespace EngineLayer.ModernSearch
                             {
                                 peptideSpectralMatches[i].AddOrReplace(compactPeptide, thisScore, notch, CommonParameters.ReportAllAmbiguity);
                             }
-                        }
 
-                        if (CommonParameters.CalculateEValue)
-                        {
-                            peptideSpectralMatches[i].AddThisScoreToScoreDistribution(thisScore);
+                            if (CommonParameters.CalculateEValue)
+                            {
+                                peptideSpectralMatches[i].AllScores.Add(thisScore);
+                            }
                         }
                     }
 

--- a/EngineLayer/PeptideSpectralMatch.cs
+++ b/EngineLayer/PeptideSpectralMatch.cs
@@ -41,8 +41,7 @@ namespace EngineLayer
             ScanPrecursorMonoisotopicPeakMz = scan.PrecursorMonoisotopicPeakMz;
             ScanPrecursorMass = scan.PrecursorMass;
             AddOrReplace(peptide, score, notch, true);
-            AllScores = new List<int>(new int[(int)Math.Floor(score) + 1]);
-            AllScores[AllScores.Count - 1]++;
+            this.AllScores = new List<double>();
             MatchedIonDictOnlyMatches = new Dictionary<ProductType, double[]>();
             ProductMassErrorDa = new Dictionary<ProductType, double[]>();
             ProductMassErrorPpm = new Dictionary<ProductType, double[]>();
@@ -86,7 +85,7 @@ namespace EngineLayer
         public Dictionary<ProductType, double[]> ProductMassErrorDa { get; internal set; }
         public Dictionary<ProductType, double[]> ProductMassErrorPpm { get; internal set; }
 
-        public List<int> AllScores { get; set; }
+        public List<double> AllScores { get; set; }
 
         public double[] Features
         {
@@ -195,7 +194,7 @@ namespace EngineLayer
             DeltaScore = Score - Math.Max(RunnerUpScore, scoreCutoff);
         }
 
-        public void SetFdrValues(int cumulativeTarget, int cumulativeDecoy, double tempQValue, int cumulativeTargetNotch, int cumulativeDecoyNotch, double tempQValueNotch, double maximumLikelihood, decimal eValue, double eScore, bool calculateEValue)
+        public void SetFdrValues(int cumulativeTarget, int cumulativeDecoy, double tempQValue, int cumulativeTargetNotch, int cumulativeDecoyNotch, double tempQValueNotch, double maximumLikelihood, double eValue, double eScore, bool calculateEValue)
         {
             FdrInfo = new FdrInfo
             {
@@ -210,17 +209,6 @@ namespace EngineLayer
                 EValue = eValue,
                 CalculateEValue = calculateEValue
             };
-        }
-
-        public void AddThisScoreToScoreDistribution(double score)
-        {
-            // creates a distribution of scores for this PSM
-            int roundScore = (int)Math.Floor(score);
-            while (AllScores.Count <= roundScore)
-            {
-                AllScores.Add(0);
-            }
-            AllScores[roundScore]++;
         }
 
         #endregion Public Methods
@@ -375,7 +363,11 @@ namespace EngineLayer
         {
             bool pepWithModsIsNull = peptide == null || peptide.compactPeptides.First().Value.Item2 == null;
 
-            var pepsWithMods = pepWithModsIsNull ? null : peptide.compactPeptides.SelectMany(b => b.Value.Item2).ToList();
+            var pepsWithMods = pepWithModsIsNull ? null : peptide.compactPeptides.SelectMany(b => b.Value.Item2)
+                .OrderBy(p => p.Sequence)
+                .ThenBy(p => p.Protein.Accession)
+                .ThenBy(p => p.OneBasedStartResidueInProtein).ToList();
+
             s["Peptides Sharing Same Peaks"] = pepWithModsIsNull ? " " :
                 GlobalVariables.CheckLengthOfOutput(string.Join("|", peptide.compactPeptides.Select(b => b.Value.Item2.Count.ToString(CultureInfo.InvariantCulture))));
             s["Base Sequence"] = pepWithModsIsNull ? " " : Resolve(pepsWithMods.Select(b => b.BaseSequence)).Item1;
@@ -410,15 +402,8 @@ namespace EngineLayer
             string theoreticalsSearched = " ";
             if (!pepWithModsIsNull && peptide.FdrInfo != null && peptide.FdrInfo.CalculateEValue)
             {
-                int theoreticalsSearchedCount = peptide.AllScores[0];
-                StringBuilder allScoresSb = new StringBuilder(peptide.AllScores[0].ToString());
-                for (int ii = 1; ii < peptide.AllScores.Count; ii++)
-                {
-                    allScoresSb.Append("_" + peptide.AllScores[ii]);
-                    theoreticalsSearchedCount += peptide.AllScores[ii];
-                }
-                allScores = allScoresSb.ToString();
-                theoreticalsSearched = theoreticalsSearchedCount.ToString();
+                allScores = string.Join(";", peptide.AllScores.Select(p => p.ToString("F2", CultureInfo.InvariantCulture)));
+                theoreticalsSearched = peptide.AllScores.Count.ToString();
             }
 
             s["All Scores"] = allScores;

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -86,32 +86,32 @@
     <Reference Include="Proteomics, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\mzLib.1.0.301\lib\net45\Proteomics.dll</HintPath>
     </Reference>
-    <Reference Include="SharpLearning.Common.Interfaces, Version=0.26.8.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpLearning.Common.Interfaces.0.26.8.1\lib\net461\SharpLearning.Common.Interfaces.dll</HintPath>
+    <Reference Include="SharpLearning.Common.Interfaces, Version=0.26.9.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpLearning.Common.Interfaces.0.26.9\lib\net461\SharpLearning.Common.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="SharpLearning.Containers, Version=0.26.8.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpLearning.Containers.0.26.8.1\lib\net461\SharpLearning.Containers.dll</HintPath>
+    <Reference Include="SharpLearning.Containers, Version=0.26.9.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpLearning.Containers.0.26.9\lib\net461\SharpLearning.Containers.dll</HintPath>
     </Reference>
-    <Reference Include="SharpLearning.CrossValidation, Version=0.26.8.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpLearning.CrossValidation.0.26.8.1\lib\net461\SharpLearning.CrossValidation.dll</HintPath>
+    <Reference Include="SharpLearning.CrossValidation, Version=0.26.9.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpLearning.CrossValidation.0.26.9\lib\net461\SharpLearning.CrossValidation.dll</HintPath>
     </Reference>
-    <Reference Include="SharpLearning.DecisionTrees, Version=0.26.8.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpLearning.DecisionTrees.0.26.8.1\lib\net461\SharpLearning.DecisionTrees.dll</HintPath>
+    <Reference Include="SharpLearning.DecisionTrees, Version=0.26.9.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpLearning.DecisionTrees.0.26.9\lib\net461\SharpLearning.DecisionTrees.dll</HintPath>
     </Reference>
-    <Reference Include="SharpLearning.GradientBoost, Version=0.26.8.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpLearning.GradientBoost.0.26.8.1\lib\net461\SharpLearning.GradientBoost.dll</HintPath>
+    <Reference Include="SharpLearning.GradientBoost, Version=0.26.9.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpLearning.GradientBoost.0.26.9\lib\net461\SharpLearning.GradientBoost.dll</HintPath>
     </Reference>
-    <Reference Include="SharpLearning.InputOutput, Version=0.26.8.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpLearning.InputOutput.0.26.8.1\lib\net461\SharpLearning.InputOutput.dll</HintPath>
+    <Reference Include="SharpLearning.InputOutput, Version=0.26.9.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpLearning.InputOutput.0.26.9\lib\net461\SharpLearning.InputOutput.dll</HintPath>
     </Reference>
-    <Reference Include="SharpLearning.Metrics, Version=0.26.8.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpLearning.Metrics.0.26.8.1\lib\net461\SharpLearning.Metrics.dll</HintPath>
+    <Reference Include="SharpLearning.Metrics, Version=0.26.9.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpLearning.Metrics.0.26.9\lib\net461\SharpLearning.Metrics.dll</HintPath>
     </Reference>
-    <Reference Include="SharpLearning.Optimization, Version=0.26.8.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpLearning.Optimization.0.26.8.1\lib\net461\SharpLearning.Optimization.dll</HintPath>
+    <Reference Include="SharpLearning.Optimization, Version=0.26.9.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpLearning.Optimization.0.26.9\lib\net461\SharpLearning.Optimization.dll</HintPath>
     </Reference>
-    <Reference Include="SharpLearning.RandomForest, Version=0.26.8.1, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\SharpLearning.RandomForest.0.26.8.1\lib\net461\SharpLearning.RandomForest.dll</HintPath>
+    <Reference Include="SharpLearning.RandomForest, Version=0.26.9.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SharpLearning.RandomForest.0.26.9\lib\net461\SharpLearning.RandomForest.dll</HintPath>
     </Reference>
     <Reference Include="Spectra, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\mzLib.1.0.301\lib\net45\Spectra.dll</HintPath>

--- a/GUI/packages.config
+++ b/GUI/packages.config
@@ -5,14 +5,14 @@
   <package id="mzLib" version="1.0.301" targetFramework="net471" />
   <package id="Nett" version="0.8.0" targetFramework="net471" />
   <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net471" />
-  <package id="SharpLearning.Common.Interfaces" version="0.26.8.1" targetFramework="net471" />
-  <package id="SharpLearning.Containers" version="0.26.8.1" targetFramework="net471" />
-  <package id="SharpLearning.CrossValidation" version="0.26.8.1" targetFramework="net471" />
-  <package id="SharpLearning.DecisionTrees" version="0.26.8.1" targetFramework="net471" />
-  <package id="SharpLearning.GradientBoost" version="0.26.8.1" targetFramework="net471" />
-  <package id="SharpLearning.InputOutput" version="0.26.8.1" targetFramework="net471" />
-  <package id="SharpLearning.Metrics" version="0.26.8.1" targetFramework="net471" />
-  <package id="SharpLearning.Optimization" version="0.26.8.1" targetFramework="net471" />
-  <package id="SharpLearning.RandomForest" version="0.26.8.1" targetFramework="net471" />
+  <package id="SharpLearning.Common.Interfaces" version="0.26.9" targetFramework="net471" />
+  <package id="SharpLearning.Containers" version="0.26.9" targetFramework="net471" />
+  <package id="SharpLearning.CrossValidation" version="0.26.9" targetFramework="net471" />
+  <package id="SharpLearning.DecisionTrees" version="0.26.9" targetFramework="net471" />
+  <package id="SharpLearning.GradientBoost" version="0.26.9" targetFramework="net471" />
+  <package id="SharpLearning.InputOutput" version="0.26.9" targetFramework="net471" />
+  <package id="SharpLearning.Metrics" version="0.26.9" targetFramework="net471" />
+  <package id="SharpLearning.Optimization" version="0.26.9" targetFramework="net471" />
+  <package id="SharpLearning.RandomForest" version="0.26.9" targetFramework="net471" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net471" />
 </packages>

--- a/TaskLayer/CalibrationTask/CalibrationTask.cs
+++ b/TaskLayer/CalibrationTask/CalibrationTask.cs
@@ -133,7 +133,7 @@ namespace TaskLayer
                 // get filename stuff
                 var originalUncalibratedFilePath = currentRawFileList[spectraFileIndex];
                 var originalUncalibratedFilenameWithoutExtension = Path.GetFileNameWithoutExtension(originalUncalibratedFilePath);
-                string calibratedFilePath = Path.Combine(OutputFolder, originalUncalibratedFilenameWithoutExtension + "-calib.mzml");
+                string calibratedFilePath = Path.Combine(OutputFolder, originalUncalibratedFilenameWithoutExtension + "-calib.mzML");
 
                 // mark the file as in-progress
                 StartingDataFile(originalUncalibratedFilePath, new List<string> { taskId, "Individual Spectra Files", originalUncalibratedFilePath });

--- a/TaskLayer/TaskLayer.csproj
+++ b/TaskLayer/TaskLayer.csproj
@@ -10,15 +10,15 @@
     <PackageReference Include="mzLib" Version="1.0.301" />
     <PackageReference Include="NetSerializer" Version="4.1.0" />
     <PackageReference Include="Nett" Version="0.8.0" />
-    <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.Containers" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.CrossValidation" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.DecisionTrees" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.GradientBoost" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.InputOutput" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.Metrics" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.Optimization" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.RandomForest" Version="0.26.8.1" />
+    <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.Containers" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.CrossValidation" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.DecisionTrees" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.GradientBoost" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.InputOutput" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.Metrics" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.Optimization" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.RandomForest" Version="0.26.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Test/BinGenerationTest.cs
+++ b/Test/BinGenerationTest.cs
@@ -42,7 +42,7 @@ namespace Test
             };
 
             string proteinDbFilePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "BinGenerationTest.xml");
-            string mzmlFilePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "BinGenerationTest.mzml");
+            string mzmlFilePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "BinGenerationTest.mzML");
 
             Protein prot1 = new Protein("MEDEEK", "prot1");
             Protein prot2 = new Protein("MENEEK", "prot2");
@@ -106,8 +106,8 @@ namespace Test
             };
 
             string proteinDbFilePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestProteinSplitAcrossFiles.xml");
-            string mzmlFilePath1 = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestProteinSplitAcrossFiles1.mzml");
-            string mzmlFilePath2 = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestProteinSplitAcrossFiles2.mzml");
+            string mzmlFilePath1 = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestProteinSplitAcrossFiles1.mzML");
+            string mzmlFilePath2 = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestProteinSplitAcrossFiles2.mzML");
 
             ModificationMotif.TryGetMotif("D", out ModificationMotif motif);
             ModificationWithMass mod = new ModificationWithMass("mod1", "mt", motif, TerminusLocalization.Any, 10);

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -10,15 +10,15 @@
     <PackageReference Include="mzLib" Version="1.0.301" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.Containers" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.CrossValidation" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.DecisionTrees" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.GradientBoost" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.InputOutput" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.Metrics" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.Optimization" Version="0.26.8.1" />
-    <PackageReference Include="SharpLearning.RandomForest" Version="0.26.8.1" />
+    <PackageReference Include="SharpLearning.Common.Interfaces" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.Containers" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.CrossValidation" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.DecisionTrees" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.GradientBoost" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.InputOutput" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.Metrics" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.Optimization" Version="0.26.9" />
+    <PackageReference Include="SharpLearning.RandomForest" Version="0.26.9" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* 0.0.278 (#1134) (#1135)

* hide "download portable .zip" button in updater (#1115)

* order calibration datapoints prior to random forest function (#1116)

* hide "download portable .zip" button in updater

* order calibration datapoints prior to calibration function for more reproducibility

* revise calibration results text (median and interquartile range of PSM precursor and product ppm errors); big unit test

* remove nice calibration unit test :( takes too long in appveyor

* fix crash

* remove unused

* Small changes (#1118)

fix some gui problems post-gptmd task

* fix version parsing bug (#1119)

fix version parsing bug

* random seed stuff in calibration engine (#1120)

* random seed stuff in calibration

* more random seed

* automatically change tolerances on calibration failure; increase rand… (#1121)

* automatically change tolerances on calibration failure; increase random forest tree depth, num trees

* cleanup

* reorder tasks with + and -; files added to gui are ordered first before adding (#1122)

* reorder tasks with + and -; files dragged in are sorted alphabetically before being added to the gui

* fix gptmd file-specific precursor tolerances (#1123)

* fix gptmd file-specific tolerances

* Tool tips (#1109)

* Tooltips for (hopefully) more clarity

* XL crosslinker with different amino acid  (#1089)

* XL Different crosslink sites

* XL crosslink different amino acid GUI

* XL Improve codeCov

* XL Improve CodeCov2

* XL test Target 90% coverage

* XLTest Target 90% coverage2

* XLTest Target 90% coverage3

* XL pep.XML mod position N ter refer as 0

* XL test diff crosslink site

* Optimize xltest code

* XL improve code quality

* gui warning stuff (#1132)

* gui warning stuff

* Delete example.mzML

* Delete mouse-10.xml

* Delete Task5SearchExample.toml

* Delete Task4GptmdExample.toml

* Delete Task3SearchExample.toml

* Delete Task2CalibrationExample.toml

* Delete Task1SearchExample.toml

* fix empty protein db crash and correct prose (#1136)

* Fix crash and prose (#1138)

* fix empty protein db crash and correct prose

* modern search bugfix

* fix unit tests

* add num MS2 spectra to results (#1139)

* add num MS2 spectra to results

* Nonspecific gui cover (#1143)

* NonSpecific Search mode user-friendliness

* Edits for writing pruned DB (#1045)

* alphabetize protein group names

* new alphabetize protein groups

* update

* update with test

* update good test

* ok

* comment

* kljh

* Bug fixes for pruned database generation! Now all proteins that can be identified via non-ambigous psms are written to the pruned database, but modifications are only written on proteins where they are localized

* reconcile w master branch

* fix bugs that were caught by unit tests, builds properly

* UnitTest for protein Pruned DB generation if complete and functions

* fix merge stuff

* Revisions based on edits

* Finished revisions with test restructure

* Codecy Changes

* minor codecy fix

* more codecy fixes

* coadacy

* codacy again

* final codacy edit.. i hope

* update mzLib (fix a crash related to finding an MS2's precursor scan) (#1148)

* Make PeptideSpectralMatch.ToString() code more maintainable by tethering (#1145)

header strings to the value strings for each PSM. Also, added sequence
variations to the output.

* "Trivial change" (#1151)

* Remove unimportant warning.

* "higher quality data points" which have no observable improvement in calibration

* nah, changed my mind.

*  mzML consistent naming (#1153)

* Remove unimportant warning.

* "higher quality data points" which have no observable improvement in calibration

* nah, changed my mind.

* mzML consistent naming

* partial revert to allow any mzml case for reading

* revert mistake

* update sharplearning, eValue calculations, PSM ambiguous peptide ordering (#1155)

* update eValue calculations; update sharplearning

* order ambiguous peptide hits in PSM output; update eValue-related output

* fix search cutoff

* fix crash

* correct modern search evalue bug

* fix crash in modern search+evalue

* add evalue comments

* merge fix (#1158)