### PR TITLE
Refactor common parameters to use default initializers

### DIFF
--- a/EngineLayer/CommonParameters.cs
+++ b/EngineLayer/CommonParameters.cs
@@ -2,133 +2,83 @@
 using Proteomics.ProteolyticDigestion;
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace EngineLayer
 {
+    /// <summary>
+    /// Parameters used across engines within a certain task
+    /// </summary>
     public class CommonParameters
     {
-        // this parameterless constructor needs to exist to read the toml.
-        // if you can figure out a way to get rid of it, feel free...
-        public CommonParameters() : this(digestionParams: null)
-        {
-        }
+        // Note:
+        //
+        // Any new property must not be nullable (int?) or else if it is null,
+        // the null setting will not be written to a toml and the default will override
+        // (so it's okay if the default is null)
 
-        public CommonParameters(bool bIons = true, bool yIons = true, bool zDotIons = false, bool cIons = false, bool doPrecursorDeconvolution = true,
-            bool useProvidedPrecursorInfo = true, double deconvolutionIntensityRatio = 3, int deconvolutionMaxAssumedChargeState = 12, bool reportAllAmbiguity = true,
-            bool addCompIons = false, int totalPartitions = 1, double scoreCutoff = 5, int topNpeaks = 200, double minRatio = 0.01, bool trimMs1Peaks = false,
-            bool trimMsMsPeaks = true, bool useDeltaScore = false, bool calculateEValue = false, Tolerance productMassTolerance = null, Tolerance precursorMassTolerance = null, Tolerance deconvolutionMassTolerance = null,
-            int maxThreadsToUsePerFile = -1, DigestionParams digestionParams = null, IEnumerable<(string, string)> listOfModsVariable = null, IEnumerable<(string, string)> listOfModsFixed = null)
-        {
-            BIons = bIons;
-            YIons = yIons;
-            ZdotIons = zDotIons;
-            CIons = cIons;
-            DoPrecursorDeconvolution = doPrecursorDeconvolution;
-            UseProvidedPrecursorInfo = useProvidedPrecursorInfo;
-            DeconvolutionIntensityRatio = deconvolutionIntensityRatio;
-            DeconvolutionMaxAssumedChargeState = deconvolutionMaxAssumedChargeState;
-            ReportAllAmbiguity = reportAllAmbiguity;
-            AddCompIons = addCompIons;
-            TotalPartitions = totalPartitions;
-            ScoreCutoff = scoreCutoff;
-            TopNpeaks = topNpeaks;
-            MinRatio = minRatio;
-            TrimMs1Peaks = trimMs1Peaks;
-            TrimMsMsPeaks = trimMsMsPeaks;
-            UseDeltaScore = useDeltaScore;
-            CalculateEValue = calculateEValue;
-            MaxThreadsToUsePerFile = maxThreadsToUsePerFile;
+        // General
 
-            ProductMassTolerance = productMassTolerance ?? new PpmTolerance(20);
-            PrecursorMassTolerance = precursorMassTolerance ?? new PpmTolerance(5);
-            DeconvolutionMassTolerance = deconvolutionMassTolerance ?? new PpmTolerance(4);
-            DigestionParams = digestionParams ?? new DigestionParams();
-            ListOfModsVariable = listOfModsVariable ?? new List<(string, string)> { ("Common Variable", "Oxidation of M") };
-            ListOfModsFixed = listOfModsFixed ?? new List<(string, string)> { ("Common Fixed", "Carbamidomethyl of C"), ("Common Fixed", "Carbamidomethyl of U") };
-
-            if (maxThreadsToUsePerFile == -1)
-            {
-                MaxThreadsToUsePerFile = Environment.ProcessorCount > 1 ? Environment.ProcessorCount - 1 : 1;
-            }
-            else
-            {
-                MaxThreadsToUsePerFile = maxThreadsToUsePerFile;
-            }
-        }
-
-        //Any new property must not be nullable (int?) or else if it is null, the null setting will not be written to a toml and the default will override (so it's okay if the default is null)
         public string TaskDescriptor { get; set; }
 
-        public int MaxThreadsToUsePerFile { get; set; }
-        public IEnumerable<(string, string)> ListOfModsFixed { get; private set; }
-        public IEnumerable<(string, string)> ListOfModsVariable { get; private set; }
-        public bool DoPrecursorDeconvolution { get; private set; }
-        public bool UseProvidedPrecursorInfo { get; private set; }
-        public double DeconvolutionIntensityRatio { get; private set; }
-        public int DeconvolutionMaxAssumedChargeState { get; private set; }
-        public Tolerance DeconvolutionMassTolerance { get; private set; }
-        public int TotalPartitions { get; private set; }
-        public bool BIons { get; private set; }
-        public bool YIons { get; private set; }
-        public bool ZdotIons { get; private set; }
-        public bool CIons { get; private set; }
-        public Tolerance ProductMassTolerance { get; private set; }
-        public Tolerance PrecursorMassTolerance { get; private set; }
-        public bool AddCompIons { get; private set; }
-        public double ScoreCutoff { get; private set; }
-        public DigestionParams DigestionParams { get; private set; }
-        public bool ReportAllAmbiguity { get; private set; }
-        public int TopNpeaks { get; private set; }
-        public double MinRatio { get; private set; }
-        public bool TrimMs1Peaks { get; private set; }
-        public bool TrimMsMsPeaks { get; private set; }
-        public bool UseDeltaScore { get; private set; }
-        public bool CalculateEValue { get; private set; }
+        // Search settings
 
+        public DigestionParams DigestionParams { get; set; } = new DigestionParams();
+        public Tolerance ProductMassTolerance { get; set; } = new PpmTolerance(20);
+        public Tolerance PrecursorMassTolerance { get; set; } = new PpmTolerance(5);
+        public bool ReportAllAmbiguity { get; set; } = true;
+        public double ScoreCutoff { get; set; } = 5;
+        public bool UseProvidedPrecursorInfo { get; set; } = true;
+
+        // Modifications
+
+        public IEnumerable<(string, string)> ListOfModsFixed { get; set; } = new List<(string, string)> { ("Common Fixed", "Carbamidomethyl of C"), ("Common Fixed", "Carbamidomethyl of U") };
+        public IEnumerable<(string, string)> ListOfModsVariable { get; set; } = new List<(string, string)> { ("Common Variable", "Oxidation of M") };
+
+        // FDR calculations
+
+        public int MaxThreadsToUsePerFile { get; set; } = Environment.ProcessorCount > 1 ? Environment.ProcessorCount - 1 : 1;
+        public bool CalculateEValue { get; set; }
+
+        // Ions
+
+        public bool BIons { get; set; } = true;
+        public bool YIons { get; set; } = true;
+        public bool ZdotIons { get; set; }
+        public bool CIons { get; set; }
+        public bool AddCompIons { get; set; }
+
+        // Deconvolution
+
+        public bool DoPrecursorDeconvolution { get; set; } = true;
+        public double DeconvolutionIntensityRatio { get; set; } = 3;
+        public int DeconvolutionMaxAssumedChargeState { get; set; } = 12;
+        public Tolerance DeconvolutionMassTolerance { get; set; } = new PpmTolerance(4);
+
+        // Peak trimming
+
+        public int TopNpeaks { get; set; } = 200;
+        public double MinRatio { get; set; } = 0.01;
+        public bool TrimMs1Peaks { get; set; }
+        public bool TrimMsMsPeaks { get; set; } = true;
+
+        // Thread Usage
+
+        public int TotalPartitions { get; set; } = 1;
+        public bool UseDeltaScore { get; set; }
+
+        /// <summary>
+        /// Copies the information from this CommonParameters object to the return object
+        /// </summary>
+        /// <returns></returns>
         public CommonParameters Clone()
         {
-            return new CommonParameters(
-                bIons: this.BIons,
-                yIons: this.YIons,
-                zDotIons: this.ZdotIons,
-                cIons: this.CIons,
-                doPrecursorDeconvolution: this.DoPrecursorDeconvolution,
-                useProvidedPrecursorInfo: this.UseProvidedPrecursorInfo,
-                deconvolutionIntensityRatio: this.DeconvolutionIntensityRatio,
-                deconvolutionMaxAssumedChargeState: this.DeconvolutionMaxAssumedChargeState,
-                reportAllAmbiguity: this.ReportAllAmbiguity,
-                addCompIons: this.AddCompIons,
-                totalPartitions: this.TotalPartitions,
-                scoreCutoff: this.ScoreCutoff,
-                topNpeaks: this.TopNpeaks,
-                minRatio: this.MinRatio,
-                trimMs1Peaks: this.TrimMs1Peaks,
-                trimMsMsPeaks: this.TrimMsMsPeaks,
-                useDeltaScore: this.UseDeltaScore,
-                calculateEValue: this.CalculateEValue,
-                productMassTolerance: this.ProductMassTolerance,
-                precursorMassTolerance: this.PrecursorMassTolerance,
-                deconvolutionMassTolerance: this.DeconvolutionMassTolerance,
-                maxThreadsToUsePerFile: this.MaxThreadsToUsePerFile,
-                digestionParams: this.DigestionParams,
-                listOfModsVariable: this.ListOfModsVariable,
-                listOfModsFixed: this.ListOfModsFixed
-            );
-        }
-
-        public void SetProductMassTolerance(Tolerance ProductMassTolerance)
-        {
-            this.ProductMassTolerance = ProductMassTolerance;
-        }
-
-        public void SetPrecursorMassTolerance(Tolerance PrecursorMassTolerance)
-        {
-            this.PrecursorMassTolerance = PrecursorMassTolerance;
-        }
-
-        public void SetDigestionParams(DigestionParams DigestionParams)
-        {
-            this.DigestionParams = DigestionParams;
+            CommonParameters c = new CommonParameters();
+            foreach (PropertyInfo property in typeof(CommonParameters).GetProperties())
+            {
+                property.SetValue(c, property.GetValue(this));
+            }
+            return c;
         }
     }
 }

--- a/GUI/CalibrateTaskWindow.xaml.cs
+++ b/GUI/CalibrateTaskWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using EngineLayer;
 using MzLibUtil;
+using Proteomics.ProteolyticDigestion;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -9,7 +10,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using TaskLayer;
-using Proteomics.ProteolyticDigestion;
 
 namespace MetaMorpheusGUI
 {
@@ -190,9 +190,9 @@ namespace MetaMorpheusGUI
             int MaxModificationIsoforms = int.Parse(maxModificationIsoformsTextBox.Text, CultureInfo.InvariantCulture);
             DigestionParams digestionParamsToSave = new DigestionParams(
                 protease: protease.Name,
-                maxMissedCleavages: MaxMissedCleavages, 
-                minPeptideLength: MinPeptideLength, 
-                maxPeptideLength: MaxPeptideLength, 
+                maxMissedCleavages: MaxMissedCleavages,
+                minPeptideLength: MinPeptideLength,
+                maxPeptideLength: MaxPeptideLength,
                 maxModificationIsoforms: MaxModificationIsoforms);
 
             var listOfModsVariable = new List<(string, string)>();
@@ -225,32 +225,32 @@ namespace MetaMorpheusGUI
             {
                 PrecursorMassTolerance = new PpmTolerance(double.Parse(precursorMassToleranceTextBox.Text, CultureInfo.InvariantCulture));
             }
-            CommonParameters CommonParamsToSave = new CommonParameters(
-                digestionParams: digestionParamsToSave,
-                bIons: bCheckBox.IsChecked.Value,
-                yIons: yCheckBox.IsChecked.Value,
-                cIons: cCheckBox.IsChecked.Value,
-                zDotIons: zdotCheckBox.IsChecked.Value,
-                scoreCutoff: double.Parse(minScoreAllowed.Text, CultureInfo.InvariantCulture),
-                listOfModsFixed: listOfModsFixed,
-                listOfModsVariable: listOfModsVariable,
-                productMassTolerance: ProductMassTolerance,
-                precursorMassTolerance: PrecursorMassTolerance);
+            CommonParameters commonParamsToSave = new CommonParameters();
+            commonParamsToSave.DigestionParams = digestionParamsToSave;
+            commonParamsToSave.BIons = bCheckBox.IsChecked.Value;
+            commonParamsToSave.YIons = yCheckBox.IsChecked.Value;
+            commonParamsToSave.CIons = cCheckBox.IsChecked.Value;
+            commonParamsToSave.ZdotIons = zdotCheckBox.IsChecked.Value;
+            commonParamsToSave.ScoreCutoff = double.Parse(minScoreAllowed.Text, CultureInfo.InvariantCulture);
+            commonParamsToSave.ListOfModsFixed = listOfModsFixed;
+            commonParamsToSave.ListOfModsVariable = listOfModsVariable;
+            commonParamsToSave.ProductMassTolerance = ProductMassTolerance;
+            commonParamsToSave.PrecursorMassTolerance = PrecursorMassTolerance;
 
             if (int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture) <= Environment.ProcessorCount && int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture) > 0)
             {
-                CommonParamsToSave.MaxThreadsToUsePerFile = int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture);
+                commonParamsToSave.MaxThreadsToUsePerFile = int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture);
             }
             if (OutputFileNameTextBox.Text != "")
             {
-                CommonParamsToSave.TaskDescriptor = OutputFileNameTextBox.Text;
+                commonParamsToSave.TaskDescriptor = OutputFileNameTextBox.Text;
             }
             else
             {
-                CommonParamsToSave.TaskDescriptor = "CalibrateTask";
+                commonParamsToSave.TaskDescriptor = "CalibrateTask";
             }
 
-            TheTask.CommonParameters = CommonParamsToSave;
+            TheTask.CommonParameters = commonParamsToSave;
 
             DialogResult = true;
         }

--- a/GUI/FileSpecificParametersWindow.xaml.cs
+++ b/GUI/FileSpecificParametersWindow.xaml.cs
@@ -1,14 +1,13 @@
 ﻿using EngineLayer;
 using MzLibUtil;
 using Nett;
-using System;
+using Proteomics.ProteolyticDigestion;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Windows;
 using System.Windows.Input;
 using TaskLayer;
-using Proteomics.ProteolyticDigestion;
 
 namespace MetaMorpheusGUI
 {
@@ -17,8 +16,7 @@ namespace MetaMorpheusGUI
     /// </summary>
     public partial class FileSpecificParametersWindow : Window
     {
-
-        //Window that is opened if user wishes to change file specific settings (TOML) for 
+        //Window that is opened if user wishes to change file specific settings (TOML) for
         //individual or multiple spectra files. Creates a toml file where settings can be
         //viewed, loaded, and changed from it.
         public FileSpecificParametersWindow(ObservableCollection<RawDataForDataGrid> selectedSpectraFiles)
@@ -146,7 +144,6 @@ namespace MetaMorpheusGUI
 
             // write parameters to toml files for the selected spectra files
 
-
             var tomlPathsForSelectedFiles = SelectedSpectra.Select(p => Path.Combine(Directory.GetParent(p.FilePath).ToString(), Path.GetFileNameWithoutExtension(p.FileName)) + ".toml");
             foreach (var tomlToWrite in tomlPathsForSelectedFiles)
             {
@@ -198,12 +195,12 @@ namespace MetaMorpheusGUI
 
                     if (fileSpecificParams.PrecursorMassTolerance != null)
                     {
-                        tempCommonParams.SetPrecursorMassTolerance(fileSpecificParams.PrecursorMassTolerance);
+                        tempCommonParams.PrecursorMassTolerance = fileSpecificParams.PrecursorMassTolerance;
                         fileSpecificPrecursorMassTolEnabled.IsChecked = true;
                     }
                     if (fileSpecificParams.ProductMassTolerance != null)
                     {
-                        tempCommonParams.SetProductMassTolerance(fileSpecificParams.ProductMassTolerance);
+                        tempCommonParams.ProductMassTolerance = fileSpecificParams.ProductMassTolerance;
                         fileSpecificProductMassTolEnabled.IsChecked = true;
                     }
                     if (fileSpecificParams.Protease != null)
@@ -252,7 +249,7 @@ namespace MetaMorpheusGUI
                 maxPeptideLength: tempMaxPeptideLength,
                 maxModsForPeptides: tempMaxModsForPeptide);
 
-            tempCommonParams.SetDigestionParams(digestParams);
+            tempCommonParams.DigestionParams = digestParams;
 
             // populate the GUI
             foreach (Protease protease in ProteaseDictionary.Dictionary.Values)

--- a/GUI/GPTMDTaskWindow.xaml.cs
+++ b/GUI/GPTMDTaskWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using EngineLayer;
 using MzLibUtil;
+using Proteomics.ProteolyticDigestion;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -9,7 +10,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using TaskLayer;
-using Proteomics.ProteolyticDigestion;
 
 namespace MetaMorpheusGUI
 {
@@ -269,35 +269,35 @@ namespace MetaMorpheusGUI
             {
                 listOfModsFixed.AddRange(heh.Children.Where(b => b.Use).Select(b => (b.Parent.DisplayName, b.DisplayName)));
             }
-            CommonParameters CommonParamsToSave = new CommonParameters(
-                digestionParams: new DigestionParams(
-                    protease: protease.Name,
-                    maxMissedCleavages: MaxMissedCleavages,
-                    minPeptideLength: MinPeptideLength,
-                    maxPeptideLength: MaxPeptideLength,
-                    maxModificationIsoforms: MaxModificationIsoforms,
-                    initiatorMethionineBehavior: InitiatorMethionineBehavior),
-                    bIons: bCheckBox.IsChecked.Value,
-                    yIons: yCheckBox.IsChecked.Value,
-                    cIons: cCheckBox.IsChecked.Value,
-                    zDotIons: zdotCheckBox.IsChecked.Value,
-                    scoreCutoff: double.Parse(minScoreAllowed.Text, CultureInfo.InvariantCulture),
-                    precursorMassTolerance: PrecursorMassTolerance,
-                    productMassTolerance: ProductMassTolerance,
-                    listOfModsFixed: listOfModsFixed,
-                    listOfModsVariable: listOfModsVariable);
+            CommonParameters commonParamsToSave = new CommonParameters();
+            commonParamsToSave.DigestionParams = new DigestionParams(
+                protease: protease.Name,
+                maxMissedCleavages: MaxMissedCleavages,
+                minPeptideLength: MinPeptideLength,
+                maxPeptideLength: MaxPeptideLength,
+                maxModificationIsoforms: MaxModificationIsoforms,
+                initiatorMethionineBehavior: InitiatorMethionineBehavior);
+            commonParamsToSave.BIons = bCheckBox.IsChecked.Value;
+            commonParamsToSave.YIons = yCheckBox.IsChecked.Value;
+            commonParamsToSave.CIons = cCheckBox.IsChecked.Value;
+            commonParamsToSave.ZdotIons = zdotCheckBox.IsChecked.Value;
+            commonParamsToSave.ScoreCutoff = double.Parse(minScoreAllowed.Text, CultureInfo.InvariantCulture);
+            commonParamsToSave.PrecursorMassTolerance = PrecursorMassTolerance;
+            commonParamsToSave.ProductMassTolerance = ProductMassTolerance;
+            commonParamsToSave.ListOfModsFixed = listOfModsFixed;
+            commonParamsToSave.ListOfModsVariable = listOfModsVariable;
 
             if (int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture) <= Environment.ProcessorCount && int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture) > 0)
             {
-                CommonParamsToSave.MaxThreadsToUsePerFile = int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture);
+                commonParamsToSave.MaxThreadsToUsePerFile = int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture);
             }
             if (OutputFileNameTextBox.Text != "")
             {
-                CommonParamsToSave.TaskDescriptor = OutputFileNameTextBox.Text;
+                commonParamsToSave.TaskDescriptor = OutputFileNameTextBox.Text;
             }
             else
             {
-                CommonParamsToSave.TaskDescriptor = "GPTMDTask";
+                commonParamsToSave.TaskDescriptor = "GPTMDTask";
             }
 
             TheTask.GptmdParameters.ListOfModsGptmd = new List<(string, string)>();
@@ -306,7 +306,7 @@ namespace MetaMorpheusGUI
                 TheTask.GptmdParameters.ListOfModsGptmd.AddRange(heh.Children.Where(b => b.Use).Select(b => (b.Parent.DisplayName, b.DisplayName)));
             }
 
-            TheTask.CommonParameters = CommonParamsToSave;
+            TheTask.CommonParameters = commonParamsToSave;
 
             DialogResult = true;
         }

--- a/GUI/NeoSearchTaskWindow.xaml.cs
+++ b/GUI/NeoSearchTaskWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using EngineLayer;
 using MzLibUtil;
+using Proteomics.ProteolyticDigestion;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -9,7 +10,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using TaskLayer;
-using Proteomics.ProteolyticDigestion;
 
 namespace MetaMorpheusGUI
 {
@@ -305,10 +305,10 @@ namespace MetaMorpheusGUI
             DigestionParams digestionParamsToSave = new DigestionParams(
                 protease: protease.Name,
                 maxMissedCleavages: maxMissedCleavages,
-                minPeptideLength: minPeptideLength, 
-                maxPeptideLength: maxPeptideLength, 
-                maxModificationIsoforms: maxModificationIsoforms, 
-                initiatorMethionineBehavior: initiatorMethionineBehavior, 
+                minPeptideLength: minPeptideLength,
+                maxPeptideLength: maxPeptideLength,
+                maxModificationIsoforms: maxModificationIsoforms,
+                initiatorMethionineBehavior: initiatorMethionineBehavior,
                 maxModsForPeptides: maxModsForPeptide);
 
             Tolerance ProductMassTolerance;
@@ -351,22 +351,20 @@ namespace MetaMorpheusGUI
                 listOfModsFixed.AddRange(heh.Children.Where(b => b.Use).Select(b => (b.Parent.DisplayName, b.DisplayName)));
             }
 
-            CommonParameters CommonParamsToSave = new CommonParameters(
-                digestionParams: digestionParamsToSave,
-                bIons: bCheckBox.IsChecked.Value,
-                yIons: yCheckBox.IsChecked.Value,
-                cIons: cCheckBox.IsChecked.Value,
-                zDotIons: zdotCheckBox.IsChecked.Value,
-                productMassTolerance: ProductMassTolerance,
-                precursorMassTolerance: PrecursorMassTolerance,
-                listOfModsFixed: listOfModsFixed,
-                listOfModsVariable: listOfModsVariable)
-            {
-                TaskDescriptor = (OutputFileNameTextBox.Text != "") ? OutputFileNameTextBox.Text : "NeoSearchTask"
-            };
+            CommonParameters c = new CommonParameters();
+            c.DigestionParams = digestionParamsToSave;
+            c.BIons = bCheckBox.IsChecked.Value;
+            c.YIons = yCheckBox.IsChecked.Value;
+            c.CIons = cCheckBox.IsChecked.Value;
+            c.ZdotIons = zdotCheckBox.IsChecked.Value;
+            c.ProductMassTolerance = ProductMassTolerance;
+            c.PrecursorMassTolerance = PrecursorMassTolerance;
+            c.ListOfModsFixed = listOfModsFixed;
+            c.ListOfModsVariable = listOfModsVariable;
+            c.TaskDescriptor = (OutputFileNameTextBox.Text != "") ? OutputFileNameTextBox.Text : "NeoSearchTask";
 
             TheTask.NeoParameters = neoParameters;
-            TheTask.CommonParameters = CommonParamsToSave;
+            TheTask.CommonParameters = c;
 
             DialogResult = true;
         }

--- a/GUI/SearchTaskWindow.xaml.cs
+++ b/GUI/SearchTaskWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using EngineLayer;
 using MzLibUtil;
+using Proteomics.ProteolyticDigestion;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -11,7 +12,6 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using TaskLayer;
 using UsefulProteomicsDatabases;
-using Proteomics.ProteolyticDigestion;
 
 namespace MetaMorpheusGUI
 {
@@ -68,7 +68,7 @@ namespace MetaMorpheusGUI
         internal SearchTask TheTask { get; private set; }
 
         private void CheckIfNumber(object sender, TextCompositionEventArgs e)
-        { 
+        {
             e.Handled = !GlobalGuiSettings.CheckIsNumber(e.Text);
         }
 
@@ -270,7 +270,6 @@ namespace MetaMorpheusGUI
 
         private void SaveButton_Click(object sender, RoutedEventArgs e)
         {
-
             if (nonSpecificSearchRadioButton1.IsChecked.Value || semiSpecificSearchRadioButton.IsChecked.Value)
             {
                 if ((bCheckBox.IsChecked.Value || cCheckBox.IsChecked.Value) && (yCheckBox.IsChecked.Value || zdotCheckBox.IsChecked.Value))
@@ -319,12 +318,10 @@ namespace MetaMorpheusGUI
                     MessageBox.Show("Warning: Complementary ions are strongly recommended when using this algorithm.");
             }
 
-
-            
-           if (!GlobalGuiSettings.CheckTaskSettingsValidity(precursorMassToleranceTextBox.Text, productMassToleranceTextBox.Text, missedCleavagesTextBox.Text,
-                maxModificationIsoformsTextBox.Text, MinPeptideLengthTextBox.Text, MaxPeptideLengthTextBox.Text, maxThreadsTextBox.Text, minScoreAllowed.Text,
-                peakFindingToleranceTextBox.Text, histogramBinWidthTextBox.Text, DeconvolutionMaxAssumedChargeStateTextBox.Text, TopNPeaksTextBox.Text,
-                MinRatioTextBox.Text, numberOfDatabaseSearchesTextBox.Text, MaxModNumTextBox.Text, MaxFragmentMassTextBox.Text))
+            if (!GlobalGuiSettings.CheckTaskSettingsValidity(precursorMassToleranceTextBox.Text, productMassToleranceTextBox.Text, missedCleavagesTextBox.Text,
+                 maxModificationIsoformsTextBox.Text, MinPeptideLengthTextBox.Text, MaxPeptideLengthTextBox.Text, maxThreadsTextBox.Text, minScoreAllowed.Text,
+                 peakFindingToleranceTextBox.Text, histogramBinWidthTextBox.Text, DeconvolutionMaxAssumedChargeStateTextBox.Text, TopNPeaksTextBox.Text,
+                 MinRatioTextBox.Text, numberOfDatabaseSearchesTextBox.Text, MaxModNumTextBox.Text, MaxFragmentMassTextBox.Text))
             {
                 return;
             }
@@ -387,37 +384,37 @@ namespace MetaMorpheusGUI
             int TopNpeaks = int.Parse(TopNPeaksTextBox.Text);
             double MinRatio = double.Parse(MinRatioTextBox.Text);
 
-            CommonParameters CommonParamsToSave = new CommonParameters(
-                useDeltaScore: deltaScoreCheckBox.IsChecked.Value,
-                reportAllAmbiguity: allAmbiguity.IsChecked.Value,
-                deconvolutionMaxAssumedChargeState: int.Parse(DeconvolutionMaxAssumedChargeStateTextBox.Text, CultureInfo.InvariantCulture),
-                totalPartitions: int.Parse(numberOfDatabaseSearchesTextBox.Text, CultureInfo.InvariantCulture),
-                doPrecursorDeconvolution: deconvolutePrecursors.IsChecked.Value,
-                useProvidedPrecursorInfo: useProvidedPrecursor.IsChecked.Value,
-                scoreCutoff: double.Parse(minScoreAllowed.Text, CultureInfo.InvariantCulture),
-                calculateEValue: eValueCheckBox.IsChecked.Value,
-                listOfModsFixed: listOfModsFixed,
-                listOfModsVariable: listOfModsVariable,
-                bIons: bCheckBox.IsChecked.Value,
-                yIons: yCheckBox.IsChecked.Value,
-                cIons: cCheckBox.IsChecked.Value,
-                zDotIons: zdotCheckBox.IsChecked.Value,
-                precursorMassTolerance: PrecursorMassTolerance,
-                productMassTolerance: ProductMassTolerance,
-                digestionParams: digestionParamsToSave,
-                trimMs1Peaks: TrimMs1Peaks,
-                trimMsMsPeaks: TrimMsMsPeaks,
-                topNpeaks: TopNpeaks,
-                minRatio: MinRatio,
-                addCompIons: addCompIonCheckBox.IsChecked.Value);
+            CommonParameters commonParamsToSave = new CommonParameters();
+            commonParamsToSave.UseDeltaScore = deltaScoreCheckBox.IsChecked.Value;
+            commonParamsToSave.ReportAllAmbiguity = allAmbiguity.IsChecked.Value;
+            commonParamsToSave.DeconvolutionMaxAssumedChargeState = int.Parse(DeconvolutionMaxAssumedChargeStateTextBox.Text, CultureInfo.InvariantCulture);
+            commonParamsToSave.TotalPartitions = int.Parse(numberOfDatabaseSearchesTextBox.Text, CultureInfo.InvariantCulture);
+            commonParamsToSave.DoPrecursorDeconvolution = deconvolutePrecursors.IsChecked.Value;
+            commonParamsToSave.UseProvidedPrecursorInfo = useProvidedPrecursor.IsChecked.Value;
+            commonParamsToSave.ScoreCutoff = double.Parse(minScoreAllowed.Text, CultureInfo.InvariantCulture);
+            commonParamsToSave.CalculateEValue = eValueCheckBox.IsChecked.Value;
+            commonParamsToSave.ListOfModsFixed = listOfModsFixed;
+            commonParamsToSave.ListOfModsVariable = listOfModsVariable;
+            commonParamsToSave.BIons = bCheckBox.IsChecked.Value;
+            commonParamsToSave.YIons = yCheckBox.IsChecked.Value;
+            commonParamsToSave.CIons = cCheckBox.IsChecked.Value;
+            commonParamsToSave.ZdotIons = zdotCheckBox.IsChecked.Value;
+            commonParamsToSave.PrecursorMassTolerance = PrecursorMassTolerance;
+            commonParamsToSave.ProductMassTolerance = ProductMassTolerance;
+            commonParamsToSave.DigestionParams = digestionParamsToSave;
+            commonParamsToSave.TrimMs1Peaks = TrimMs1Peaks;
+            commonParamsToSave.TrimMsMsPeaks = TrimMsMsPeaks;
+            commonParamsToSave.TopNpeaks = TopNpeaks;
+            commonParamsToSave.MinRatio = MinRatio;
+            commonParamsToSave.AddCompIons = addCompIonCheckBox.IsChecked.Value;
 
             if (OutputFileNameTextBox.Text != "")
             {
-                CommonParamsToSave.TaskDescriptor = OutputFileNameTextBox.Text;
+                commonParamsToSave.TaskDescriptor = OutputFileNameTextBox.Text;
             }
             else
             {
-                CommonParamsToSave.TaskDescriptor = "SearchTask";
+                commonParamsToSave.TaskDescriptor = "SearchTask";
             }
 
             if (classicSearchRadioButton.IsChecked.Value)
@@ -462,7 +459,7 @@ namespace MetaMorpheusGUI
 
             if (!maxThreadsTextBox.Text.Equals("") && (int.Parse(maxThreadsTextBox.Text) <= Environment.ProcessorCount && int.Parse(maxThreadsTextBox.Text) > 0))
             {
-                CommonParamsToSave.MaxThreadsToUsePerFile = int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture);
+                commonParamsToSave.MaxThreadsToUsePerFile = int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture);
             }
             if (massDiffAcceptExact.IsChecked.HasValue && massDiffAcceptExact.IsChecked.Value)
             {
@@ -501,7 +498,7 @@ namespace MetaMorpheusGUI
 
             SetModSelectionForPrunedDB();
 
-            TheTask.CommonParameters = CommonParamsToSave;
+            TheTask.CommonParameters = commonParamsToSave;
 
             DialogResult = true;
         }

--- a/GUI/XLSearchTaskWindow.xaml.cs
+++ b/GUI/XLSearchTaskWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using EngineLayer;
 using EngineLayer.CrosslinkSearch;
 using MzLibUtil;
+using Proteomics.ProteolyticDigestion;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -11,7 +12,6 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using TaskLayer;
 using UsefulProteomicsDatabases;
-using Proteomics.ProteolyticDigestion;
 
 namespace MetaMorpheusGUI
 {
@@ -68,7 +68,7 @@ namespace MetaMorpheusGUI
         {
             e.Handled = !GlobalGuiSettings.CheckIsNumber(e.Text);
         }
-        
+
         private void Row_DoubleClick(object sender, MouseButtonEventArgs e)
         {
             var ye = sender as DataGridCell;
@@ -306,10 +306,10 @@ namespace MetaMorpheusGUI
             InitiatorMethionineBehavior InitiatorMethionineBehavior = ((InitiatorMethionineBehavior)initiatorMethionineBehaviorComboBox.SelectedIndex);
             DigestionParams digestionParamsToSave = new DigestionParams(
                 protease: protease.Name,
-                maxMissedCleavages: MaxMissedCleavages, 
-                minPeptideLength: MinPeptideLength, 
-                maxPeptideLength: MaxPeptideLength, 
-                maxModificationIsoforms: MaxModificationIsoforms, 
+                maxMissedCleavages: MaxMissedCleavages,
+                minPeptideLength: MinPeptideLength,
+                maxPeptideLength: MaxPeptideLength,
+                maxModificationIsoforms: MaxModificationIsoforms,
                 initiatorMethionineBehavior: InitiatorMethionineBehavior);
 
             Tolerance ProductMassTolerance;
@@ -340,32 +340,33 @@ namespace MetaMorpheusGUI
                 listOfModsFixed.AddRange(heh.Children.Where(b => b.Use).Select(b => (b.Parent.DisplayName, b.DisplayName)));
             }
 
-            CommonParameters CommonParamsToSave = new CommonParameters(
-                productMassTolerance: ProductMassTolerance,
-                doPrecursorDeconvolution: deconvolutePrecursors.IsChecked.Value,
-                useProvidedPrecursorInfo: useProvidedPrecursor.IsChecked.Value,
-                digestionParams: digestionParamsToSave,
-                trimMs1Peaks: trimMs1.IsChecked.Value,
-                trimMsMsPeaks: trimMsMs.IsChecked.Value,
-                topNpeaks: int.Parse(TopNPeaksTextBox.Text),
-                minRatio: double.Parse(MinRatioTextBox.Text),
-                bIons: bCheckBox.IsChecked.Value,
-                yIons: yCheckBox.IsChecked.Value,
-                cIons: cCheckBox.IsChecked.Value,
-                zDotIons: zdotCheckBox.IsChecked.Value,
-                scoreCutoff: double.Parse(minScoreAllowed.Text, CultureInfo.InvariantCulture),
-                totalPartitions: int.Parse(numberOfDatabaseSearchesTextBox.Text, CultureInfo.InvariantCulture),
-                listOfModsVariable: listOfModsVariable,
-                listOfModsFixed: listOfModsFixed);
+            CommonParameters commonParamsToSave = new CommonParameters();
+            commonParamsToSave.ProductMassTolerance = ProductMassTolerance;
+            commonParamsToSave.DoPrecursorDeconvolution = deconvolutePrecursors.IsChecked.Value;
+            commonParamsToSave.UseProvidedPrecursorInfo = useProvidedPrecursor.IsChecked.Value;
+            commonParamsToSave.DigestionParams = digestionParamsToSave;
+            commonParamsToSave.TrimMs1Peaks = trimMs1.IsChecked.Value;
+            commonParamsToSave.TrimMsMsPeaks = trimMsMs.IsChecked.Value;
+            commonParamsToSave.TopNpeaks = int.Parse(TopNPeaksTextBox.Text);
+            commonParamsToSave.MinRatio = double.Parse(MinRatioTextBox.Text);
+            commonParamsToSave.BIons = bCheckBox.IsChecked.Value;
+            commonParamsToSave.YIons = yCheckBox.IsChecked.Value;
+            commonParamsToSave.CIons = cCheckBox.IsChecked.Value;
+            commonParamsToSave.ZdotIons = zdotCheckBox.IsChecked.Value;
+            commonParamsToSave.ScoreCutoff = double.Parse(minScoreAllowed.Text, CultureInfo.InvariantCulture);
+            commonParamsToSave.TotalPartitions = int.Parse(numberOfDatabaseSearchesTextBox.Text, CultureInfo.InvariantCulture);
+            commonParamsToSave.ListOfModsVariable = listOfModsVariable;
+            commonParamsToSave.ListOfModsFixed = listOfModsFixed;
+
             if (OutputFileNameTextBox.Text != "")
             {
-                CommonParamsToSave.TaskDescriptor = OutputFileNameTextBox.Text;
+                commonParamsToSave.TaskDescriptor = OutputFileNameTextBox.Text;
             }
             else
             {
-                CommonParamsToSave.TaskDescriptor = "XLSearchTask";
+                commonParamsToSave.TaskDescriptor = "XLSearchTask";
             }
-            TheTask.CommonParameters = CommonParamsToSave;
+            TheTask.CommonParameters = commonParamsToSave;
 
             DialogResult = true;
         }

--- a/TaskLayer/CalibrationTask/CalibrationTask.cs
+++ b/TaskLayer/CalibrationTask/CalibrationTask.cs
@@ -21,12 +21,12 @@ namespace TaskLayer
     {
         public CalibrationTask() : base(MyTask.Calibrate)
         {
-            CommonParameters = new CommonParameters(
-                productMassTolerance: new PpmTolerance(25),
-                precursorMassTolerance: new PpmTolerance(15),
-                trimMsMsPeaks: false,
-                doPrecursorDeconvolution: false,
-                scoreCutoff: 10);
+            CommonParameters = new CommonParameters();
+            CommonParameters.ProductMassTolerance = new PpmTolerance(25);
+            CommonParameters.PrecursorMassTolerance = new PpmTolerance(15);
+            CommonParameters.TrimMsMsPeaks = false;
+            CommonParameters.DoPrecursorDeconvolution = false;
+            CommonParameters.ScoreCutoff = 10;
 
             CalibrationParameters = new CalibrationParameters();
         }
@@ -123,18 +123,18 @@ namespace TaskLayer
 
                     if (i == 1) // failed round 1
                     {
-                        this.CommonParameters.SetPrecursorMassTolerance(new PpmTolerance(20));
-                        this.CommonParameters.SetProductMassTolerance(new PpmTolerance(50));
+                        CommonParameters.PrecursorMassTolerance = new PpmTolerance(20);
+                        CommonParameters.ProductMassTolerance = new PpmTolerance(50);
                     }
                     else if (i == 2) // failed round 2
                     {
-                        this.CommonParameters.SetPrecursorMassTolerance(new PpmTolerance(30));
-                        this.CommonParameters.SetProductMassTolerance(new PpmTolerance(100));
+                        CommonParameters.PrecursorMassTolerance = new PpmTolerance(30);
+                        CommonParameters.ProductMassTolerance = new PpmTolerance(100);
                     }
                     else if (i == 3) // failed round 3
                     {
-                        this.CommonParameters.SetPrecursorMassTolerance(new PpmTolerance(40));
-                        this.CommonParameters.SetProductMassTolerance(new PpmTolerance(150));
+                        CommonParameters.PrecursorMassTolerance = new PpmTolerance(40);
+                        CommonParameters.ProductMassTolerance = new PpmTolerance(150);
                     }
                     else // failed round 4
                     {

--- a/TaskLayer/MetaMorpheusTask.cs
+++ b/TaskLayer/MetaMorpheusTask.cs
@@ -174,15 +174,14 @@ namespace TaskLayer
             bool cIons = fileSpecificParams.CIons ?? commonParams.CIons;
             bool zdotIons = fileSpecificParams.ZdotIons ?? commonParams.ZdotIons;
 
-            CommonParameters returnParams = new CommonParameters(
-                bIons: bIons,
-                yIons: yIons,
-                cIons: cIons,
-                zDotIons: zdotIons,
-                precursorMassTolerance: precursorMassTolerance,
-                productMassTolerance: productMassTolerance,
-                digestionParams: fileSpecificDigestionParams);
-
+            CommonParameters returnParams = new CommonParameters();
+            returnParams.BIons = bIons;
+            returnParams.YIons = yIons;
+            returnParams.CIons = cIons;
+            returnParams.ZdotIons = zdotIons;
+            returnParams.PrecursorMassTolerance = precursorMassTolerance;
+            returnParams.ProductMassTolerance = productMassTolerance;
+            returnParams.DigestionParams = fileSpecificDigestionParams;
             return returnParams;
         }
 

--- a/TaskLayer/NeoSearchTask/NeoSearchTask.cs
+++ b/TaskLayer/NeoSearchTask/NeoSearchTask.cs
@@ -21,11 +21,11 @@ namespace TaskLayer
             NeoParameters = new NeoParameters();
             var tempDigParams = new DigestionParams(protease: "non-specific", maxMissedCleavages: 12, minPeptideLength: 8, maxPeptideLength: 13);
 
-            CommonParameters = new CommonParameters(
-                digestionParams: tempDigParams,
-                doPrecursorDeconvolution: false,
-                precursorMassTolerance: new PpmTolerance(double.MaxValue),
-                productMassTolerance: new PpmTolerance(double.MaxValue));
+            CommonParameters = new CommonParameters();
+            CommonParameters.DigestionParams = tempDigParams;
+            CommonParameters.DoPrecursorDeconvolution = false;
+            CommonParameters.PrecursorMassTolerance = new PpmTolerance(double.MaxValue);
+            CommonParameters.ProductMassTolerance = new PpmTolerance(double.MaxValue);
         }
 
         public enum NeoTaskType { AggregateTargetDecoyFiles, GenerateSplicedPeptides, AggregateNormalSplicedFiles, SearchTransDb };

--- a/Test/AddCompIonsTest.cs
+++ b/Test/AddCompIonsTest.cs
@@ -41,19 +41,21 @@ namespace Test
             Protease protease = new Protease("Custom Protease3", new List<Tuple<string, TerminusType>> { new Tuple<string, TerminusType>("K", TerminusType.C) }, new List<Tuple<string, TerminusType>>(), CleavageSpecificity.Full, null, null, null);
             ProteaseDictionary.Dictionary.Add(protease.Name, protease);
 
-            CommonParameters CommonParameters = new CommonParameters(
-                digestionParams: new DigestionParams(protease: protease.Name, maxMissedCleavages: 0, minPeptideLength: 1),
-                scoreCutoff: 1,
-                addCompIons: false);
-            PeptideSpectralMatch[] allPsmsArray = new PeptideSpectralMatch[listOfSortedms2Scans.Length];
-            new ClassicSearchEngine(allPsmsArray, listOfSortedms2Scans, variableModifications, fixedModifications, proteinList, new List<ProductType> { ProductType.B, ProductType.Y }, searchModes, CommonParameters, new List<string>()).Run();
+            CommonParameters commonParameters = new CommonParameters();
+            commonParameters.DigestionParams = new DigestionParams(protease: protease.Name, maxMissedCleavages: 0, minPeptideLength: 1);
+            commonParameters.ScoreCutoff = 1;
+            commonParameters.AddCompIons = false;
 
-            CommonParameters CommonParameters2 = new CommonParameters(
-                digestionParams: new DigestionParams(protease: protease.Name, maxMissedCleavages: 0, minPeptideLength: 1),
-                scoreCutoff: 1,
-                addCompIons: true);
+            PeptideSpectralMatch[] allPsmsArray = new PeptideSpectralMatch[listOfSortedms2Scans.Length];
+            new ClassicSearchEngine(allPsmsArray, listOfSortedms2Scans, variableModifications, fixedModifications, proteinList, new List<ProductType> { ProductType.B, ProductType.Y }, searchModes, commonParameters, new List<string>()).Run();
+
+            CommonParameters commonParameters2 = new CommonParameters();
+            commonParameters2.DigestionParams = new DigestionParams(protease: protease.Name, maxMissedCleavages: 0, minPeptideLength: 1);
+            commonParameters2.ScoreCutoff = 1;
+            commonParameters2.AddCompIons = true;
+
             PeptideSpectralMatch[] allPsmsArray2 = new PeptideSpectralMatch[listOfSortedms2Scans.Length];
-            new ClassicSearchEngine(allPsmsArray2, listOfSortedms2Scans, variableModifications, fixedModifications, proteinList, new List<ProductType> { ProductType.B, ProductType.Y }, searchModes, CommonParameters2, new List<string>()).Run();
+            new ClassicSearchEngine(allPsmsArray2, listOfSortedms2Scans, variableModifications, fixedModifications, proteinList, new List<ProductType> { ProductType.B, ProductType.Y }, searchModes, commonParameters2, new List<string>()).Run();
 
             double scoreT = allPsmsArray2[0].Score;
             double scoreF = allPsmsArray[0].Score;
@@ -102,11 +104,17 @@ namespace Test
             };
             Protease protease = new Protease("singleN4", new List<Tuple<string, TerminusType>> { new Tuple<string, TerminusType>("K", TerminusType.C) }, new List<Tuple<string, TerminusType>>(), CleavageSpecificity.Full, null, null, null);
             ProteaseDictionary.Dictionary.Add(protease.Name, protease);
-            CommonParameters CommonParameters = new CommonParameters(digestionParams: new DigestionParams(protease: protease.Name, minPeptideLength: 1), scoreCutoff: 1);
-            CommonParameters withCompIons = new CommonParameters(digestionParams: new DigestionParams(protease: protease.Name, minPeptideLength: 1), scoreCutoff: 1, addCompIons: true);
+            CommonParameters commonParameters = new CommonParameters();
+            commonParameters.DigestionParams = new DigestionParams(protease: protease.Name, minPeptideLength: 1);
+            commonParameters.ScoreCutoff = 1;
+
+            CommonParameters withCompIons = new CommonParameters();
+            withCompIons.DigestionParams = new DigestionParams(protease: protease.Name, minPeptideLength: 1);
+            withCompIons.ScoreCutoff = 1;
+            withCompIons.AddCompIons = true;
 
             var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications,
-                new List<ProductType> { ProductType.B, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters, SearchParameters.MaxFragmentSize, new List<string>());
+                new List<ProductType> { ProductType.B, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { commonParameters.DigestionParams }, commonParameters, SearchParameters.MaxFragmentSize, new List<string>());
 
             var indexResults = (IndexingResults)indexEngine.Run();
 
@@ -118,11 +126,11 @@ namespace Test
 
             var listOfSortedms2Scans = MetaMorpheusTask.GetMs2Scans(myMsDataFile, null, DoPrecursorDeconvolution, UseProvidedPrecursorInfo, DeconvolutionIntensityRatio, DeconvolutionMaxAssumedChargeState, DeconvolutionMassTolerance).OrderBy(b => b.PrecursorMass).ToArray();
 
-            MassDiffAcceptor massDiffAcceptor = SearchTask.GetMassDiffAcceptor(CommonParameters.PrecursorMassTolerance, SearchParameters.MassDiffAcceptorType, SearchParameters.CustomMdac);
+            MassDiffAcceptor massDiffAcceptor = SearchTask.GetMassDiffAcceptor(commonParameters.PrecursorMassTolerance, SearchParameters.MassDiffAcceptorType, SearchParameters.CustomMdac);
 
             // without complementary ions
             PeptideSpectralMatch[] allPsmsArray = new PeptideSpectralMatch[listOfSortedms2Scans.Length];
-            new ModernSearchEngine(allPsmsArray, listOfSortedms2Scans, indexResults.PeptideIndex, indexResults.FragmentIndex, new List<ProductType> { ProductType.B, ProductType.Y }, 0, CommonParameters, massDiffAcceptor, SearchParameters.MaximumMassThatFragmentIonScoreIsDoubled, new List<string>()).Run();
+            new ModernSearchEngine(allPsmsArray, listOfSortedms2Scans, indexResults.PeptideIndex, indexResults.FragmentIndex, new List<ProductType> { ProductType.B, ProductType.Y }, 0, commonParameters, massDiffAcceptor, SearchParameters.MaximumMassThatFragmentIonScoreIsDoubled, new List<string>()).Run();
 
             // with complementary ions
             PeptideSpectralMatch[] allPsmsArray2 = new PeptideSpectralMatch[listOfSortedms2Scans.Length];

--- a/Test/AmbiguityTest.cs
+++ b/Test/AmbiguityTest.cs
@@ -20,12 +20,12 @@ namespace Test
         {
             Protease protease = new Protease("Custom Protease4", new List<Tuple<string, TerminusType>> { new Tuple<string, TerminusType>("K", TerminusType.C) }, new List<Tuple<string, TerminusType>>(), CleavageSpecificity.Full, null, null, null);
             ProteaseDictionary.Dictionary.Add(protease.Name, protease);
-            CommonParameters CommonParameters = new CommonParameters(
-                digestionParams: new DigestionParams(
-                    protease: protease.Name,
-                    minPeptideLength: 1),
-                scoreCutoff: 1,
-                reportAllAmbiguity: false);
+            CommonParameters commonParameters = new CommonParameters();
+            commonParameters.DigestionParams = new DigestionParams(
+                protease: protease.Name,
+                minPeptideLength: 1);
+            commonParameters.ScoreCutoff = 1;
+            commonParameters.ReportAllAmbiguity = false;
 
             var myMsDataFile = new TestDataFile();
             var variableModifications = new List<ModificationWithMass>();
@@ -44,15 +44,15 @@ namespace Test
 
             PeptideSpectralMatch[] allPsmsArrayt = new PeptideSpectralMatch[listOfSortedms2Scans.Length];
             PeptideSpectralMatch[] allPsmsArrayf = new PeptideSpectralMatch[listOfSortedms2Scans.Length];
-            new ClassicSearchEngine(allPsmsArrayt, listOfSortedms2Scans, variableModifications, fixedModifications, proteinList, new List<ProductType> { ProductType.B, ProductType.Y }, searchModes, CommonParameters, new List<string>()).Run();
-            new ClassicSearchEngine(allPsmsArrayf, listOfSortedms2Scans, variableModifications, fixedModifications, proteinList, new List<ProductType> { ProductType.B, ProductType.Y }, searchModes, CommonParameters, new List<string>()).Run();
+            new ClassicSearchEngine(allPsmsArrayt, listOfSortedms2Scans, variableModifications, fixedModifications, proteinList, new List<ProductType> { ProductType.B, ProductType.Y }, searchModes, commonParameters, new List<string>()).Run();
+            new ClassicSearchEngine(allPsmsArrayf, listOfSortedms2Scans, variableModifications, fixedModifications, proteinList, new List<ProductType> { ProductType.B, ProductType.Y }, searchModes, commonParameters, new List<string>()).Run();
 
             var haht = (SequencesToActualProteinPeptidesEngineResults)new SequencesToActualProteinPeptidesEngine(new List<PeptideSpectralMatch>
             { allPsmsArrayt[0] }, proteinList, fixedModifications, variableModifications, new List<ProductType>
-            { ProductType.B, ProductType.Y }, new List<DigestionParams> { CommonParameters.DigestionParams }, true, CommonParameters, new List<string>()).Run();
+            { ProductType.B, ProductType.Y }, new List<DigestionParams> { commonParameters.DigestionParams }, true, commonParameters, new List<string>()).Run();
             var hahf = (SequencesToActualProteinPeptidesEngineResults)new SequencesToActualProteinPeptidesEngine(new List<PeptideSpectralMatch>
             { allPsmsArrayf[0] }, proteinList, fixedModifications, variableModifications, new List<ProductType>
-            { ProductType.B, ProductType.Y }, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters.ReportAllAmbiguity, CommonParameters, new List<string>()).Run();
+            { ProductType.B, ProductType.Y }, new List<DigestionParams> { commonParameters.DigestionParams }, commonParameters.ReportAllAmbiguity, commonParameters, new List<string>()).Run();
 
             foreach (var huh in allPsmsArrayt)
             {

--- a/Test/AnalysisEngineTest.cs
+++ b/Test/AnalysisEngineTest.cs
@@ -21,14 +21,14 @@ namespace Test
         {
             Protease protease = new Protease("Custom Protease5", new List<Tuple<string, TerminusType>> { new Tuple<string, TerminusType>("K", TerminusType.C) }, new List<Tuple<string, TerminusType>>(), CleavageSpecificity.Full, null, null, null);
             ProteaseDictionary.Dictionary.Add(protease.Name, protease);
-            CommonParameters CommonParameters = new CommonParameters(
-                digestionParams: new DigestionParams(
-                    protease: protease.Name,
-                    maxMissedCleavages: 0,
-                    minPeptideLength: 1,
-                    maxModificationIsoforms: 1042),
-                scoreCutoff: 1,
-                productMassTolerance: new PpmTolerance(10));
+            CommonParameters commonParams = new CommonParameters();
+            commonParams.DigestionParams = new DigestionParams(
+                protease: protease.Name,
+                maxMissedCleavages: 0,
+                minPeptideLength: 1,
+                maxModificationIsoforms: 1042);
+            commonParams.ScoreCutoff = 1;
+            commonParams.ProductMassTolerance = new PpmTolerance(10);
 
             List<ModificationWithMass> localizeableModifications = new List<ModificationWithMass>();
             List<ModificationWithMass> variableModifications = new List<ModificationWithMass>();
@@ -50,18 +50,18 @@ namespace Test
             }
 
             var proteinList = new List<Protein> { new Protein("MNNNKQQQ", "accession") };
-            var modPep = proteinList.First().Digest(CommonParameters.DigestionParams, fixedModifications, variableModifications).Last();
+            var modPep = proteinList.First().Digest(commonParams.DigestionParams, fixedModifications, variableModifications).Last();
             HashSet<PeptideWithSetModifications> value1 = new HashSet<PeptideWithSetModifications> { modPep };
             CompactPeptide compactPeptide1 = new CompactPeptide(value1.First(), TerminusType.None);
 
             Assert.AreEqual("QQQ", value1.First().BaseSequence);
-            var modPep2 = proteinList.First().Digest(CommonParameters.DigestionParams, fixedModifications, variableModifications).First();
+            var modPep2 = proteinList.First().Digest(commonParams.DigestionParams, fixedModifications, variableModifications).First();
             HashSet<PeptideWithSetModifications> value2 = new HashSet<PeptideWithSetModifications> { modPep2 };
             CompactPeptide compactPeptide2 = new CompactPeptide(value2.First(), TerminusType.None);
 
             Assert.AreEqual("MNNNK", value2.First().BaseSequence);
 
-            var modPep3 = proteinList.First().Digest(CommonParameters.DigestionParams, fixedModifications, variableModifications).ToList()[1];
+            var modPep3 = proteinList.First().Digest(commonParams.DigestionParams, fixedModifications, variableModifications).ToList()[1];
             HashSet<PeptideWithSetModifications> value3 = new HashSet<PeptideWithSetModifications> { modPep3 };
             CompactPeptide compactPeptide3 = new CompactPeptide(value3.First(), TerminusType.None);
             Assert.AreEqual("NNNK", value3.First().BaseSequence);
@@ -74,9 +74,9 @@ namespace Test
             Ms2ScanWithSpecificMass scanB = new Ms2ScanWithSpecificMass(new MsDataScan(new MzSpectrum(new double[] { 1 }, new double[] { 1 }, false), 3, 1, true, Polarity.Positive, double.NaN, null, null, MZAnalyzerType.Orbitrap, double.NaN, null, null, "scan=2", double.NaN, null, null, double.NaN, null, DissociationType.AnyActivationType, 1, null), 2 + 132.040, 1, null);
             Ms2ScanWithSpecificMass scanC = new Ms2ScanWithSpecificMass(new MsDataScan(new MzSpectrum(new double[] { 1 }, new double[] { 1 }, false), 4, 1, true, Polarity.Positive, double.NaN, null, null, MZAnalyzerType.Orbitrap, double.NaN, null, null, "scan=3", double.NaN, null, null, double.NaN, null, DissociationType.AnyActivationType, 1, null), 3, 1, null);
 
-            PeptideSpectralMatch matchA = new PeptideSpectralMatch(compactPeptide1, 0, 0, 0, scanA, CommonParameters.DigestionParams);
-            PeptideSpectralMatch matchB = new PeptideSpectralMatch(compactPeptide2, 0, 0, 0, scanB, CommonParameters.DigestionParams);
-            PeptideSpectralMatch matchC = new PeptideSpectralMatch(compactPeptide3, 0, 0, 0, scanC, CommonParameters.DigestionParams);
+            PeptideSpectralMatch matchA = new PeptideSpectralMatch(compactPeptide1, 0, 0, 0, scanA, commonParams.DigestionParams);
+            PeptideSpectralMatch matchB = new PeptideSpectralMatch(compactPeptide2, 0, 0, 0, scanB, commonParams.DigestionParams);
+            PeptideSpectralMatch matchC = new PeptideSpectralMatch(compactPeptide3, 0, 0, 0, scanC, commonParams.DigestionParams);
 
             var newPsms = new List<PeptideSpectralMatch> { matchA, matchB, matchC };
 
@@ -98,7 +98,7 @@ namespace Test
                 Assert.AreEqual(1, l.FinalBins.Count);
             };
 
-            SequencesToActualProteinPeptidesEngine sequencesToActualProteinPeptidesEngine = new SequencesToActualProteinPeptidesEngine(newPsms, proteinList, fixedModifications, variableModifications, new List<ProductType> { ProductType.B, ProductType.Y }, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters.ReportAllAmbiguity, CommonParameters, new List<string>());
+            SequencesToActualProteinPeptidesEngine sequencesToActualProteinPeptidesEngine = new SequencesToActualProteinPeptidesEngine(newPsms, proteinList, fixedModifications, variableModifications, new List<ProductType> { ProductType.B, ProductType.Y }, new List<DigestionParams> { commonParams.DigestionParams }, commonParams.ReportAllAmbiguity, commonParams, new List<string>());
 
             var res = (SequencesToActualProteinPeptidesEngineResults)sequencesToActualProteinPeptidesEngine.Run();
 
@@ -106,7 +106,7 @@ namespace Test
                 if (huh != null)
                     huh.MatchToProteinLinkedPeptides(res.CompactPeptideToProteinPeptideMatching);
 
-            FdrAnalysisEngine engine = new FdrAnalysisEngine(newPsms, searchMode.NumNotches, CommonParameters, new List<string> { "ff" });
+            FdrAnalysisEngine engine = new FdrAnalysisEngine(newPsms, searchMode.NumNotches, commonParams, new List<string> { "ff" });
 
             engine.Run();
         }

--- a/Test/BinGenerationTest.cs
+++ b/Test/BinGenerationTest.cs
@@ -18,10 +18,12 @@ namespace Test
         [Test]
         public static void TestBinGeneration()
         {
+            CommonParameters c = new CommonParameters();
+            c.ScoreCutoff = 1;
+            c.DigestionParams = new DigestionParams(minPeptideLength: 5, initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
             SearchTask st = new SearchTask
             {
-                CommonParameters = new CommonParameters(scoreCutoff: 1, digestionParams: new DigestionParams(minPeptideLength: 5, initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain)),
-
+                CommonParameters = c,
                 SearchParameters = new SearchParameters
                 {
                     DoHistogramAnalysis = true,
@@ -74,15 +76,15 @@ namespace Test
         [Test]
         public static void TestProteinSplitAcrossFiles()
         {
-            SearchTask st = new SearchTask()
+            CommonParameters c = new CommonParameters();
+            c.ScoreCutoff = 1;
+            c.DigestionParams = new DigestionParams(
+                maxMissedCleavages: 0,
+                minPeptideLength: 5,
+                initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
+            SearchTask st = new SearchTask
             {
-                CommonParameters = new CommonParameters(
-                    scoreCutoff: 1,
-                    digestionParams: new DigestionParams(
-                        maxMissedCleavages: 0,
-                        minPeptideLength: 5,
-                        initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain)),
-
+                CommonParameters = c,
                 SearchParameters = new SearchParameters
                 {
                     DoHistogramAnalysis = true,

--- a/Test/CoIsolationTests.cs
+++ b/Test/CoIsolationTests.cs
@@ -21,7 +21,10 @@ namespace Test
         {
             Protease protease = new Protease("CustProtease", new List<Tuple<string, TerminusType>> { new Tuple<string, TerminusType>("K", TerminusType.C) }, new List<Tuple<string, TerminusType>>(), CleavageSpecificity.Full, null, null, null);
             ProteaseDictionary.Dictionary.Add(protease.Name, protease);
-            CommonParameters CommonParameters = new CommonParameters(scoreCutoff: 1, deconvolutionIntensityRatio: 50, digestionParams: new DigestionParams(protease.Name, minPeptideLength: 1));
+            CommonParameters commonParameters = new CommonParameters();
+            commonParameters.ScoreCutoff = 1;
+            commonParameters.DeconvolutionIntensityRatio = 50;
+            commonParameters.DigestionParams = new DigestionParams(protease.Name, minPeptideLength: 1);
 
             var variableModifications = new List<ModificationWithMass>();
             var fixedModifications = new List<ModificationWithMass>();
@@ -65,7 +68,7 @@ namespace Test
             PeptideSpectralMatch[] allPsmsArray = new PeptideSpectralMatch[listOfSortedms2Scans.Length];
 
             List<ProductType> lp = new List<ProductType> { ProductType.B, ProductType.Y };
-            new ClassicSearchEngine(allPsmsArray, listOfSortedms2Scans, variableModifications, fixedModifications, proteinList, lp, searchModes, CommonParameters, new List<string>()).Run();
+            new ClassicSearchEngine(allPsmsArray, listOfSortedms2Scans, variableModifications, fixedModifications, proteinList, lp, searchModes, commonParameters, new List<string>()).Run();
 
             // Two matches for this single scan! Corresponding to two co-isolated masses
             Assert.AreEqual(2, allPsmsArray.Length);
@@ -74,7 +77,7 @@ namespace Test
             Assert.AreEqual(2, allPsmsArray[0].ScanNumber);
 
             var ojdfkj = (SequencesToActualProteinPeptidesEngineResults)new SequencesToActualProteinPeptidesEngine(new List<PeptideSpectralMatch>
-            { allPsmsArray[0], allPsmsArray[1] }, proteinList, fixedModifications, variableModifications, lp, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters.ReportAllAmbiguity, CommonParameters, new List<string>()).Run();
+            { allPsmsArray[0], allPsmsArray[1] }, proteinList, fixedModifications, variableModifications, lp, new List<DigestionParams> { commonParameters.DigestionParams }, commonParameters.ReportAllAmbiguity, commonParameters, new List<string>()).Run();
 
             foreach (var huh in allPsmsArray)
             {

--- a/Test/IndexEngineTest.cs
+++ b/Test/IndexEngineTest.cs
@@ -39,16 +39,18 @@ namespace Test
 
             Protease p = new Protease("Custom Protease2", new List<Tuple<string, TerminusType>> { new Tuple<string, TerminusType>("K", TerminusType.C) }, new List<Tuple<string, TerminusType>>(), CleavageSpecificity.Full, null, null, null);
             ProteaseDictionary.Dictionary.Add(p.Name, p);
-            CommonParameters CommonParameters = new CommonParameters(scoreCutoff: 1, digestionParams: new DigestionParams(protease: p.Name, minPeptideLength: 1));
+            CommonParameters commonParams = new CommonParameters();
+            commonParams.ScoreCutoff = 1;
+            commonParams.DigestionParams = new DigestionParams(protease: p.Name, minPeptideLength: 1);
 
             var engine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType>
-            { ProductType.B, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters, 30000, new List<string>());
+            { ProductType.B, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { commonParams.DigestionParams }, commonParams, 30000, new List<string>());
 
             var results = (IndexingResults)engine.Run();
 
             Assert.AreEqual(5, results.PeptideIndex.Count);
 
-            var digestedList = proteinList[0].Digest(CommonParameters.DigestionParams, new List<ModificationWithMass>(), variableModifications).ToList();
+            var digestedList = proteinList[0].Digest(commonParams.DigestionParams, new List<ModificationWithMass>(), variableModifications).ToList();
 
             Assert.AreEqual(5, digestedList.Count);
             foreach (var fdfd in digestedList)
@@ -84,14 +86,14 @@ namespace Test
 
             Protease protease = new Protease("Custom Protease", new List<Tuple<string, TerminusType>> { new Tuple<string, TerminusType>("K", TerminusType.C) }, new List<Tuple<string, TerminusType>>(), CleavageSpecificity.Full, null, null, null);
             ProteaseDictionary.Dictionary.Add(protease.Name, protease);
-            CommonParameters CommonParameters = new CommonParameters(
-                digestionParams: new DigestionParams(
+            CommonParameters commonParameters = new CommonParameters();
+            commonParameters.DigestionParams = new DigestionParams(
                     protease: protease.Name,
                     minPeptideLength: 1,
-                    initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain),
-                scoreCutoff: 1);
+                    initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
+            commonParameters.ScoreCutoff = 1;
 
-            var engine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.B, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters, 30000, new List<string>());
+            var engine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.B, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { commonParameters.DigestionParams }, commonParameters, 30000, new List<string>());
 
             var results = (IndexingResults)engine.Run();
 

--- a/Test/LocalizationTest.cs
+++ b/Test/LocalizationTest.cs
@@ -54,7 +54,9 @@ namespace Test
 
             newPsm.MatchToProteinLinkedPeptides(matching);
 
-            CommonParameters commonParameters = new CommonParameters(productMassTolerance: fragmentTolerance);
+            CommonParameters commonParameters = new CommonParameters();
+            commonParameters.ProductMassTolerance = fragmentTolerance;
+
             LocalizationEngine f = new LocalizationEngine(new List<PeptideSpectralMatch> { newPsm }, lp, myMsDataFile, commonParameters, new List<string>());
             f.Run();
 

--- a/Test/ModificationAnalysisTest.cs
+++ b/Test/ModificationAnalysisTest.cs
@@ -61,20 +61,20 @@ namespace Test
             PeptideWithSetModifications pwsm4 = new PeptideWithSetModifications(0, protein1, 1, 9, allModsOneIsNterminus4);
             CompactPeptideBase pep4 = new CompactPeptide(pwsm4, TerminusType.None);
 
-            CommonParameters CommonParameters = new CommonParameters(
-                digestionParams: new DigestionParams(
+            CommonParameters commonParameters = new CommonParameters();
+            commonParameters.DigestionParams = new DigestionParams(
                     maxMissedCleavages: 0,
                     minPeptideLength: 1,
-                    maxModificationIsoforms: int.MaxValue),
-                scoreCutoff: 1);
+                    maxModificationIsoforms: int.MaxValue);
+            commonParameters.ScoreCutoff = 1;
 
             var newPsms = new List<PeptideSpectralMatch>
             {
-                new PeptideSpectralMatch(pep1, 0,10,0,scan,CommonParameters.DigestionParams),
-                new PeptideSpectralMatch(pep1, 0,10,0,scan, CommonParameters.DigestionParams),
-                new PeptideSpectralMatch(pep2, 0,10,0,scan, CommonParameters.DigestionParams),
-                new PeptideSpectralMatch(pep3, 0,10,0,scan, CommonParameters.DigestionParams),
-                new PeptideSpectralMatch(pep4, 0,10,0,scan,CommonParameters.DigestionParams),
+                new PeptideSpectralMatch(pep1, 0,10,0,scan,commonParameters.DigestionParams),
+                new PeptideSpectralMatch(pep1, 0,10,0,scan, commonParameters.DigestionParams),
+                new PeptideSpectralMatch(pep2, 0,10,0,scan, commonParameters.DigestionParams),
+                new PeptideSpectralMatch(pep3, 0,10,0,scan, commonParameters.DigestionParams),
+                new PeptideSpectralMatch(pep4, 0,10,0,scan,commonParameters.DigestionParams),
             };
 
             MassDiffAcceptor searchMode = new SinglePpmAroundZeroSearchMode(5);
@@ -82,13 +82,13 @@ namespace Test
 
             SequencesToActualProteinPeptidesEngine sequencesToActualProteinPeptidesEngine = new SequencesToActualProteinPeptidesEngine
             (newPsms, proteinList, new List<ModificationWithMass>(), new List<ModificationWithMass>(), new List<ProductType>
-            { ProductType.B, ProductType.Y }, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters.ReportAllAmbiguity, CommonParameters, new List<string>());
+            { ProductType.B, ProductType.Y }, new List<DigestionParams> { commonParameters.DigestionParams }, commonParameters.ReportAllAmbiguity, commonParameters, new List<string>());
             var nice = (SequencesToActualProteinPeptidesEngineResults)sequencesToActualProteinPeptidesEngine.Run();
             foreach (var psm in newPsms)
             {
                 psm.MatchToProteinLinkedPeptides(nice.CompactPeptideToProteinPeptideMatching);
             }
-            FdrAnalysisEngine fdrAnalysisEngine = new FdrAnalysisEngine(newPsms, searchMode.NumNotches, CommonParameters, new List<string>());
+            FdrAnalysisEngine fdrAnalysisEngine = new FdrAnalysisEngine(newPsms, searchMode.NumNotches, commonParameters, new List<string>());
             fdrAnalysisEngine.Run();
             ModificationAnalysisEngine modificationAnalysisEngine = new ModificationAnalysisEngine(newPsms, new CommonParameters(), new List<string>());
             var res = (ModificationAnalysisResults)modificationAnalysisEngine.Run();
@@ -136,18 +136,20 @@ namespace Test
             PeptideWithSetModifications pwsm3 = new PeptideWithSetModifications(0, protein1, 2, 9, allModsOneIsNterminus3);
             CompactPeptideBase pep3 = new CompactPeptide(pwsm3, TerminusType.None);
 
-            CommonParameters CommonParameters = new CommonParameters(digestionParams: new DigestionParams(maxMissedCleavages: 0, minPeptideLength: 1), scoreCutoff: 1);
+            CommonParameters commonParameters = new CommonParameters();
+            commonParameters.DigestionParams = new DigestionParams(maxMissedCleavages: 0, minPeptideLength: 1);
+            commonParameters.ScoreCutoff = 1;
 
             var newPsms = new List<PeptideSpectralMatch>
             {
-                new PeptideSpectralMatch(pep1, 0,10,0,scan, CommonParameters.DigestionParams),
-                new PeptideSpectralMatch(pep3, 0,10,0,scan, CommonParameters.DigestionParams),
+                new PeptideSpectralMatch(pep1, 0, 10, 0, scan, commonParameters.DigestionParams),
+                new PeptideSpectralMatch(pep3, 0, 10, 0, scan, commonParameters.DigestionParams),
             };
 
             MassDiffAcceptor searchMode = new SinglePpmAroundZeroSearchMode(5);
             List<Protein> proteinList = new List<Protein> { protein1 };
 
-            SequencesToActualProteinPeptidesEngine sequencesToActualProteinPeptidesEngine = new SequencesToActualProteinPeptidesEngine(newPsms, proteinList, new List<ModificationWithMass>(), new List<ModificationWithMass>(), new List<ProductType> { ProductType.B, ProductType.Y }, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters.ReportAllAmbiguity, CommonParameters, new List<string>());
+            SequencesToActualProteinPeptidesEngine sequencesToActualProteinPeptidesEngine = new SequencesToActualProteinPeptidesEngine(newPsms, proteinList, new List<ModificationWithMass>(), new List<ModificationWithMass>(), new List<ProductType> { ProductType.B, ProductType.Y }, new List<DigestionParams> { commonParameters.DigestionParams }, commonParameters.ReportAllAmbiguity, commonParameters, new List<string>());
 
             var nice = (SequencesToActualProteinPeptidesEngineResults)sequencesToActualProteinPeptidesEngine.Run();
             foreach (var psm in newPsms)
@@ -157,7 +159,7 @@ namespace Test
 
             Assert.AreEqual(2, nice.CompactPeptideToProteinPeptideMatching[pep1].Count);
 
-            FdrAnalysisEngine fdrAnalysisEngine = new FdrAnalysisEngine(newPsms, searchMode.NumNotches, CommonParameters, new List<string>());
+            FdrAnalysisEngine fdrAnalysisEngine = new FdrAnalysisEngine(newPsms, searchMode.NumNotches, commonParameters, new List<string>());
             fdrAnalysisEngine.Run();
             ModificationAnalysisEngine modificationAnalysisEngine = new ModificationAnalysisEngine(newPsms, new CommonParameters(), new List<string>());
             var res = (ModificationAnalysisResults)modificationAnalysisEngine.Run();

--- a/Test/MyPeptideTest.cs
+++ b/Test/MyPeptideTest.cs
@@ -37,14 +37,16 @@ namespace Test
 
             PeptideSpectralMatch[] globalPsms = new PeptideSpectralMatch[1];
             Ms2ScanWithSpecificMass[] arrayOfSortedMS2Scans = { new Ms2ScanWithSpecificMass(scan, 0, 0, null) };
-            CommonParameters CommonParameters = new CommonParameters(
-                productMassTolerance: new PpmTolerance(5),
-                scoreCutoff: 1,
-                digestionParams: new DigestionParams(
-                    maxMissedCleavages: 0,
-                    minPeptideLength: 1,
-                    initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain));
-            ClassicSearchEngine cse = new ClassicSearchEngine(globalPsms, arrayOfSortedMS2Scans, new List<ModificationWithMass>(), new List<ModificationWithMass>(), new List<Protein> { prot }, new List<ProductType> { ProductType.B, ProductType.Y }, new OpenSearchMode(), CommonParameters, new List<string>());
+            CommonParameters commonParameters = new CommonParameters();
+
+            commonParameters.ProductMassTolerance = new PpmTolerance(5);
+            commonParameters.ScoreCutoff = 1;
+            commonParameters.DigestionParams = new DigestionParams(
+                maxMissedCleavages: 0,
+                minPeptideLength: 1,
+                initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
+
+            ClassicSearchEngine cse = new ClassicSearchEngine(globalPsms, arrayOfSortedMS2Scans, new List<ModificationWithMass>(), new List<ModificationWithMass>(), new List<Protein> { prot }, new List<ProductType> { ProductType.B, ProductType.Y }, new OpenSearchMode(), commonParameters, new List<string>());
 
             cse.Run();
             Assert.AreEqual(globalPsms[0].MatchedFragmentIons.Count, 3);
@@ -68,15 +70,15 @@ namespace Test
 
             PeptideSpectralMatch[] globalPsms = new PeptideSpectralMatch[1];
             Ms2ScanWithSpecificMass[] arrayOfSortedMS2Scans = { new Ms2ScanWithSpecificMass(scan, 0, 0, null) };
-            CommonParameters CommonParameters = new CommonParameters(
-                scoreCutoff: 1,
-                productMassTolerance: new PpmTolerance(5),
-                digestionParams: new DigestionParams(
-                    maxMissedCleavages: 0,
-                    minPeptideLength: 1,
-                    maxModificationIsoforms: int.MaxValue,
-                    initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain));
-            ClassicSearchEngine cse = new ClassicSearchEngine(globalPsms, arrayOfSortedMS2Scans, new List<ModificationWithMass>(), new List<ModificationWithMass>(), new List<Protein> { prot }, new List<ProductType> { ProductType.B, ProductType.Y }, new OpenSearchMode(), CommonParameters, new List<string>());
+            CommonParameters commonParameters = new CommonParameters();
+            commonParameters.ScoreCutoff = 1;
+            commonParameters.ProductMassTolerance = new PpmTolerance(5);
+            commonParameters.DigestionParams = new DigestionParams(
+                maxMissedCleavages: 0,
+                minPeptideLength: 1,
+                maxModificationIsoforms: int.MaxValue,
+                initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
+            ClassicSearchEngine cse = new ClassicSearchEngine(globalPsms, arrayOfSortedMS2Scans, new List<ModificationWithMass>(), new List<ModificationWithMass>(), new List<Protein> { prot }, new List<ProductType> { ProductType.B, ProductType.Y }, new OpenSearchMode(), commonParameters, new List<string>());
 
             cse.Run();
             Assert.Less(globalPsms[0].Score, 2);
@@ -101,15 +103,16 @@ namespace Test
 
             PeptideSpectralMatch[] globalPsms = new PeptideSpectralMatch[1];
             Ms2ScanWithSpecificMass[] arrayOfSortedMS2Scans = { new Ms2ScanWithSpecificMass(scan, 0, 0, null) };
-            CommonParameters CommonParameters = new CommonParameters(
-                productMassTolerance: new PpmTolerance(5),
-                scoreCutoff: 1,
-                digestionParams: new DigestionParams(
-                    maxMissedCleavages: 0,
-                    minPeptideLength: 1,
-                    maxModificationIsoforms: int.MaxValue,
-                    initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain));
-            ClassicSearchEngine cse = new ClassicSearchEngine(globalPsms, arrayOfSortedMS2Scans, new List<ModificationWithMass>(), new List<ModificationWithMass>(), new List<Protein> { prot }, new List<ProductType> { ProductType.B, ProductType.Y }, new OpenSearchMode(), CommonParameters, new List<string>());
+            CommonParameters commonParameters = new CommonParameters();
+            commonParameters.ProductMassTolerance = new PpmTolerance(5);
+            commonParameters.ScoreCutoff = 1;
+            commonParameters.DigestionParams = new DigestionParams(
+                maxMissedCleavages: 0,
+                minPeptideLength: 1,
+                maxModificationIsoforms: int.MaxValue,
+                initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
+
+            ClassicSearchEngine cse = new ClassicSearchEngine(globalPsms, arrayOfSortedMS2Scans, new List<ModificationWithMass>(), new List<ModificationWithMass>(), new List<Protein> { prot }, new List<ProductType> { ProductType.B, ProductType.Y }, new OpenSearchMode(), commonParameters, new List<string>());
 
             cse.Run();
             Assert.Less(globalPsms[0].Score, 2);
@@ -134,12 +137,19 @@ namespace Test
 
             PeptideSpectralMatch[] globalPsms = new PeptideSpectralMatch[1];
             Ms2ScanWithSpecificMass[] arrayOfSortedMS2Scans = { new Ms2ScanWithSpecificMass(scan, 600, 1, null) };
-            CommonParameters CommonParameters = new CommonParameters(productMassTolerance: new PpmTolerance(5), scoreCutoff: 1, digestionParams: new DigestionParams(maxMissedCleavages: 0, minPeptideLength: 1, maxModificationIsoforms: int.MaxValue, initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain));
+            CommonParameters commonParameters = new CommonParameters();
+            commonParameters.ProductMassTolerance = new PpmTolerance(5);
+            commonParameters.ScoreCutoff = 1;
+            commonParameters.DigestionParams = new DigestionParams(
+                maxMissedCleavages: 0,
+                minPeptideLength: 1,
+                maxModificationIsoforms: int.MaxValue,
+                initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
 
             var indexEngine = new IndexingEngine(new List<Protein> { prot }, new List<ModificationWithMass>(), new List<ModificationWithMass>(), new List<ProductType>
-            { ProductType.B, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters, 30000, new List<string>());
+            { ProductType.B, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { commonParameters.DigestionParams }, commonParameters, 30000, new List<string>());
             var indexResults = (IndexingResults)indexEngine.Run();
-            var cse = new ModernSearchEngine(globalPsms, arrayOfSortedMS2Scans, indexResults.PeptideIndex, indexResults.FragmentIndex, new List<ProductType> { ProductType.B, ProductType.Y }, 0, CommonParameters, new OpenSearchMode(), 0, new List<string>());
+            var cse = new ModernSearchEngine(globalPsms, arrayOfSortedMS2Scans, indexResults.PeptideIndex, indexResults.FragmentIndex, new List<ProductType> { ProductType.B, ProductType.Y }, 0, commonParameters, new OpenSearchMode(), 0, new List<string>());
 
             cse.Run();
             Assert.Less(globalPsms[0].Score, 2);
@@ -163,9 +173,16 @@ namespace Test
 
             PeptideSpectralMatch[] globalPsms = new PeptideSpectralMatch[1];
             Ms2ScanWithSpecificMass[] arrayOfSortedMS2Scans = { new Ms2ScanWithSpecificMass(scan, 0, 0, null) };
-            CommonParameters CommonParameters = new CommonParameters(productMassTolerance: new PpmTolerance(5), scoreCutoff: 1, digestionParams: new DigestionParams(maxMissedCleavages: 0, minPeptideLength: 1, maxModificationIsoforms: int.MaxValue, initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain));
+            CommonParameters commonParameters = new CommonParameters();
+            commonParameters.ProductMassTolerance = new PpmTolerance(5);
+            commonParameters.ScoreCutoff = 1;
+            commonParameters.DigestionParams = new DigestionParams(
+                maxMissedCleavages: 0,
+                minPeptideLength: 1,
+                maxModificationIsoforms: int.MaxValue,
+                initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
 
-            ClassicSearchEngine cse = new ClassicSearchEngine(globalPsms, arrayOfSortedMS2Scans, new List<ModificationWithMass>(), new List<ModificationWithMass>(), new List<Protein> { prot }, new List<ProductType> { ProductType.B, ProductType.Y }, new OpenSearchMode(), CommonParameters, new List<string>());
+            ClassicSearchEngine cse = new ClassicSearchEngine(globalPsms, arrayOfSortedMS2Scans, new List<ModificationWithMass>(), new List<ModificationWithMass>(), new List<Protein> { prot }, new List<ProductType> { ProductType.B, ProductType.Y }, new OpenSearchMode(), commonParameters, new List<string>());
 
             cse.Run();
             Assert.IsNull(globalPsms[0]);

--- a/Test/MyTaskTest.cs
+++ b/Test/MyTaskTest.cs
@@ -20,11 +20,16 @@ namespace Test
         public static void TestEverythingRunner()
         {
             foreach (var modFile in Directory.GetFiles(@"Mods"))
+            {
                 GlobalVariables.AddMods(PtmListLoader.ReadModsFromFile(modFile));
+            }
+
+            CommonParameters c = new CommonParameters();
+            c.DigestionParams = new DigestionParams(maxMissedCleavages: 0, minPeptideLength: 1, initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
 
             CalibrationTask task1 = new CalibrationTask
             {
-                CommonParameters = new CommonParameters(digestionParams: new DigestionParams(maxMissedCleavages: 0, minPeptideLength: 1, initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain)),
+                CommonParameters = c,
 
                 CalibrationParameters = new CalibrationParameters
                 {
@@ -104,28 +109,25 @@ namespace Test
             foreach (var modFile in Directory.GetFiles(@"Mods"))
                 GlobalVariables.AddMods(PtmListLoader.ReadModsFromFile(modFile));
 
+            CommonParameters c = new CommonParameters();
+            c.DigestionParams = new DigestionParams(maxMissedCleavages: 0, minPeptideLength: 1, initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
+            c.ListOfModsVariable = new List<(string, string)> { ("Common Variable", "Oxidation of M") };
+            c.ListOfModsFixed = new List<(string, string)> { ("Common Fixed", "Carbamidomethyl of C") };
+            c.ProductMassTolerance = new AbsoluteTolerance(0.01);
+
             CalibrationTask task1 = new CalibrationTask
             {
-                CommonParameters = new CommonParameters
-                (
-                    digestionParams: new DigestionParams(maxMissedCleavages: 0, minPeptideLength: 1, initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain),
-                    listOfModsVariable: new List<(string, string)> { ("Common Variable", "Oxidation of M") },
-                    listOfModsFixed: new List<(string, string)> { ("Common Fixed", "Carbamidomethyl of C") },
-                    productMassTolerance: new AbsoluteTolerance(0.01)
-                ),
+                CommonParameters = c,
                 CalibrationParameters = new CalibrationParameters
                 {
                     NumFragmentsNeededForEveryIdentification = 6,
                 }
             };
-            GptmdTask task2 = new GptmdTask
-            {
-                CommonParameters = new CommonParameters
-                (
-                    digestionParams: new DigestionParams(),
-                    productMassTolerance: new AbsoluteTolerance(0.01)
-                ),
-            };
+
+            CommonParameters c2 = new CommonParameters();
+            c2.ProductMassTolerance = new AbsoluteTolerance(0.01);
+
+            GptmdTask task2 = new GptmdTask { CommonParameters = c2 };
 
             SearchTask task3 = new SearchTask
             {
@@ -198,16 +200,15 @@ namespace Test
         [Test]
         public static void MakeSureFdrDoesntSkip()
         {
+            CommonParameters c = new CommonParameters();
+            c.DigestionParams = new DigestionParams(minPeptideLength: 2);
+            c.ScoreCutoff = 1;
+            c.DeconvolutionIntensityRatio = 999;
+            c.DeconvolutionMassTolerance = new PpmTolerance(50);
+
             MetaMorpheusTask task = new SearchTask
             {
-                CommonParameters = new CommonParameters
-                (
-                    digestionParams: new DigestionParams(minPeptideLength: 2),
-
-                    scoreCutoff: 1,
-                    deconvolutionIntensityRatio: 999,
-                    deconvolutionMassTolerance: new PpmTolerance(50)
-                ),
+                CommonParameters = c,
                 SearchParameters = new SearchParameters
                 {
                     DecoyType = DecoyType.None,
@@ -273,17 +274,16 @@ namespace Test
             {
                 ModificationMotif.TryGetMotif("T", out ModificationMotif motif);
                 GlobalVariables.AddMods(new List<ModificationWithMass> { new ModificationWithMass("ok", "okType", motif, TerminusLocalization.Any, 229) });
+                CommonParameters c = new CommonParameters();
+                c.DigestionParams = new DigestionParams(initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain);
+                c.ListOfModsFixed = new List<(string, string)>();
+                c.ListOfModsVariable = new List<(string, string)>();
+                c.ScoreCutoff = 1;
+                c.PrecursorMassTolerance = new AbsoluteTolerance(1);
+
                 task1 = new GptmdTask
                 {
-                    CommonParameters = new CommonParameters
-                    (
-                        digestionParams: new DigestionParams(initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain),
-                        listOfModsVariable: new List<(string, string)>(),
-                        listOfModsFixed: new List<(string, string)>(),
-                        scoreCutoff: 1,
-                        precursorMassTolerance: new AbsoluteTolerance(1)
-                    ),
-
+                    CommonParameters = c,
                     GptmdParameters = new GptmdParameters
                     {
                         ListOfModsGptmd = new List<(string, string)> { ("okType", "ok") },
@@ -324,13 +324,12 @@ namespace Test
         [Test]
         public static void TestPeptideCount()
         {
+            CommonParameters c = new CommonParameters();
+            c.DigestionParams = new DigestionParams(minPeptideLength: 5);
+
             SearchTask testPeptides = new SearchTask
             {
-                CommonParameters = new CommonParameters
-                (
-
-                    digestionParams: new DigestionParams(minPeptideLength: 5)
-                ),
+                CommonParameters = c,
                 SearchParameters = new SearchParameters
                 {
                     WritePrunedDatabase = true,

--- a/Test/SearchEngineTests.cs
+++ b/Test/SearchEngineTests.cs
@@ -24,11 +24,11 @@ namespace Test
         {
             Protease protease = new Protease("Customized Protease", new List<Tuple<string, TerminusType>> { new Tuple<string, TerminusType>("K", TerminusType.C) }, new List<Tuple<string, TerminusType>>(), CleavageSpecificity.Full, null, null, null);
             ProteaseDictionary.Dictionary.Add(protease.Name, protease);
-            CommonParameters CommonParameters = new CommonParameters
-                (digestionParams: new DigestionParams(
-                    protease: protease.Name,
-                    minPeptideLength: 1),
-                scoreCutoff: 1);
+            CommonParameters commonParameters = new CommonParameters();
+            commonParameters.DigestionParams = new DigestionParams(
+                protease: protease.Name,
+                minPeptideLength: 1);
+            commonParameters.ScoreCutoff = 1;
 
             var myMsDataFile = new TestDataFile();
             var variableModifications = new List<ModificationWithMass>();
@@ -46,7 +46,7 @@ namespace Test
             var listOfSortedms2Scans = MetaMorpheusTask.GetMs2Scans(myMsDataFile, null, DoPrecursorDeconvolution, UseProvidedPrecursorInfo, DeconvolutionIntensityRatio, DeconvolutionMaxAssumedChargeState, DeconvolutionMassTolerance).OrderBy(b => b.PrecursorMass).ToArray();
 
             PeptideSpectralMatch[] allPsmsArray = new PeptideSpectralMatch[listOfSortedms2Scans.Length];
-            new ClassicSearchEngine(allPsmsArray, listOfSortedms2Scans, variableModifications, fixedModifications, proteinList, new List<ProductType> { ProductType.B, ProductType.Y }, searchModes, CommonParameters, new List<string>()).Run();
+            new ClassicSearchEngine(allPsmsArray, listOfSortedms2Scans, variableModifications, fixedModifications, proteinList, new List<ProductType> { ProductType.B, ProductType.Y }, searchModes, commonParameters, new List<string>()).Run();
 
             // Single search mode
             Assert.AreEqual(1, allPsmsArray.Length);
@@ -59,7 +59,7 @@ namespace Test
 
             var hah = (SequencesToActualProteinPeptidesEngineResults)new SequencesToActualProteinPeptidesEngine(new List<PeptideSpectralMatch>
             { allPsmsArray[0] }, proteinList, fixedModifications, variableModifications, new List<ProductType> { ProductType.B, ProductType.Y }, new List<DigestionParams>
-            { CommonParameters.DigestionParams }, CommonParameters.ReportAllAmbiguity, CommonParameters, new List<string>()).Run();
+            { commonParameters.DigestionParams }, commonParameters.ReportAllAmbiguity, commonParameters, new List<string>()).Run();
 
             foreach (var huh in allPsmsArray)
                 if (huh != null)
@@ -71,12 +71,12 @@ namespace Test
         [Test]
         public static void TestClassicSearchEngineWithWeirdPeptide()
         {
-            CommonParameters CommonParameters = new CommonParameters(
-                digestionParams: new DigestionParams(
+            CommonParameters commonParameters = new CommonParameters();
+            commonParameters.DigestionParams = new DigestionParams(
                     protease: "Customized Protease",
                     maxMissedCleavages: 0,
-                    minPeptideLength: 1),
-                scoreCutoff: 1);
+                    minPeptideLength: 1);
+            commonParameters.ScoreCutoff = 1;
 
             var myMsDataFile = new TestDataFile();
             var variableModifications = new List<ModificationWithMass>();
@@ -94,7 +94,7 @@ namespace Test
             var listOfSortedms2Scans = MetaMorpheusTask.GetMs2Scans(myMsDataFile, null, DoPrecursorDeconvolution, UseProvidedPrecursorInfo, DeconvolutionIntensityRatio, DeconvolutionMaxAssumedChargeState, DeconvolutionMassTolerance).OrderBy(b => b.PrecursorMass).ToArray();
 
             PeptideSpectralMatch[] allPsmsArray = new PeptideSpectralMatch[listOfSortedms2Scans.Length];
-            new ClassicSearchEngine(allPsmsArray, listOfSortedms2Scans, variableModifications, fixedModifications, proteinList, new List<ProductType> { ProductType.B, ProductType.Y }, searchModes, CommonParameters, new List<string>()).Run();
+            new ClassicSearchEngine(allPsmsArray, listOfSortedms2Scans, variableModifications, fixedModifications, proteinList, new List<ProductType> { ProductType.B, ProductType.Y }, searchModes, commonParameters, new List<string>()).Run();
 
             // Single search mode
             Assert.AreEqual(1, allPsmsArray.Length);
@@ -105,7 +105,7 @@ namespace Test
             Assert.IsTrue(allPsmsArray[0].Score > 1);
             Assert.AreEqual(2, allPsmsArray[0].ScanNumber);
 
-            var hah = (SequencesToActualProteinPeptidesEngineResults)new SequencesToActualProteinPeptidesEngine(new List<PeptideSpectralMatch> { allPsmsArray[0] }, proteinList, fixedModifications, variableModifications, new List<ProductType> { ProductType.B, ProductType.Y }, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters.ReportAllAmbiguity, CommonParameters, new List<string>()).Run();
+            var hah = (SequencesToActualProteinPeptidesEngineResults)new SequencesToActualProteinPeptidesEngine(new List<PeptideSpectralMatch> { allPsmsArray[0] }, proteinList, fixedModifications, variableModifications, new List<ProductType> { ProductType.B, ProductType.Y }, new List<DigestionParams> { commonParameters.DigestionParams }, commonParameters.ReportAllAmbiguity, commonParameters, new List<string>()).Run();
 
             foreach (var huh in allPsmsArray)
                 if (huh != null)
@@ -123,12 +123,12 @@ namespace Test
                 SearchTarget = true,
             };
 
-            CommonParameters CommonParameters = new CommonParameters(
-                precursorMassTolerance: new PpmTolerance(5),
-                digestionParams: new DigestionParams(
-                    protease: "Customized Protease",
-                    minPeptideLength: 1),
-                scoreCutoff: 1);
+            CommonParameters commonParameters = new CommonParameters();
+            commonParameters.PrecursorMassTolerance = new PpmTolerance(5);
+            commonParameters.DigestionParams = new DigestionParams(
+                protease: "Customized Protease",
+                minPeptideLength: 1);
+            commonParameters.ScoreCutoff = 1;
 
             var myMsDataFile = new TestDataFile();
             var variableModifications = new List<ModificationWithMass>();
@@ -152,7 +152,7 @@ namespace Test
             var proteinList = new List<Protein> { new Protein("MNNNKQQQ", null) };
 
             var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType>
-            { ProductType.B, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters, SearchParameters.MaxFragmentSize, new List<string>());
+            { ProductType.B, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { commonParameters.DigestionParams }, commonParameters, SearchParameters.MaxFragmentSize, new List<string>());
             var indexResults = (IndexingResults)indexEngine.Run();
 
             bool DoPrecursorDeconvolution = true;
@@ -163,10 +163,10 @@ namespace Test
 
             var listOfSortedms2Scans = MetaMorpheusTask.GetMs2Scans(myMsDataFile, null, DoPrecursorDeconvolution, UseProvidedPrecursorInfo, DeconvolutionIntensityRatio, DeconvolutionMaxAssumedChargeState, DeconvolutionMassTolerance).OrderBy(b => b.PrecursorMass).ToArray();
 
-            MassDiffAcceptor massDiffAcceptor = SearchTask.GetMassDiffAcceptor(CommonParameters.PrecursorMassTolerance, SearchParameters.MassDiffAcceptorType, SearchParameters.CustomMdac);
+            MassDiffAcceptor massDiffAcceptor = SearchTask.GetMassDiffAcceptor(commonParameters.PrecursorMassTolerance, SearchParameters.MassDiffAcceptorType, SearchParameters.CustomMdac);
 
             PeptideSpectralMatch[] allPsmsArray = new PeptideSpectralMatch[listOfSortedms2Scans.Length];
-            new ModernSearchEngine(allPsmsArray, listOfSortedms2Scans, indexResults.PeptideIndex, indexResults.FragmentIndex, new List<ProductType> { ProductType.B, ProductType.Y }, 0, CommonParameters, massDiffAcceptor, SearchParameters.MaximumMassThatFragmentIonScoreIsDoubled, new List<string>()).Run();
+            new ModernSearchEngine(allPsmsArray, listOfSortedms2Scans, indexResults.PeptideIndex, indexResults.FragmentIndex, new List<ProductType> { ProductType.B, ProductType.Y }, 0, commonParameters, massDiffAcceptor, SearchParameters.MaximumMassThatFragmentIonScoreIsDoubled, new List<string>()).Run();
 
             // Single search mode
             Assert.AreEqual(1, allPsmsArray.Length);
@@ -178,7 +178,7 @@ namespace Test
             Assert.IsTrue(allPsmsArray[0].Score > 1);
             Assert.AreEqual(2, allPsmsArray[0].ScanNumber);
 
-            var hah = (SequencesToActualProteinPeptidesEngineResults)new SequencesToActualProteinPeptidesEngine(new List<PeptideSpectralMatch> { allPsmsArray[0] }, proteinList, fixedModifications, variableModifications, new List<ProductType> { ProductType.B, ProductType.Y }, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters.ReportAllAmbiguity, CommonParameters, new List<string>()).Run();
+            var hah = (SequencesToActualProteinPeptidesEngineResults)new SequencesToActualProteinPeptidesEngine(new List<PeptideSpectralMatch> { allPsmsArray[0] }, proteinList, fixedModifications, variableModifications, new List<ProductType> { ProductType.B, ProductType.Y }, new List<DigestionParams> { commonParameters.DigestionParams }, commonParameters.ReportAllAmbiguity, commonParameters, new List<string>()).Run();
 
             foreach (var huh in allPsmsArray)
                 if (huh != null)
@@ -198,27 +198,27 @@ namespace Test
                 MaxFragmentSize = 1, // super small index
             };
 
-            CommonParameters CommonParameters = new CommonParameters(
-                productMassTolerance: new AbsoluteTolerance(100), // super large tolerance (100 Da)
-                digestionParams: new DigestionParams(
-                    protease: "Customized Protease",
-                    minPeptideLength: 1),
-                scoreCutoff: 1,
-                addCompIons: true);
+            CommonParameters commonParameters = new CommonParameters();
+            commonParameters.ProductMassTolerance = new AbsoluteTolerance(100); // super large tolerance (100 Da)
+            commonParameters.DigestionParams = new DigestionParams(
+                protease: "Customized Protease",
+                minPeptideLength: 1);
+            commonParameters.ScoreCutoff = 1;
+            commonParameters.AddCompIons = true;
 
             var proteinList = new List<Protein> { new Protein("K", null) };
 
             var indexEngine = new IndexingEngine(proteinList, new List<ModificationWithMass>(), new List<ModificationWithMass>(),
-                new List<ProductType> { ProductType.B, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams },
-                CommonParameters, SearchParameters.MaxFragmentSize, new List<string>());
+                new List<ProductType> { ProductType.B, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { commonParameters.DigestionParams },
+                commonParameters, SearchParameters.MaxFragmentSize, new List<string>());
             var indexResults = (IndexingResults)indexEngine.Run();
 
             var listOfSortedms2Scans = MetaMorpheusTask.GetMs2Scans(new TestDataFile(), null, true, true, 4, 10, new PpmTolerance(5)).OrderBy(b => b.PrecursorMass).ToArray();
 
-            MassDiffAcceptor massDiffAcceptor = SearchTask.GetMassDiffAcceptor(CommonParameters.PrecursorMassTolerance, SearchParameters.MassDiffAcceptorType, SearchParameters.CustomMdac);
+            MassDiffAcceptor massDiffAcceptor = SearchTask.GetMassDiffAcceptor(commonParameters.PrecursorMassTolerance, SearchParameters.MassDiffAcceptorType, SearchParameters.CustomMdac);
 
             PeptideSpectralMatch[] allPsmsArray = new PeptideSpectralMatch[listOfSortedms2Scans.Length];
-            new ModernSearchEngine(allPsmsArray, listOfSortedms2Scans, indexResults.PeptideIndex, indexResults.FragmentIndex, new List<ProductType> { ProductType.B, ProductType.Y }, 0, CommonParameters, massDiffAcceptor, SearchParameters.MaximumMassThatFragmentIonScoreIsDoubled, new List<string>()).Run();
+            new ModernSearchEngine(allPsmsArray, listOfSortedms2Scans, indexResults.PeptideIndex, indexResults.FragmentIndex, new List<ProductType> { ProductType.B, ProductType.Y }, 0, commonParameters, massDiffAcceptor, SearchParameters.MaximumMassThatFragmentIonScoreIsDoubled, new List<string>()).Run();
 
             // no assertions... just don't crash...
         }
@@ -229,12 +229,11 @@ namespace Test
             //just check if it crashes or not.
             SearchParameters SearchParameters = new SearchParameters();
 
-            CommonParameters CommonParameters = new CommonParameters(
-                digestionParams: new DigestionParams(
-                    protease: "Customized Protease"),
-                scoreCutoff: 255);
+            CommonParameters commonParameters = new CommonParameters();
+            commonParameters.DigestionParams = new DigestionParams(protease: "Customized Protease");
+            commonParameters.ScoreCutoff = 255;
 
-            MassDiffAcceptor massDiffAcceptor = SearchTask.GetMassDiffAcceptor(CommonParameters.PrecursorMassTolerance, SearchParameters.MassDiffAcceptorType, SearchParameters.CustomMdac);
+            MassDiffAcceptor massDiffAcceptor = SearchTask.GetMassDiffAcceptor(commonParameters.PrecursorMassTolerance, SearchParameters.MassDiffAcceptorType, SearchParameters.CustomMdac);
 
             var myMsDataFile = new TestDataFile(true); //empty
             var variableModifications = new List<ModificationWithMass>();
@@ -259,7 +258,7 @@ namespace Test
 
             var searchModes = new SinglePpmAroundZeroSearchMode(5);
 
-            var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.B, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters, SearchParameters.MaxFragmentSize, new List<string>());
+            var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.B, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { commonParameters.DigestionParams }, commonParameters, SearchParameters.MaxFragmentSize, new List<string>());
             var indexResults = (IndexingResults)indexEngine.Run();
 
             bool DoPrecursorDeconvolution = true;
@@ -273,13 +272,13 @@ namespace Test
             PeptideSpectralMatch[] allPsmsArray = new PeptideSpectralMatch[listOfSortedms2Scans.Length];
 
             //Classic
-            new ClassicSearchEngine(allPsmsArray, listOfSortedms2Scans, variableModifications, fixedModifications, proteinList, new List<ProductType> { ProductType.B, ProductType.Y }, searchModes, CommonParameters, new List<string>()).Run();
+            new ClassicSearchEngine(allPsmsArray, listOfSortedms2Scans, variableModifications, fixedModifications, proteinList, new List<ProductType> { ProductType.B, ProductType.Y }, searchModes, commonParameters, new List<string>()).Run();
 
             //Modern
-            new ModernSearchEngine(allPsmsArray, listOfSortedms2Scans, indexResults.PeptideIndex, indexResults.FragmentIndex, new List<ProductType> { ProductType.B, ProductType.Y }, 0, CommonParameters, massDiffAcceptor, SearchParameters.MaximumMassThatFragmentIonScoreIsDoubled, new List<string>()).Run();
+            new ModernSearchEngine(allPsmsArray, listOfSortedms2Scans, indexResults.PeptideIndex, indexResults.FragmentIndex, new List<ProductType> { ProductType.B, ProductType.Y }, 0, commonParameters, massDiffAcceptor, SearchParameters.MaximumMassThatFragmentIonScoreIsDoubled, new List<string>()).Run();
 
             //NonSpecific
-            new NonSpecificEnzymeSearchEngine(allPsmsArray, listOfSortedms2Scans, indexResults.PeptideIndex, indexResults.FragmentIndex, indexResults.FragmentIndex, new List<ProductType> { ProductType.B }, 0, CommonParameters, massDiffAcceptor, SearchParameters.MaximumMassThatFragmentIonScoreIsDoubled, new List<string>()).Run();
+            new NonSpecificEnzymeSearchEngine(allPsmsArray, listOfSortedms2Scans, indexResults.PeptideIndex, indexResults.FragmentIndex, indexResults.FragmentIndex, new List<ProductType> { ProductType.B }, 0, commonParameters, massDiffAcceptor, SearchParameters.MaximumMassThatFragmentIonScoreIsDoubled, new List<string>()).Run();
         }
 
         [Test]
@@ -291,11 +290,11 @@ namespace Test
                 SearchTarget = true,
             };
 
-            CommonParameters CommonParameters = new CommonParameters(
-                digestionParams: new DigestionParams(
-                    protease: "Customized Protease",
-                    minPeptideLength: 1),
-                scoreCutoff: 1);
+            CommonParameters commonParameters = new CommonParameters();
+            commonParameters.DigestionParams = new DigestionParams(
+                protease: "Customized Protease",
+                minPeptideLength: 1);
+            commonParameters.ScoreCutoff = 1;
 
             var myMsDataFile = new TestDataFile();
             var variableModifications = new List<ModificationWithMass>();
@@ -304,7 +303,7 @@ namespace Test
 
             var proteinList = new List<Protein> { new Protein("MNNNKQXQ", null) };
 
-            var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.B, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters, SearchParameters.MaxFragmentSize, new List<string>());
+            var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.B, ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { commonParameters.DigestionParams }, commonParameters, SearchParameters.MaxFragmentSize, new List<string>());
             var indexResults = (IndexingResults)indexEngine.Run();
 
             bool DoPrecursorDeconvolution = true;
@@ -314,10 +313,10 @@ namespace Test
             Tolerance DeconvolutionMassTolerance = new PpmTolerance(5);
 
             var listOfSortedms2Scans = MetaMorpheusTask.GetMs2Scans(myMsDataFile, null, DoPrecursorDeconvolution, UseProvidedPrecursorInfo, DeconvolutionIntensityRatio, DeconvolutionMaxAssumedChargeState, DeconvolutionMassTolerance).OrderBy(b => b.PrecursorMass).ToArray();
-            MassDiffAcceptor massDiffAcceptor = SearchTask.GetMassDiffAcceptor(CommonParameters.PrecursorMassTolerance, SearchParameters.MassDiffAcceptorType, SearchParameters.CustomMdac);
+            MassDiffAcceptor massDiffAcceptor = SearchTask.GetMassDiffAcceptor(commonParameters.PrecursorMassTolerance, SearchParameters.MassDiffAcceptorType, SearchParameters.CustomMdac);
 
             PeptideSpectralMatch[] allPsmsArray = new PeptideSpectralMatch[listOfSortedms2Scans.Length];
-            var engine = new ModernSearchEngine(allPsmsArray, listOfSortedms2Scans, indexResults.PeptideIndex, indexResults.FragmentIndex, new List<ProductType> { ProductType.B, ProductType.Y }, 0, CommonParameters, massDiffAcceptor, SearchParameters.MaximumMassThatFragmentIonScoreIsDoubled, new List<string>());
+            var engine = new ModernSearchEngine(allPsmsArray, listOfSortedms2Scans, indexResults.PeptideIndex, indexResults.FragmentIndex, new List<ProductType> { ProductType.B, ProductType.Y }, 0, commonParameters, massDiffAcceptor, SearchParameters.MaximumMassThatFragmentIonScoreIsDoubled, new List<string>());
             var searchResults = engine.Run();
 
             // Single search mode
@@ -331,7 +330,7 @@ namespace Test
             Assert.AreEqual(2, allPsmsArray[0].ScanNumber);
 
             new SequencesToActualProteinPeptidesEngine(new List<PeptideSpectralMatch> { allPsmsArray[0] }, proteinList, fixedModifications, variableModifications,
-                new List<ProductType> { ProductType.B, ProductType.Y }, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters.ReportAllAmbiguity, CommonParameters, new List<string>()).Run();
+                new List<ProductType> { ProductType.B, ProductType.Y }, new List<DigestionParams> { commonParameters.DigestionParams }, commonParameters.ReportAllAmbiguity, commonParameters, new List<string>()).Run();
 
             Assert.AreEqual(3, allPsmsArray[0].NumDifferentCompactPeptides);
         }
@@ -346,11 +345,11 @@ namespace Test
             Protease protease = new Protease("single N", new List<Tuple<string, TerminusType>> { new Tuple<string, TerminusType>("K", TerminusType.None), new Tuple<string, TerminusType>("G", TerminusType.None) }, new List<Tuple<string, TerminusType>>(), CleavageSpecificity.SingleN, null, null, null);
             ProteaseDictionary.Dictionary.Add(protease.Name, protease);
             DigestionParams dp = new DigestionParams(protease: protease.Name);
-            CommonParameters CommonParameters = new CommonParameters(
-                precursorMassTolerance: new PpmTolerance(5),
-                digestionParams: dp,
-                scoreCutoff: 1,
-                addCompIons: true);
+            CommonParameters commonParameters = new CommonParameters();
+            commonParameters.PrecursorMassTolerance = new PpmTolerance(5);
+            commonParameters.DigestionParams = dp;
+            commonParameters.ScoreCutoff = 1;
+            commonParameters.AddCompIons = true;
 
             var myMsDataFile = new TestDataFile("Yes, I'd like one slightly larger please");
             var variableModifications = new List<ModificationWithMass>();
@@ -375,12 +374,13 @@ namespace Test
 
             var proteinList = new List<Protein> { new Protein("GGGGGMNNNKQQQGGGGG", "TestProtein") };
 
-            CommonParameters = new CommonParameters(
-                digestionParams: new DigestionParams(protease: protease.Name, minPeptideLength: 1),
-                precursorMassTolerance: new PpmTolerance(5),
-                scoreCutoff: 1);
+            commonParameters = new CommonParameters();
+            commonParameters.DigestionParams = new DigestionParams(protease: protease.Name, minPeptideLength: 1);
+            commonParameters.PrecursorMassTolerance = new PpmTolerance(5);
+            commonParameters.ScoreCutoff = 1;
+
             var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType>
-            { ProductType.B }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters, 100000, new List<string>());
+            { ProductType.B }, 1, DecoyType.Reverse, new List<DigestionParams> { commonParameters.DigestionParams }, commonParameters, 100000, new List<string>());
             var indexResults = (IndexingResults)indexEngine.Run();
             var peptideIndex = indexResults.PeptideIndex;
             var fragmentIndexDict = indexResults.FragmentIndex;
@@ -393,16 +393,16 @@ namespace Test
 
             var listOfSortedms2Scans = MetaMorpheusTask.GetMs2Scans(myMsDataFile, null, DoPrecursorDeconvolution, UseProvidedPrecursorInfo, DeconvolutionIntensityRatio, DeconvolutionMaxAssumedChargeState, DeconvolutionMassTolerance).OrderBy(b => b.PrecursorMass).ToArray();
 
-            MassDiffAcceptor massDiffAcceptor = SearchTask.GetMassDiffAcceptor(CommonParameters.PrecursorMassTolerance, SearchParameters.MassDiffAcceptorType, SearchParameters.CustomMdac);
+            MassDiffAcceptor massDiffAcceptor = SearchTask.GetMassDiffAcceptor(commonParameters.PrecursorMassTolerance, SearchParameters.MassDiffAcceptorType, SearchParameters.CustomMdac);
 
             PeptideSpectralMatch[] allPsmsArray = new PeptideSpectralMatch[listOfSortedms2Scans.Length];
-            CommonParameters = new CommonParameters(
-                digestionParams: new DigestionParams(protease: protease.Name, minPeptideLength: 5),
-                precursorMassTolerance: new PpmTolerance(5),
-                scoreCutoff: 1,
-                addCompIons: true);
+            commonParameters = new CommonParameters();
+            commonParameters.DigestionParams = new DigestionParams(protease: protease.Name, minPeptideLength: 5);
+            commonParameters.PrecursorMassTolerance = new PpmTolerance(5);
+            commonParameters.ScoreCutoff = 1;
+            commonParameters.AddCompIons = true;
 
-            new NonSpecificEnzymeSearchEngine(allPsmsArray, listOfSortedms2Scans, peptideIndex, fragmentIndexDict, fragmentIndexDict, new List<ProductType> { ProductType.B }, 0, CommonParameters, massDiffAcceptor, SearchParameters.MaximumMassThatFragmentIonScoreIsDoubled, new List<string>()).Run();
+            new NonSpecificEnzymeSearchEngine(allPsmsArray, listOfSortedms2Scans, peptideIndex, fragmentIndexDict, fragmentIndexDict, new List<ProductType> { ProductType.B }, 0, commonParameters, massDiffAcceptor, SearchParameters.MaximumMassThatFragmentIonScoreIsDoubled, new List<string>()).Run();
 
             // Single search mode
             Assert.AreEqual(1, allPsmsArray.Length);
@@ -412,15 +412,15 @@ namespace Test
 
             Assert.IsTrue(allPsmsArray[0].Score > 4);
             Assert.AreEqual(2, allPsmsArray[0].ScanNumber);
-            CommonParameters = new CommonParameters(
-                 digestionParams: new DigestionParams(protease: protease.Name, minPeptideLength: 1),
-                 precursorMassTolerance: new PpmTolerance(5),
-                 scoreCutoff: 1);
+            commonParameters = new CommonParameters();
+            commonParameters.DigestionParams = new DigestionParams(protease: protease.Name, minPeptideLength: 1);
+            commonParameters.PrecursorMassTolerance = new PpmTolerance(5);
+            commonParameters.ScoreCutoff = 1;
 
             Dictionary<CompactPeptideBase, HashSet<PeptideWithSetModifications>> compactPeptideToProteinPeptideMatching = new Dictionary<CompactPeptideBase, HashSet<PeptideWithSetModifications>>();
 
             new NonSpecificEnzymeSequencesToActualPeptides(compactPeptideToProteinPeptideMatching, new List<PeptideSpectralMatch> { allPsmsArray[0] },
-                proteinList, fixedModifications, variableModifications, new List<ProductType> { ProductType.B }, new List<DigestionParams> { CommonParameters.DigestionParams }, massDiffAcceptor, CommonParameters.ReportAllAmbiguity, CommonParameters, new List<string>()).Run();
+                proteinList, fixedModifications, variableModifications, new List<ProductType> { ProductType.B }, new List<DigestionParams> { commonParameters.DigestionParams }, massDiffAcceptor, commonParameters.ReportAllAmbiguity, commonParameters, new List<string>()).Run();
 
             foreach (var huh in allPsmsArray)
                 if (huh != null)
@@ -441,11 +441,11 @@ namespace Test
             ProteaseDictionary.Dictionary.Add(protease.Name, protease);
             var dp = new DigestionParams(protease: protease.Name);
 
-            CommonParameters CommonParameters = new CommonParameters(
-                digestionParams: dp,
-                scoreCutoff: 4,
-                precursorMassTolerance: new PpmTolerance(5),
-                addCompIons: true);
+            CommonParameters commonParameters = new CommonParameters();
+            commonParameters.DigestionParams = dp;
+            commonParameters.ScoreCutoff = 4;
+            commonParameters.PrecursorMassTolerance = new PpmTolerance(5);
+            commonParameters.AddCompIons = true;
 
             var myMsDataFile = new TestDataFile("Yes, I'd like one slightly larger please");
             var variableModifications = new List<ModificationWithMass>();
@@ -467,13 +467,13 @@ namespace Test
             }
 
             var proteinList = new List<Protein> { new Protein("GGGGGMNNNKQQQGGGGG", null) };
-            CommonParameters = new CommonParameters(
-                digestionParams: new DigestionParams(protease: protease.Name, minPeptideLength: 1),
-                precursorMassTolerance: new PpmTolerance(5),
-                scoreCutoff: 4);
+            commonParameters = new CommonParameters();
+            commonParameters.DigestionParams = new DigestionParams(protease: protease.Name, minPeptideLength: 1);
+            commonParameters.PrecursorMassTolerance = new PpmTolerance(5);
+            commonParameters.ScoreCutoff = 4;
 
             var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType>
-            { ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters, SearchParameters.MaxFragmentSize, new List<string>());
+            { ProductType.Y }, 1, DecoyType.Reverse, new List<DigestionParams> { commonParameters.DigestionParams }, commonParameters, SearchParameters.MaxFragmentSize, new List<string>());
 
             var indexResults = (IndexingResults)indexEngine.Run();
             var peptideIndex = indexResults.PeptideIndex;
@@ -486,14 +486,15 @@ namespace Test
             Tolerance DeconvolutionMassTolerance = new PpmTolerance(5);
 
             var listOfSortedms2Scans = MetaMorpheusTask.GetMs2Scans(myMsDataFile, null, DoPrecursorDeconvolution, UseProvidedPrecursorInfo, DeconvolutionIntensityRatio, DeconvolutionMaxAssumedChargeState, DeconvolutionMassTolerance).OrderBy(b => b.PrecursorMass).ToArray();
-            MassDiffAcceptor massDiffAcceptor = SearchTask.GetMassDiffAcceptor(CommonParameters.PrecursorMassTolerance, SearchParameters.MassDiffAcceptorType, SearchParameters.CustomMdac);
+            MassDiffAcceptor massDiffAcceptor = SearchTask.GetMassDiffAcceptor(commonParameters.PrecursorMassTolerance, SearchParameters.MassDiffAcceptorType, SearchParameters.CustomMdac);
 
             PeptideSpectralMatch[] allPsmsArray = new PeptideSpectralMatch[listOfSortedms2Scans.Length];
-            CommonParameters = new CommonParameters(
-               digestionParams: new DigestionParams(protease: protease.Name, minPeptideLength: 5),
-               precursorMassTolerance: new PpmTolerance(5),
-               scoreCutoff: 4);
-            var engine = new NonSpecificEnzymeSearchEngine(allPsmsArray, listOfSortedms2Scans, peptideIndex, fragmentIndexDict, fragmentIndexDict, new List<ProductType> { ProductType.Y }, 0, CommonParameters, massDiffAcceptor, SearchParameters.MaximumMassThatFragmentIonScoreIsDoubled, new List<string>());
+            commonParameters = new CommonParameters();
+            commonParameters.DigestionParams = new DigestionParams(protease: protease.Name, minPeptideLength: 5);
+            commonParameters.PrecursorMassTolerance = new PpmTolerance(5);
+            commonParameters.ScoreCutoff = 4;
+
+            var engine = new NonSpecificEnzymeSearchEngine(allPsmsArray, listOfSortedms2Scans, peptideIndex, fragmentIndexDict, fragmentIndexDict, new List<ProductType> { ProductType.Y }, 0, commonParameters, massDiffAcceptor, SearchParameters.MaximumMassThatFragmentIonScoreIsDoubled, new List<string>());
             var searchResults = engine.Run();
 
             // Single search mode
@@ -506,14 +507,14 @@ namespace Test
             Assert.IsTrue(allPsmsArray[0].Score > 4);
             Assert.AreEqual(2, allPsmsArray[0].ScanNumber);
 
-            CommonParameters = new CommonParameters(
-               digestionParams: new DigestionParams(protease: protease.Name, minPeptideLength: 1),
-               precursorMassTolerance: new PpmTolerance(5),
-               scoreCutoff: 4);
+            commonParameters = new CommonParameters();
+            commonParameters.DigestionParams = new DigestionParams(protease: protease.Name, minPeptideLength: 1);
+            commonParameters.PrecursorMassTolerance = new PpmTolerance(5);
+            commonParameters.ScoreCutoff = 4;
 
             Dictionary<CompactPeptideBase, HashSet<PeptideWithSetModifications>> compactPeptideToProteinPeptideMatching = new Dictionary<CompactPeptideBase, HashSet<PeptideWithSetModifications>>();
             new NonSpecificEnzymeSequencesToActualPeptides(compactPeptideToProteinPeptideMatching, new List<PeptideSpectralMatch>
-            { allPsmsArray[0] }, proteinList, fixedModifications, variableModifications, new List<ProductType> { ProductType.Y }, new List<DigestionParams> { CommonParameters.DigestionParams }, massDiffAcceptor, CommonParameters.ReportAllAmbiguity, CommonParameters, new List<string>()).Run();
+            { allPsmsArray[0] }, proteinList, fixedModifications, variableModifications, new List<ProductType> { ProductType.Y }, new List<DigestionParams> { commonParameters.DigestionParams }, massDiffAcceptor, commonParameters.ReportAllAmbiguity, commonParameters, new List<string>()).Run();
 
             foreach (var huh in allPsmsArray)
             {
@@ -588,20 +589,20 @@ namespace Test
             var searchModes = new SinglePpmAroundZeroSearchMode(5);
             var protease = new Protease("singleN3", new List<Tuple<string, TerminusType>> { new Tuple<string, TerminusType>("K", TerminusType.C) }, new List<Tuple<string, TerminusType>>(), CleavageSpecificity.None, null, null, null);
             ProteaseDictionary.Dictionary.Add(protease.Name, protease);
-            CommonParameters CommonParameters = new CommonParameters(
-                productMassTolerance: productMassTolerance,
-                digestionParams: new DigestionParams(protease: protease.Name, minPeptideLength: 5, maxModsForPeptides: 2, semiProteaseDigestion: true),
-                yIons: false,
-                scoreCutoff: 2,
-                addCompIons: true);
+            CommonParameters commonParameters = new CommonParameters();
+            commonParameters.ProductMassTolerance = productMassTolerance;
+            commonParameters.DigestionParams = new DigestionParams(protease: protease.Name, minPeptideLength: 5, maxModsForPeptides: 2, semiProteaseDigestion: true);
+            commonParameters.YIons = false;
+            commonParameters.ScoreCutoff = 2;
+            commonParameters.AddCompIons = true;
 
-            HashSet<DigestionParams> digestParams = new HashSet<DigestionParams> { CommonParameters.DigestionParams };
-            var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.B }, 1, DecoyType.Reverse, digestParams, CommonParameters, 100000, new List<string>());
+            HashSet<DigestionParams> digestParams = new HashSet<DigestionParams> { commonParameters.DigestionParams };
+            var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.B }, 1, DecoyType.Reverse, digestParams, commonParameters, 100000, new List<string>());
             var indexResults = (IndexingResults)indexEngine.Run();
             var peptideIndex = indexResults.PeptideIndex;
             var fragmentIndexDict = indexResults.FragmentIndex;
 
-            var precursorIndexEngine = new PrecursorIndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.B }, 1, DecoyType.Reverse, digestParams, CommonParameters, 100000, new List<string>());
+            var precursorIndexEngine = new PrecursorIndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.B }, 1, DecoyType.Reverse, digestParams, commonParameters, 100000, new List<string>());
             var precursorIndexResults = (IndexingResults)precursorIndexEngine.Run();
             var precursorIndexDict = precursorIndexResults.FragmentIndex;
 
@@ -614,7 +615,7 @@ namespace Test
             var listOfSortedms2Scans = MetaMorpheusTask.GetMs2Scans(myMsDataFile, null, DoPrecursorDeconvolution, UseProvidedPrecursorInfo, DeconvolutionIntensityRatio, DeconvolutionMaxAssumedChargeState, DeconvolutionMassTolerance).OrderBy(b => b.PrecursorMass).ToArray();
 
             PeptideSpectralMatch[] allPsmsArray = new PeptideSpectralMatch[listOfSortedms2Scans.Length];
-            var engine = new NonSpecificEnzymeSearchEngine(allPsmsArray, listOfSortedms2Scans, peptideIndex, fragmentIndexDict, precursorIndexDict, new List<ProductType> { ProductType.B }, 1, CommonParameters, searchModes, 0, new List<string>());
+            var engine = new NonSpecificEnzymeSearchEngine(allPsmsArray, listOfSortedms2Scans, peptideIndex, fragmentIndexDict, precursorIndexDict, new List<ProductType> { ProductType.B }, 1, commonParameters, searchModes, 0, new List<string>());
             var searchResults = engine.Run();
 
             // Single search mode
@@ -627,7 +628,7 @@ namespace Test
             Assert.AreEqual(2, allPsmsArray[0].ScanNumber);
 
             Dictionary<CompactPeptideBase, HashSet<PeptideWithSetModifications>> compactPeptideToProteinPeptideMatching = new Dictionary<CompactPeptideBase, HashSet<PeptideWithSetModifications>>();
-            new NonSpecificEnzymeSequencesToActualPeptides(compactPeptideToProteinPeptideMatching, new List<PeptideSpectralMatch> { allPsmsArray[0] }, proteinList, fixedModifications, variableModifications, new List<ProductType> { ProductType.B }, digestParams, searchModes, CommonParameters.ReportAllAmbiguity, CommonParameters, new List<string>()).Run();
+            new NonSpecificEnzymeSequencesToActualPeptides(compactPeptideToProteinPeptideMatching, new List<PeptideSpectralMatch> { allPsmsArray[0] }, proteinList, fixedModifications, variableModifications, new List<ProductType> { ProductType.B }, digestParams, searchModes, commonParameters.ReportAllAmbiguity, commonParameters, new List<string>()).Run();
 
             foreach (var huh in allPsmsArray)
             {
@@ -670,15 +671,15 @@ namespace Test
             var searchModes = new SinglePpmAroundZeroSearchMode(5);
             var protease = new Protease("singleC3", new List<Tuple<string, TerminusType>> { new Tuple<string, TerminusType>("G", TerminusType.C) }, new List<Tuple<string, TerminusType>>(), CleavageSpecificity.None, null, null, null);
             ProteaseDictionary.Dictionary.Add(protease.Name, protease);
-            CommonParameters CommonParameters = new CommonParameters(
-                scoreCutoff: 1,
-                productMassTolerance: productMassTolerance,
-                digestionParams: new DigestionParams(protease: protease.Name, maxMissedCleavages: 5, minPeptideLength: 5, semiProteaseDigestion: true, terminusTypeSemiProtease: TerminusType.C),
-                bIons: false,
-                addCompIons: true);
+            CommonParameters commonParameters = new CommonParameters();
+            commonParameters.ScoreCutoff = 1;
+            commonParameters.ProductMassTolerance = productMassTolerance;
+            commonParameters.DigestionParams = new DigestionParams(protease: protease.Name, maxMissedCleavages: 5, minPeptideLength: 5, semiProteaseDigestion: true, terminusTypeSemiProtease: TerminusType.C);
+            commonParameters.BIons = false;
+            commonParameters.AddCompIons = true;
 
-            HashSet<DigestionParams> digestParams = new HashSet<DigestionParams> { CommonParameters.DigestionParams };
-            var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.Y }, 1, DecoyType.Reverse, digestParams, CommonParameters, 30000, new List<string>());
+            HashSet<DigestionParams> digestParams = new HashSet<DigestionParams> { commonParameters.DigestionParams };
+            var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, new List<ProductType> { ProductType.Y }, 1, DecoyType.Reverse, digestParams, commonParameters, 30000, new List<string>());
             var indexResults = (IndexingResults)indexEngine.Run();
             var peptideIndex = indexResults.PeptideIndex;
             var fragmentIndexDict = indexResults.FragmentIndex;
@@ -692,7 +693,7 @@ namespace Test
             var listOfSortedms2Scans = MetaMorpheusTask.GetMs2Scans(myMsDataFile, null, DoPrecursorDeconvolution, UseProvidedPrecursorInfo, DeconvolutionIntensityRatio, DeconvolutionMaxAssumedChargeState, DeconvolutionMassTolerance).OrderBy(b => b.PrecursorMass).ToArray();
 
             PeptideSpectralMatch[] allPsmsArray = new PeptideSpectralMatch[listOfSortedms2Scans.Length];
-            var engine = new NonSpecificEnzymeSearchEngine(allPsmsArray, listOfSortedms2Scans, peptideIndex, fragmentIndexDict, fragmentIndexDict, new List<ProductType> { ProductType.Y }, 1, CommonParameters, searchModes, 0, new List<string>());
+            var engine = new NonSpecificEnzymeSearchEngine(allPsmsArray, listOfSortedms2Scans, peptideIndex, fragmentIndexDict, fragmentIndexDict, new List<ProductType> { ProductType.Y }, 1, commonParameters, searchModes, 0, new List<string>());
             var searchResults = engine.Run();
 
             // Single search mode
@@ -705,7 +706,7 @@ namespace Test
             Assert.AreEqual(2, allPsmsArray[0].ScanNumber);
 
             Dictionary<CompactPeptideBase, HashSet<PeptideWithSetModifications>> compactPeptideToProteinPeptideMatching = new Dictionary<CompactPeptideBase, HashSet<PeptideWithSetModifications>>();
-            new NonSpecificEnzymeSequencesToActualPeptides(compactPeptideToProteinPeptideMatching, new List<PeptideSpectralMatch> { allPsmsArray[0] }, proteinList, fixedModifications, variableModifications, new List<ProductType> { ProductType.Y }, digestParams, searchModes, CommonParameters.ReportAllAmbiguity, CommonParameters, new List<string>()).Run();
+            new NonSpecificEnzymeSequencesToActualPeptides(compactPeptideToProteinPeptideMatching, new List<PeptideSpectralMatch> { allPsmsArray[0] }, proteinList, fixedModifications, variableModifications, new List<ProductType> { ProductType.Y }, digestParams, searchModes, commonParameters.ReportAllAmbiguity, commonParameters, new List<string>()).Run();
 
             foreach (var huh in allPsmsArray)
             {
@@ -748,12 +749,11 @@ namespace Test
             var protease2 = new Protease("semi-trypsin2", new List<Tuple<string, TerminusType>> { new Tuple<string, TerminusType>("N", TerminusType.C) }, new List<Tuple<string, TerminusType>>(), CleavageSpecificity.Semi, null, null, null);
             ProteaseDictionary.Dictionary.Add(protease.Name, protease);
             ProteaseDictionary.Dictionary.Add(protease2.Name, protease2);
-            CommonParameters CommonParameters = new CommonParameters(
-                productMassTolerance: productMassTolerance,
-                digestionParams: new DigestionParams(protease: protease.Name, maxMissedCleavages: 5)
-                );
+            CommonParameters commonParameters = new CommonParameters();
+            commonParameters.ProductMassTolerance = productMassTolerance;
+            commonParameters.DigestionParams = new DigestionParams(protease: protease.Name, maxMissedCleavages: 5);
 
-            HashSet<DigestionParams> digestParams = new HashSet<DigestionParams> { CommonParameters.DigestionParams };
+            HashSet<DigestionParams> digestParams = new HashSet<DigestionParams> { commonParameters.DigestionParams };
 
             bool DoPrecursorDeconvolution = true;
             bool UseProvidedPrecursorInfo = true;
@@ -764,17 +764,15 @@ namespace Test
             var listOfSortedms2Scans = MetaMorpheusTask.GetMs2Scans(myMsDataFile, null, DoPrecursorDeconvolution, UseProvidedPrecursorInfo, DeconvolutionIntensityRatio, DeconvolutionMaxAssumedChargeState, DeconvolutionMassTolerance).OrderBy(b => b.PrecursorMass).ToArray();
 
             PeptideSpectralMatch[] allPsmsArray = new PeptideSpectralMatch[listOfSortedms2Scans.Length];
-            new ClassicSearchEngine(allPsmsArray, listOfSortedms2Scans, variableModifications, fixedModifications, proteinList, new List<ProductType> { ProductType.B, ProductType.Y }, searchModes, CommonParameters, new List<string>()).Run();
+            new ClassicSearchEngine(allPsmsArray, listOfSortedms2Scans, variableModifications, fixedModifications, proteinList, new List<ProductType> { ProductType.B, ProductType.Y }, searchModes, commonParameters, new List<string>()).Run();
 
             //////////////////////////////
 
-            CommonParameters CommonParameters2 = new CommonParameters
-            (
-                productMassTolerance: productMassTolerance,
-                digestionParams: new DigestionParams(protease: protease2.Name, maxMissedCleavages: 5)
-            );
+            CommonParameters commonParameters2 = new CommonParameters();
+            commonParameters2.ProductMassTolerance = productMassTolerance;
+            commonParameters2.DigestionParams = new DigestionParams(protease: protease2.Name, maxMissedCleavages: 5);
 
-            HashSet<DigestionParams> digestParams2 = new HashSet<DigestionParams> { CommonParameters2.DigestionParams };
+            HashSet<DigestionParams> digestParams2 = new HashSet<DigestionParams> { commonParameters2.DigestionParams };
 
             bool DoPrecursorDeconvolution2 = true;
             bool UseProvidedPrecursorInfo2 = true;
@@ -785,7 +783,7 @@ namespace Test
             var listOfSortedms2Scans2 = MetaMorpheusTask.GetMs2Scans(myMsDataFile, null, DoPrecursorDeconvolution2, UseProvidedPrecursorInfo2, DeconvolutionIntensityRatio2, DeconvolutionMaxAssumedChargeState2, DeconvolutionMassTolerance2).OrderBy(b => b.PrecursorMass).ToArray();
 
             PeptideSpectralMatch[] allPsmsArray2 = new PeptideSpectralMatch[listOfSortedms2Scans2.Length];
-            new ClassicSearchEngine(allPsmsArray2, listOfSortedms2Scans2, variableModifications, fixedModifications, proteinList, new List<ProductType> { ProductType.B, ProductType.Y }, searchModes, CommonParameters2, new List<string>()).Run();
+            new ClassicSearchEngine(allPsmsArray2, listOfSortedms2Scans2, variableModifications, fixedModifications, proteinList, new List<ProductType> { ProductType.B, ProductType.Y }, searchModes, commonParameters2, new List<string>()).Run();
             // Single search mode
             Assert.AreEqual(1, allPsmsArray2.Length);
             Assert.AreEqual(allPsmsArray.Length, allPsmsArray2.Length);
@@ -799,8 +797,8 @@ namespace Test
             Assert.AreEqual(2, allPsmsArray2[0].ScanNumber);
             Assert.AreEqual(allPsmsArray[0].ScanNumber, allPsmsArray2[0].ScanNumber);
 
-            var hah = (SequencesToActualProteinPeptidesEngineResults)new SequencesToActualProteinPeptidesEngine(new List<PeptideSpectralMatch> { allPsmsArray[0] }, proteinList, fixedModifications, variableModifications, new List<ProductType> { ProductType.B, ProductType.Y }, digestParams, CommonParameters.ReportAllAmbiguity, CommonParameters, new List<string>()).Run();
-            var hah2 = (SequencesToActualProteinPeptidesEngineResults)new SequencesToActualProteinPeptidesEngine(new List<PeptideSpectralMatch> { allPsmsArray2[0] }, proteinList, fixedModifications, variableModifications, new List<ProductType> { ProductType.B, ProductType.Y }, digestParams2, CommonParameters.ReportAllAmbiguity, CommonParameters, new List<string>()).Run();
+            var hah = (SequencesToActualProteinPeptidesEngineResults)new SequencesToActualProteinPeptidesEngine(new List<PeptideSpectralMatch> { allPsmsArray[0] }, proteinList, fixedModifications, variableModifications, new List<ProductType> { ProductType.B, ProductType.Y }, digestParams, commonParameters.ReportAllAmbiguity, commonParameters, new List<string>()).Run();
+            var hah2 = (SequencesToActualProteinPeptidesEngineResults)new SequencesToActualProteinPeptidesEngine(new List<PeptideSpectralMatch> { allPsmsArray2[0] }, proteinList, fixedModifications, variableModifications, new List<ProductType> { ProductType.B, ProductType.Y }, digestParams2, commonParameters.ReportAllAmbiguity, commonParameters, new List<string>()).Run();
 
             foreach (var huh in allPsmsArray)
             {

--- a/Test/SearchWithPeptidesAddedInParsimony.cs
+++ b/Test/SearchWithPeptidesAddedInParsimony.cs
@@ -18,6 +18,10 @@ namespace Test
         public static void SearchWithPeptidesAddedInParsimonyTest()
         {
             // Make sure can run the complete search task when multiple compact peptides may correspond to a single PWSM
+            CommonParameters c = new CommonParameters();
+            c.ScoreCutoff = 1;
+            c.DigestionParams = new DigestionParams(minPeptideLength: 2);
+
             SearchTask st = new SearchTask
             {
                 SearchParameters = new SearchParameters
@@ -26,19 +30,19 @@ namespace Test
                     DecoyType = DecoyType.None,
                     ModPeptidesAreDifferent = false
                 },
-                CommonParameters = new CommonParameters(scoreCutoff: 1, digestionParams: new DigestionParams(minPeptideLength: 2)),
+                CommonParameters = c
             };
 
             string xmlName = "andguiaheow.xml";
 
-            CommonParameters CommonParameters = new CommonParameters(
-                scoreCutoff: 1,
-                digestionParams: new DigestionParams(
-                    maxMissedCleavages: 0,
-                    minPeptideLength: 1,
-                    maxModificationIsoforms: 2,
-                    initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain,
-                    maxModsForPeptides: 1));
+            CommonParameters commonParameters = new CommonParameters();
+            commonParameters.ScoreCutoff = 1;
+            commonParameters.DigestionParams = new DigestionParams(
+                maxMissedCleavages: 0,
+                minPeptideLength: 1,
+                maxModificationIsoforms: 2,
+                initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain,
+                maxModsForPeptides: 1);
 
             ModificationMotif.TryGetMotif("A", out ModificationMotif motifA);
             ModificationWithMass alanineMod = new ModificationWithMass("111", "mt", motifA, TerminusLocalization.Any, 111);
@@ -61,10 +65,10 @@ namespace Test
                 };
             Protein protein2 = new Protein("MG", "protein3", oneBasedModifications: oneBasedModifications2);
 
-            PeptideWithSetModifications pepMA = protein1.Digest(CommonParameters.DigestionParams, new List<ModificationWithMass>(), variableModifications).First();
-            PeptideWithSetModifications pepMA111 = protein1.Digest(CommonParameters.DigestionParams, new List<ModificationWithMass>(), variableModifications).Last();
+            PeptideWithSetModifications pepMA = protein1.Digest(commonParameters.DigestionParams, new List<ModificationWithMass>(), variableModifications).First();
+            PeptideWithSetModifications pepMA111 = protein1.Digest(commonParameters.DigestionParams, new List<ModificationWithMass>(), variableModifications).Last();
 
-            var pepMG = protein2.Digest(CommonParameters.DigestionParams, new List<ModificationWithMass>(), variableModifications).First();
+            var pepMG = protein2.Digest(commonParameters.DigestionParams, new List<ModificationWithMass>(), variableModifications).First();
 
             ProteinDbWriter.WriteXmlDatabase(new Dictionary<string, HashSet<Tuple<int, Modification>>>(), new List<Protein> { protein1, protein2 }, xmlName);
 

--- a/Test/StefanParsimonyTest.cs
+++ b/Test/StefanParsimonyTest.cs
@@ -249,7 +249,14 @@ namespace Test
 
         private static Tuple<List<PeptideSpectralMatch>, Dictionary<CompactPeptideBase, HashSet<PeptideWithSetModifications>>, MassDiffAcceptor, bool, CompactPeptideBase, CompactPeptideBase> GetInfo(bool localizeable)
         {
-            CommonParameters CommonParameters = new CommonParameters(digestionParams: new DigestionParams(maxMissedCleavages: 0, minPeptideLength: 1, maxModificationIsoforms: 2, initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain, maxModsForPeptides: 1), scoreCutoff: 1);
+            CommonParameters commonParams = new CommonParameters();
+            commonParams.DigestionParams = new DigestionParams(
+                maxMissedCleavages: 0,
+                minPeptideLength: 1,
+                maxModificationIsoforms: 2,
+                initiatorMethionineBehavior: InitiatorMethionineBehavior.Retain,
+                maxModsForPeptides: 1);
+            commonParams.ScoreCutoff = 1;
 
             // Alanine = Glycine + CH2
             Protein protein1 = new Protein("MA", "protein1");
@@ -283,11 +290,11 @@ namespace Test
                 protein3 = new Protein("MA", "protein3");
             }
 
-            var pepWithSetModifications1 = protein1.Digest(CommonParameters.DigestionParams, allKnownFixedModifications, variableModifications).First();
+            var pepWithSetModifications1 = protein1.Digest(commonParams.DigestionParams, allKnownFixedModifications, variableModifications).First();
 
-            var pepWithSetModifications2 = protein2.Digest(CommonParameters.DigestionParams, allKnownFixedModifications, variableModifications).First();
+            var pepWithSetModifications2 = protein2.Digest(commonParams.DigestionParams, allKnownFixedModifications, variableModifications).First();
 
-            var pepWithSetModifications3 = protein3.Digest(CommonParameters.DigestionParams, allKnownFixedModifications, variableModifications).Last();
+            var pepWithSetModifications3 = protein3.Digest(commonParams.DigestionParams, allKnownFixedModifications, variableModifications).Last();
 
             CompactPeptide compactPeptide1 = new CompactPeptide(pepWithSetModifications1, TerminusType.None);
             CompactPeptide compactPeptideDuplicate = new CompactPeptide(pepWithSetModifications2, TerminusType.None);
@@ -302,11 +309,11 @@ namespace Test
             int scanIndex = 0;
             double score = 0;
             int notch = 0;
-            PeptideSpectralMatch psm1 = new PeptideSpectralMatch(compactPeptide1, notch, score, scanIndex, scan, CommonParameters.DigestionParams);
+            PeptideSpectralMatch psm1 = new PeptideSpectralMatch(compactPeptide1, notch, score, scanIndex, scan, commonParams.DigestionParams);
             psm1.SetFdrValues(0, 0, 0, 0, 0, 0, 0, 0, 0, false);
-            PeptideSpectralMatch psm2 = new PeptideSpectralMatch(compactPeptide1, notch, score, scanIndex, scan, CommonParameters.DigestionParams);
+            PeptideSpectralMatch psm2 = new PeptideSpectralMatch(compactPeptide1, notch, score, scanIndex, scan, commonParams.DigestionParams);
             psm2.SetFdrValues(0, 0, 0, 0, 0, 0, 0, 0, 0, false);
-            PeptideSpectralMatch psm3 = new PeptideSpectralMatch(compactPeptide2, notch, score, scanIndex, scan, CommonParameters.DigestionParams);
+            PeptideSpectralMatch psm3 = new PeptideSpectralMatch(compactPeptide2, notch, score, scanIndex, scan, commonParams.DigestionParams);
             psm3.SetFdrValues(0, 0, 0, 0, 0, 0, 0, 0, 0, false);
             var newPsms = new List<PeptideSpectralMatch>
             {
@@ -317,7 +324,7 @@ namespace Test
 
             MassDiffAcceptor massDiffAcceptors = new SinglePpmAroundZeroSearchMode(5);
             SequencesToActualProteinPeptidesEngine stappe = new SequencesToActualProteinPeptidesEngine(newPsms, new List<Protein> { protein1, protein2, protein3 },
-                allKnownFixedModifications, variableModifications, new List<ProductType> { ProductType.B, ProductType.Y }, new List<DigestionParams> { CommonParameters.DigestionParams }, CommonParameters.ReportAllAmbiguity, new CommonParameters(), new List<string>());
+                allKnownFixedModifications, variableModifications, new List<ProductType> { ProductType.B, ProductType.Y }, new List<DigestionParams> { commonParams.DigestionParams }, commonParams.ReportAllAmbiguity, new CommonParameters(), new List<string>());
 
             var haha = (SequencesToActualProteinPeptidesEngineResults)stappe.Run();
             var compactPeptideToProteinPeptideMatching = haha.CompactPeptideToProteinPeptideMatching;

--- a/Test/TestPsm.cs
+++ b/Test/TestPsm.cs
@@ -49,7 +49,10 @@ namespace Test
             Tolerance fragmentTolerance = new PpmTolerance(10);
             List<ProductType> lp = new List<ProductType> { ProductType.B };
 
-            new LocalizationEngine(new List<PeptideSpectralMatch> { psm }, lp, myMsDataFile, new CommonParameters(productMassTolerance: fragmentTolerance), new List<string>()).Run();
+            CommonParameters c = new CommonParameters();
+            c.ProductMassTolerance = fragmentTolerance;
+
+            new LocalizationEngine(new List<PeptideSpectralMatch> { psm }, lp, myMsDataFile, c, new List<string>()).Run();
 
             Assert.AreEqual(psm.ToString().Count(f => f == '\t'), PeptideSpectralMatch.GetTabSeparatedHeader().Count(f => f == '\t'));
 

--- a/Test/TestToml.cs
+++ b/Test/TestToml.cs
@@ -15,13 +15,13 @@ namespace Test
         [Test]
         public static void TestTomlFunction()
         {
-            SearchTask searchTask = new SearchTask
-            {
-                CommonParameters = new CommonParameters(
-                    productMassTolerance: new PpmTolerance(666),
-                    listOfModsFixed: new List<(string, string)> { ("a", "b"), ("c", "d") },
-                    listOfModsVariable: new List<(string, string)> { ("e", "f"), ("g", "h") }),
-            };
+            CommonParameters c = new CommonParameters();
+            c.ProductMassTolerance = new PpmTolerance(666);
+            c.ListOfModsFixed = new List<(string, string)> { ("a", "b"), ("c", "d") };
+            c.ListOfModsVariable = new List<(string, string)> { ("e", "f"), ("g", "h") };
+
+            SearchTask searchTask = new SearchTask { CommonParameters = c };
+
             Toml.WriteFile(searchTask, "SearchTask.toml", MetaMorpheusTask.tomlConfig);
             var searchTaskLoaded = Toml.ReadFile<SearchTask>("SearchTask.toml", MetaMorpheusTask.tomlConfig);
 

--- a/Test/gptmdPrunedBdTests.cs
+++ b/Test/gptmdPrunedBdTests.cs
@@ -46,10 +46,10 @@ namespace Test
             engine.Run();
             string final = Path.Combine(MySetUpClass.outputFolder, "task2", "DbForPrunedDbGPTMDproteinPruned.xml");
             List<Protein> proteins = ProteinDbLoader.LoadProteinXML(final, true, DecoyType.Reverse, new List<Modification>(), false, new List<string>(), out var ok);
-            //ensures that protein out put contins the correct number of proteins to match the folowing conditions. 
-                // all proteins in DB have baseSequence!=null (not ambiguous)
-                // all proteins that belong to a protein group are written to DB
-            Assert.AreEqual(proteins.Count(),20);
+            //ensures that protein out put contins the correct number of proteins to match the folowing conditions.
+            // all proteins in DB have baseSequence!=null (not ambiguous)
+            // all proteins that belong to a protein group are written to DB
+            Assert.AreEqual(proteins.Count(), 20);
             int totalNumberOfMods = 0;
             foreach (Protein p in proteins)
             {
@@ -64,6 +64,9 @@ namespace Test
         [Test]
         public static void TestPrunedDatabase()
         {
+            CommonParameters c = new CommonParameters();
+            c.DigestionParams = new DigestionParams(minPeptideLength: 5);
+
             //Create Search Task
             SearchTask task1 = new SearchTask
             {
@@ -77,7 +80,7 @@ namespace Test
                         {"ConnorModType", 1}
                     }
                 },
-                CommonParameters = new CommonParameters(digestionParams: new DigestionParams(minPeptideLength: 5))
+                CommonParameters = c
             };
 
             //add task to task list
@@ -160,6 +163,9 @@ namespace Test
         public static void TestUserModSelectionInPrunedDB()
         {
             List<(string, string)> listOfModsFixed = new List<(string, string)> { ("Common Fixed", "Carbamidomethyl of C"), ("Common Fixed", "Carbamidomethyl of U") };
+            CommonParameters c = new CommonParameters();
+            c.ListOfModsFixed = listOfModsFixed;
+
             //Create Search Task
             SearchTask task5 = new SearchTask
             {
@@ -169,7 +175,7 @@ namespace Test
                     SearchTarget = true,
                     MassDiffAcceptorType = MassDiffAcceptorType.Exact,
                 },
-                CommonParameters = new CommonParameters(listOfModsFixed: listOfModsFixed)
+                CommonParameters = c
             };
 
             task5.SearchParameters.ModsToWriteSelection["Mod"] = 0;


### PR DESCRIPTION
This change makes it so we don't have to add a new parameter in 3 places every time we add a parameter to the ComonParameters class. I also think using default initializers on the parameters makes it easier to see which have defaults set. 