### PR TITLE
Smaller refactor to common parameters

### DIFF
--- a/EngineLayer/CommonParameters.cs
+++ b/EngineLayer/CommonParameters.cs
@@ -72,13 +72,14 @@ namespace EngineLayer
             ListOfModsFixed = listOfModsFixed ?? new List<(string, string)> { ("Common Fixed", "Carbamidomethyl of C"), ("Common Fixed", "Carbamidomethyl of U") };
         }
 
-        // Note:
-        // Any new property must not be nullable (int?) or else if it is null,
-        // the null setting will not be written to a toml
-        // and the default will override (so it's okay if the default is null)
+        // Notes:
+        // 1) Any new property must not be nullable (int?) or else if it is null,
+        //    the null setting will not be written to a toml
+        //    and the default will override (so it's okay if the default is null)
+        // 2) All setters should be private unless necessary
 
         public string TaskDescriptor { get; private set; }
-        public int MaxThreadsToUsePerFile { get; set; }
+        public int MaxThreadsToUsePerFile { get; private set; }
         public IEnumerable<(string, string)> ListOfModsFixed { get; private set; }
         public IEnumerable<(string, string)> ListOfModsVariable { get; private set; }
         public bool DoPrecursorDeconvolution { get; private set; }

--- a/EngineLayer/CommonParameters.cs
+++ b/EngineLayer/CommonParameters.cs
@@ -2,6 +2,7 @@
 using Proteomics.ProteolyticDigestion;
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace EngineLayer
 {
@@ -9,16 +10,40 @@ namespace EngineLayer
     {
         // this parameterless constructor needs to exist to read the toml.
         // if you can figure out a way to get rid of it, feel free...
-        public CommonParameters() : this(digestionParams: null)
+        public CommonParameters()
+            : this(digestionParams: null)
         {
         }
 
-        public CommonParameters(bool bIons = true, bool yIons = true, bool zDotIons = false, bool cIons = false, bool doPrecursorDeconvolution = true,
-            bool useProvidedPrecursorInfo = true, double deconvolutionIntensityRatio = 3, int deconvolutionMaxAssumedChargeState = 12, bool reportAllAmbiguity = true,
-            bool addCompIons = false, int totalPartitions = 1, double scoreCutoff = 5, int topNpeaks = 200, double minRatio = 0.01, bool trimMs1Peaks = false,
-            bool trimMsMsPeaks = true, bool useDeltaScore = false, bool calculateEValue = false, Tolerance productMassTolerance = null, Tolerance precursorMassTolerance = null, Tolerance deconvolutionMassTolerance = null,
-            int maxThreadsToUsePerFile = -1, DigestionParams digestionParams = null, IEnumerable<(string, string)> listOfModsVariable = null, IEnumerable<(string, string)> listOfModsFixed = null)
+        public CommonParameters(
+            string taskDescriptor = null,
+            bool bIons = true,
+            bool yIons = true,
+            bool zDotIons = false,
+            bool cIons = false,
+            bool doPrecursorDeconvolution = true,
+            bool useProvidedPrecursorInfo = true,
+            double deconvolutionIntensityRatio = 3,
+            int deconvolutionMaxAssumedChargeState = 12,
+            bool reportAllAmbiguity = true,
+            bool addCompIons = false,
+            int totalPartitions = 1,
+            double scoreCutoff = 5,
+            int topNpeaks = 200,
+            double minRatio = 0.01,
+            bool trimMs1Peaks = false,
+            bool trimMsMsPeaks = true,
+            bool useDeltaScore = false,
+            bool calculateEValue = false,
+            Tolerance productMassTolerance = null,
+            Tolerance precursorMassTolerance = null,
+            Tolerance deconvolutionMassTolerance = null,
+            int maxThreadsToUsePerFile = -1,
+            DigestionParams digestionParams = null,
+            IEnumerable<(string, string)> listOfModsVariable = null,
+            IEnumerable<(string, string)> listOfModsFixed = null)
         {
+            TaskDescriptor = taskDescriptor;
             BIons = bIons;
             YIons = yIons;
             ZdotIons = zDotIons;
@@ -37,7 +62,7 @@ namespace EngineLayer
             TrimMsMsPeaks = trimMsMsPeaks;
             UseDeltaScore = useDeltaScore;
             CalculateEValue = calculateEValue;
-            MaxThreadsToUsePerFile = maxThreadsToUsePerFile;
+            MaxThreadsToUsePerFile = maxThreadsToUsePerFile == -1 ? Environment.ProcessorCount > 1 ? Environment.ProcessorCount - 1 : 1 : maxThreadsToUsePerFile;
 
             ProductMassTolerance = productMassTolerance ?? new PpmTolerance(20);
             PrecursorMassTolerance = precursorMassTolerance ?? new PpmTolerance(5);
@@ -45,20 +70,14 @@ namespace EngineLayer
             DigestionParams = digestionParams ?? new DigestionParams();
             ListOfModsVariable = listOfModsVariable ?? new List<(string, string)> { ("Common Variable", "Oxidation of M") };
             ListOfModsFixed = listOfModsFixed ?? new List<(string, string)> { ("Common Fixed", "Carbamidomethyl of C"), ("Common Fixed", "Carbamidomethyl of U") };
-
-            if (maxThreadsToUsePerFile == -1)
-            {
-                MaxThreadsToUsePerFile = Environment.ProcessorCount > 1 ? Environment.ProcessorCount - 1 : 1;
-            }
-            else
-            {
-                MaxThreadsToUsePerFile = maxThreadsToUsePerFile;
-            }
         }
 
-        //Any new property must not be nullable (int?) or else if it is null, the null setting will not be written to a toml and the default will override (so it's okay if the default is null)
-        public string TaskDescriptor { get; set; }
+        // Note:
+        // Any new property must not be nullable (int?) or else if it is null,
+        // the null setting will not be written to a toml
+        // and the default will override (so it's okay if the default is null)
 
+        public string TaskDescriptor { get; private set; }
         public int MaxThreadsToUsePerFile { get; set; }
         public IEnumerable<(string, string)> ListOfModsFixed { get; private set; }
         public IEnumerable<(string, string)> ListOfModsVariable { get; private set; }
@@ -72,8 +91,8 @@ namespace EngineLayer
         public bool YIons { get; private set; }
         public bool ZdotIons { get; private set; }
         public bool CIons { get; private set; }
-        public Tolerance ProductMassTolerance { get; private set; }
-        public Tolerance PrecursorMassTolerance { get; private set; }
+        public Tolerance ProductMassTolerance { get; set; } // public setter required for calibration task
+        public Tolerance PrecursorMassTolerance { get; set; } // public setter required for calibration task
         public bool AddCompIons { get; private set; }
         public double ScoreCutoff { get; private set; }
         public DigestionParams DigestionParams { get; private set; }
@@ -87,48 +106,12 @@ namespace EngineLayer
 
         public CommonParameters Clone()
         {
-            return new CommonParameters(
-                bIons: this.BIons,
-                yIons: this.YIons,
-                zDotIons: this.ZdotIons,
-                cIons: this.CIons,
-                doPrecursorDeconvolution: this.DoPrecursorDeconvolution,
-                useProvidedPrecursorInfo: this.UseProvidedPrecursorInfo,
-                deconvolutionIntensityRatio: this.DeconvolutionIntensityRatio,
-                deconvolutionMaxAssumedChargeState: this.DeconvolutionMaxAssumedChargeState,
-                reportAllAmbiguity: this.ReportAllAmbiguity,
-                addCompIons: this.AddCompIons,
-                totalPartitions: this.TotalPartitions,
-                scoreCutoff: this.ScoreCutoff,
-                topNpeaks: this.TopNpeaks,
-                minRatio: this.MinRatio,
-                trimMs1Peaks: this.TrimMs1Peaks,
-                trimMsMsPeaks: this.TrimMsMsPeaks,
-                useDeltaScore: this.UseDeltaScore,
-                calculateEValue: this.CalculateEValue,
-                productMassTolerance: this.ProductMassTolerance,
-                precursorMassTolerance: this.PrecursorMassTolerance,
-                deconvolutionMassTolerance: this.DeconvolutionMassTolerance,
-                maxThreadsToUsePerFile: this.MaxThreadsToUsePerFile,
-                digestionParams: this.DigestionParams,
-                listOfModsVariable: this.ListOfModsVariable,
-                listOfModsFixed: this.ListOfModsFixed
-            );
-        }
-
-        public void SetProductMassTolerance(Tolerance ProductMassTolerance)
-        {
-            this.ProductMassTolerance = ProductMassTolerance;
-        }
-
-        public void SetPrecursorMassTolerance(Tolerance PrecursorMassTolerance)
-        {
-            this.PrecursorMassTolerance = PrecursorMassTolerance;
-        }
-
-        public void SetDigestionParams(DigestionParams DigestionParams)
-        {
-            this.DigestionParams = DigestionParams;
+            CommonParameters c = new CommonParameters();
+            foreach (PropertyInfo property in typeof(CommonParameters).GetProperties())
+            {
+                property.SetValue(c, property.GetValue(this));
+            }
+            return c;
         }
     }
 }

--- a/GUI/CalibrateTaskWindow.xaml.cs
+++ b/GUI/CalibrateTaskWindow.xaml.cs
@@ -225,7 +225,8 @@ namespace MetaMorpheusGUI
             {
                 PrecursorMassTolerance = new PpmTolerance(double.Parse(precursorMassToleranceTextBox.Text, CultureInfo.InvariantCulture));
             }
-            CommonParameters CommonParamsToSave = new CommonParameters(
+            CommonParameters commonParamsToSave = new CommonParameters(
+                taskDescriptor: OutputFileNameTextBox.Text != "" ? OutputFileNameTextBox.Text : "CalibrateTask",
                 digestionParams: digestionParamsToSave,
                 bIons: bCheckBox.IsChecked.Value,
                 yIons: yCheckBox.IsChecked.Value,
@@ -239,18 +240,10 @@ namespace MetaMorpheusGUI
 
             if (int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture) <= Environment.ProcessorCount && int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture) > 0)
             {
-                CommonParamsToSave.MaxThreadsToUsePerFile = int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture);
-            }
-            if (OutputFileNameTextBox.Text != "")
-            {
-                CommonParamsToSave.TaskDescriptor = OutputFileNameTextBox.Text;
-            }
-            else
-            {
-                CommonParamsToSave.TaskDescriptor = "CalibrateTask";
+                commonParamsToSave.MaxThreadsToUsePerFile = int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture);
             }
 
-            TheTask.CommonParameters = CommonParamsToSave;
+            TheTask.CommonParameters = commonParamsToSave;
 
             DialogResult = true;
         }

--- a/GUI/CalibrateTaskWindow.xaml.cs
+++ b/GUI/CalibrateTaskWindow.xaml.cs
@@ -225,8 +225,12 @@ namespace MetaMorpheusGUI
             {
                 PrecursorMassTolerance = new PpmTolerance(double.Parse(precursorMassToleranceTextBox.Text, CultureInfo.InvariantCulture));
             }
+
+            bool parseMaxThreadsPerFile = int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture) <= Environment.ProcessorCount && int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture) > 0;
+
             CommonParameters commonParamsToSave = new CommonParameters(
                 taskDescriptor: OutputFileNameTextBox.Text != "" ? OutputFileNameTextBox.Text : "CalibrateTask",
+                maxThreadsToUsePerFile: parseMaxThreadsPerFile ? int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture) : new CommonParameters().MaxThreadsToUsePerFile,
                 digestionParams: digestionParamsToSave,
                 bIons: bCheckBox.IsChecked.Value,
                 yIons: yCheckBox.IsChecked.Value,
@@ -237,11 +241,6 @@ namespace MetaMorpheusGUI
                 listOfModsVariable: listOfModsVariable,
                 productMassTolerance: ProductMassTolerance,
                 precursorMassTolerance: PrecursorMassTolerance);
-
-            if (int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture) <= Environment.ProcessorCount && int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture) > 0)
-            {
-                commonParamsToSave.MaxThreadsToUsePerFile = int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture);
-            }
 
             TheTask.CommonParameters = commonParamsToSave;
 

--- a/GUI/FileSpecificParametersWindow.xaml.cs
+++ b/GUI/FileSpecificParametersWindow.xaml.cs
@@ -178,12 +178,14 @@ namespace MetaMorpheusGUI
         private void PopulateChoices()
         {
             // use default settings to populate
-            var tempCommonParams = new CommonParameters();
-            Protease tempProtease = tempCommonParams.DigestionParams.Protease;
-            int tempMinPeptideLength = tempCommonParams.DigestionParams.MinPeptideLength;
-            int tempMaxPeptideLength = tempCommonParams.DigestionParams.MaxPeptideLength;
-            int tempMaxMissedCleavages = tempCommonParams.DigestionParams.MaxMissedCleavages;
-            int tempMaxModsForPeptide = tempCommonParams.DigestionParams.MaxModsForPeptide;
+            var defaultParams = new CommonParameters();
+            Protease tempProtease = defaultParams.DigestionParams.Protease;
+            int tempMinPeptideLength = defaultParams.DigestionParams.MinPeptideLength;
+            int tempMaxPeptideLength = defaultParams.DigestionParams.MaxPeptideLength;
+            int tempMaxMissedCleavages = defaultParams.DigestionParams.MaxMissedCleavages;
+            int tempMaxModsForPeptide = defaultParams.DigestionParams.MaxModsForPeptide;
+            var tempPrecursorMassTolerance = defaultParams.PrecursorMassTolerance;
+            var tempProductMassTolerance = defaultParams.ProductMassTolerance;
 
             // do any of the selected files already have file-specific parameters specified?
             var spectraFiles = SelectedSpectra.Select(p => p.FilePath);
@@ -198,12 +200,12 @@ namespace MetaMorpheusGUI
 
                     if (fileSpecificParams.PrecursorMassTolerance != null)
                     {
-                        tempCommonParams.SetPrecursorMassTolerance(fileSpecificParams.PrecursorMassTolerance);
+                        tempPrecursorMassTolerance = fileSpecificParams.PrecursorMassTolerance;
                         fileSpecificPrecursorMassTolEnabled.IsChecked = true;
                     }
                     if (fileSpecificParams.ProductMassTolerance != null)
                     {
-                        tempCommonParams.SetProductMassTolerance(fileSpecificParams.ProductMassTolerance);
+                        tempProductMassTolerance = fileSpecificParams.ProductMassTolerance;
                         fileSpecificProductMassTolEnabled.IsChecked = true;
                     }
                     if (fileSpecificParams.Protease != null)
@@ -231,17 +233,6 @@ namespace MetaMorpheusGUI
                         tempMaxModsForPeptide = (fileSpecificParams.MaxMissedCleavages.Value);
                         fileSpecificMaxModNumEnabled.IsChecked = true;
                     }
-
-                    //if (tempFileSpecificParams.BIons != null || tempFileSpecificParams.CIons != null
-                    //    || tempFileSpecificParams.YIons != null || tempFileSpecificParams.ZdotIons != null)
-                    //{
-                    //    tempCommonParams.BIons = tempFileSpecificParams.BIons.Value;
-                    //    tempCommonParams.YIons = tempFileSpecificParams.YIons.Value;
-                    //    tempCommonParams.CIons = tempFileSpecificParams.CIons.Value;
-                    //    tempCommonParams.ZdotIons = tempFileSpecificParams.ZdotIons.Value;
-
-                    //    fileSpecificIonTypesEnabled.IsChecked = true;
-                    //}
                 }
             }
 
@@ -252,15 +243,13 @@ namespace MetaMorpheusGUI
                 maxPeptideLength: tempMaxPeptideLength,
                 maxModsForPeptides: tempMaxModsForPeptide);
 
-            tempCommonParams.SetDigestionParams(digestParams);
-
             // populate the GUI
             foreach (Protease protease in ProteaseDictionary.Dictionary.Values)
             {
                 fileSpecificProtease.Items.Add(protease);
             }
 
-            fileSpecificProtease.SelectedItem = tempCommonParams.DigestionParams.Protease;
+            fileSpecificProtease.SelectedItem = digestParams.Protease;
 
             productMassToleranceComboBox.Items.Add("Da");
             productMassToleranceComboBox.Items.Add("ppm");
@@ -270,19 +259,19 @@ namespace MetaMorpheusGUI
             precursorMassToleranceComboBox.Items.Add("ppm");
             precursorMassToleranceComboBox.SelectedIndex = 1;
 
-            precursorMassToleranceTextBox.Text = tempCommonParams.PrecursorMassTolerance.Value.ToString();
-            productMassToleranceTextBox.Text = tempCommonParams.ProductMassTolerance.Value.ToString();
-            MinPeptideLengthTextBox.Text = tempCommonParams.DigestionParams.MinPeptideLength.ToString();
+            precursorMassToleranceTextBox.Text = tempPrecursorMassTolerance.Value.ToString();
+            productMassToleranceTextBox.Text = tempProductMassTolerance.Value.ToString();
+            MinPeptideLengthTextBox.Text = digestParams.MinPeptideLength.ToString();
 
-            if (int.MaxValue != tempCommonParams.DigestionParams.MaxPeptideLength)
+            if (int.MaxValue != digestParams.MaxPeptideLength)
             {
-                MaxPeptideLengthTextBox.Text = tempCommonParams.DigestionParams.MaxPeptideLength.ToString();
+                MaxPeptideLengthTextBox.Text = digestParams.MaxPeptideLength.ToString();
             }
 
-            MaxModNumTextBox.Text = tempCommonParams.DigestionParams.MaxModsForPeptide.ToString();
-            if (int.MaxValue != tempCommonParams.DigestionParams.MaxMissedCleavages)
+            MaxModNumTextBox.Text = digestParams.MaxModsForPeptide.ToString();
+            if (int.MaxValue != digestParams.MaxMissedCleavages)
             {
-                missedCleavagesTextBox.Text = tempCommonParams.DigestionParams.MaxMissedCleavages.ToString();
+                missedCleavagesTextBox.Text = digestParams.MaxMissedCleavages.ToString();
             }
             //yCheckBox.IsChecked = tempCommonParams.YIons;
             //bCheckBox.IsChecked = tempCommonParams.BIons;

--- a/GUI/GPTMDTaskWindow.xaml.cs
+++ b/GUI/GPTMDTaskWindow.xaml.cs
@@ -269,7 +269,8 @@ namespace MetaMorpheusGUI
             {
                 listOfModsFixed.AddRange(heh.Children.Where(b => b.Use).Select(b => (b.Parent.DisplayName, b.DisplayName)));
             }
-            CommonParameters CommonParamsToSave = new CommonParameters(
+            CommonParameters commonParamsToSave = new CommonParameters(
+                taskDescriptor: OutputFileNameTextBox.Text != "" ? OutputFileNameTextBox.Text : "GPTMDTask",
                 digestionParams: new DigestionParams(
                     protease: protease.Name,
                     maxMissedCleavages: MaxMissedCleavages,
@@ -277,27 +278,19 @@ namespace MetaMorpheusGUI
                     maxPeptideLength: MaxPeptideLength,
                     maxModificationIsoforms: MaxModificationIsoforms,
                     initiatorMethionineBehavior: InitiatorMethionineBehavior),
-                    bIons: bCheckBox.IsChecked.Value,
-                    yIons: yCheckBox.IsChecked.Value,
-                    cIons: cCheckBox.IsChecked.Value,
-                    zDotIons: zdotCheckBox.IsChecked.Value,
-                    scoreCutoff: double.Parse(minScoreAllowed.Text, CultureInfo.InvariantCulture),
-                    precursorMassTolerance: PrecursorMassTolerance,
-                    productMassTolerance: ProductMassTolerance,
-                    listOfModsFixed: listOfModsFixed,
-                    listOfModsVariable: listOfModsVariable);
+                bIons: bCheckBox.IsChecked.Value,
+                yIons: yCheckBox.IsChecked.Value,
+                cIons: cCheckBox.IsChecked.Value,
+                zDotIons: zdotCheckBox.IsChecked.Value,
+                scoreCutoff: double.Parse(minScoreAllowed.Text, CultureInfo.InvariantCulture),
+                precursorMassTolerance: PrecursorMassTolerance,
+                productMassTolerance: ProductMassTolerance,
+                listOfModsFixed: listOfModsFixed,
+                listOfModsVariable: listOfModsVariable);
 
             if (int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture) <= Environment.ProcessorCount && int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture) > 0)
             {
-                CommonParamsToSave.MaxThreadsToUsePerFile = int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture);
-            }
-            if (OutputFileNameTextBox.Text != "")
-            {
-                CommonParamsToSave.TaskDescriptor = OutputFileNameTextBox.Text;
-            }
-            else
-            {
-                CommonParamsToSave.TaskDescriptor = "GPTMDTask";
+                commonParamsToSave.MaxThreadsToUsePerFile = int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture);
             }
 
             TheTask.GptmdParameters.ListOfModsGptmd = new List<(string, string)>();
@@ -306,7 +299,7 @@ namespace MetaMorpheusGUI
                 TheTask.GptmdParameters.ListOfModsGptmd.AddRange(heh.Children.Where(b => b.Use).Select(b => (b.Parent.DisplayName, b.DisplayName)));
             }
 
-            TheTask.CommonParameters = CommonParamsToSave;
+            TheTask.CommonParameters = commonParamsToSave;
 
             DialogResult = true;
         }

--- a/GUI/GPTMDTaskWindow.xaml.cs
+++ b/GUI/GPTMDTaskWindow.xaml.cs
@@ -269,8 +269,12 @@ namespace MetaMorpheusGUI
             {
                 listOfModsFixed.AddRange(heh.Children.Where(b => b.Use).Select(b => (b.Parent.DisplayName, b.DisplayName)));
             }
+
+            bool parseMaxThreadsPerFile = int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture) <= Environment.ProcessorCount && int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture) > 0;
+
             CommonParameters commonParamsToSave = new CommonParameters(
                 taskDescriptor: OutputFileNameTextBox.Text != "" ? OutputFileNameTextBox.Text : "GPTMDTask",
+                maxThreadsToUsePerFile: parseMaxThreadsPerFile ? int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture) : new CommonParameters().MaxThreadsToUsePerFile,
                 digestionParams: new DigestionParams(
                     protease: protease.Name,
                     maxMissedCleavages: MaxMissedCleavages,
@@ -287,11 +291,6 @@ namespace MetaMorpheusGUI
                 productMassTolerance: ProductMassTolerance,
                 listOfModsFixed: listOfModsFixed,
                 listOfModsVariable: listOfModsVariable);
-
-            if (int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture) <= Environment.ProcessorCount && int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture) > 0)
-            {
-                commonParamsToSave.MaxThreadsToUsePerFile = int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture);
-            }
 
             TheTask.GptmdParameters.ListOfModsGptmd = new List<(string, string)>();
             foreach (var heh in gptmdModTypeForTreeViewObservableCollection)

--- a/GUI/NeoSearchTaskWindow.xaml.cs
+++ b/GUI/NeoSearchTaskWindow.xaml.cs
@@ -351,7 +351,8 @@ namespace MetaMorpheusGUI
                 listOfModsFixed.AddRange(heh.Children.Where(b => b.Use).Select(b => (b.Parent.DisplayName, b.DisplayName)));
             }
 
-            CommonParameters CommonParamsToSave = new CommonParameters(
+            CommonParameters commonParamsToSave = new CommonParameters(
+                taskDescriptor: OutputFileNameTextBox.Text != "" ? OutputFileNameTextBox.Text : "NeoSearchTask",
                 digestionParams: digestionParamsToSave,
                 bIons: bCheckBox.IsChecked.Value,
                 yIons: yCheckBox.IsChecked.Value,
@@ -360,13 +361,10 @@ namespace MetaMorpheusGUI
                 productMassTolerance: ProductMassTolerance,
                 precursorMassTolerance: PrecursorMassTolerance,
                 listOfModsFixed: listOfModsFixed,
-                listOfModsVariable: listOfModsVariable)
-            {
-                TaskDescriptor = (OutputFileNameTextBox.Text != "") ? OutputFileNameTextBox.Text : "NeoSearchTask"
-            };
+                listOfModsVariable: listOfModsVariable);
 
             TheTask.NeoParameters = neoParameters;
-            TheTask.CommonParameters = CommonParamsToSave;
+            TheTask.CommonParameters = commonParamsToSave;
 
             DialogResult = true;
         }

--- a/GUI/SearchTaskWindow.xaml.cs
+++ b/GUI/SearchTaskWindow.xaml.cs
@@ -387,8 +387,11 @@ namespace MetaMorpheusGUI
             int TopNpeaks = int.Parse(TopNPeaksTextBox.Text);
             double MinRatio = double.Parse(MinRatioTextBox.Text);
 
+            bool parseMaxThreadsPerFile = !maxThreadsTextBox.Text.Equals("") && (int.Parse(maxThreadsTextBox.Text) <= Environment.ProcessorCount && int.Parse(maxThreadsTextBox.Text) > 0);
+        
             CommonParameters commonParamsToSave = new CommonParameters(
                 taskDescriptor: OutputFileNameTextBox.Text != "" ? OutputFileNameTextBox.Text : "SearchTask",
+                maxThreadsToUsePerFile: parseMaxThreadsPerFile ? int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture) : new CommonParameters().MaxThreadsToUsePerFile,
                 useDeltaScore: deltaScoreCheckBox.IsChecked.Value,
                 reportAllAmbiguity: allAmbiguity.IsChecked.Value,
                 deconvolutionMaxAssumedChargeState: int.Parse(DeconvolutionMaxAssumedChargeStateTextBox.Text, CultureInfo.InvariantCulture),
@@ -452,10 +455,6 @@ namespace MetaMorpheusGUI
                 TheTask.SearchParameters.DecoyType = DecoyType.None;
             }
 
-            if (!maxThreadsTextBox.Text.Equals("") && (int.Parse(maxThreadsTextBox.Text) <= Environment.ProcessorCount && int.Parse(maxThreadsTextBox.Text) > 0))
-            {
-                commonParamsToSave.MaxThreadsToUsePerFile = int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture);
-            }
             if (massDiffAcceptExact.IsChecked.HasValue && massDiffAcceptExact.IsChecked.Value)
             {
                 TheTask.SearchParameters.MassDiffAcceptorType = MassDiffAcceptorType.Exact;

--- a/GUI/SearchTaskWindow.xaml.cs
+++ b/GUI/SearchTaskWindow.xaml.cs
@@ -184,10 +184,10 @@ namespace MetaMorpheusGUI
             TopNPeaksTextBox.Text = task.CommonParameters.TopNpeaks == int.MaxValue ? "" : task.CommonParameters.TopNpeaks.ToString(CultureInfo.InvariantCulture);
             MinRatioTextBox.Text = task.CommonParameters.MinRatio.ToString(CultureInfo.InvariantCulture);
             maxThreadsTextBox.Text = task.CommonParameters.MaxThreadsToUsePerFile.ToString(CultureInfo.InvariantCulture);
-
             OutputFileNameTextBox.Text = task.CommonParameters.TaskDescriptor;
             //ckbPepXML.IsChecked = task.SearchParameters.OutPepXML;
             ckbMzId.IsChecked = task.SearchParameters.OutMzId;
+
             foreach (var mod in task.CommonParameters.ListOfModsFixed)
             {
                 var theModType = FixedModTypeForTreeViewObservableCollection.FirstOrDefault(b => b.DisplayName.Equals(mod.Item1));
@@ -387,7 +387,8 @@ namespace MetaMorpheusGUI
             int TopNpeaks = int.Parse(TopNPeaksTextBox.Text);
             double MinRatio = double.Parse(MinRatioTextBox.Text);
 
-            CommonParameters CommonParamsToSave = new CommonParameters(
+            CommonParameters commonParamsToSave = new CommonParameters(
+                taskDescriptor: OutputFileNameTextBox.Text != "" ? OutputFileNameTextBox.Text : "SearchTask",
                 useDeltaScore: deltaScoreCheckBox.IsChecked.Value,
                 reportAllAmbiguity: allAmbiguity.IsChecked.Value,
                 deconvolutionMaxAssumedChargeState: int.Parse(DeconvolutionMaxAssumedChargeStateTextBox.Text, CultureInfo.InvariantCulture),
@@ -410,15 +411,6 @@ namespace MetaMorpheusGUI
                 topNpeaks: TopNpeaks,
                 minRatio: MinRatio,
                 addCompIons: addCompIonCheckBox.IsChecked.Value);
-
-            if (OutputFileNameTextBox.Text != "")
-            {
-                CommonParamsToSave.TaskDescriptor = OutputFileNameTextBox.Text;
-            }
-            else
-            {
-                CommonParamsToSave.TaskDescriptor = "SearchTask";
-            }
 
             if (classicSearchRadioButton.IsChecked.Value)
             {
@@ -462,7 +454,7 @@ namespace MetaMorpheusGUI
 
             if (!maxThreadsTextBox.Text.Equals("") && (int.Parse(maxThreadsTextBox.Text) <= Environment.ProcessorCount && int.Parse(maxThreadsTextBox.Text) > 0))
             {
-                CommonParamsToSave.MaxThreadsToUsePerFile = int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture);
+                commonParamsToSave.MaxThreadsToUsePerFile = int.Parse(maxThreadsTextBox.Text, CultureInfo.InvariantCulture);
             }
             if (massDiffAcceptExact.IsChecked.HasValue && massDiffAcceptExact.IsChecked.Value)
             {
@@ -501,7 +493,7 @@ namespace MetaMorpheusGUI
 
             SetModSelectionForPrunedDB();
 
-            TheTask.CommonParameters = CommonParamsToSave;
+            TheTask.CommonParameters = commonParamsToSave;
 
             DialogResult = true;
         }

--- a/GUI/XLSearchTaskWindow.xaml.cs
+++ b/GUI/XLSearchTaskWindow.xaml.cs
@@ -340,7 +340,8 @@ namespace MetaMorpheusGUI
                 listOfModsFixed.AddRange(heh.Children.Where(b => b.Use).Select(b => (b.Parent.DisplayName, b.DisplayName)));
             }
 
-            CommonParameters CommonParamsToSave = new CommonParameters(
+            CommonParameters commonParamsToSave = new CommonParameters(
+                taskDescriptor: OutputFileNameTextBox.Text != "" ? OutputFileNameTextBox.Text : "XLSearchTask",
                 productMassTolerance: ProductMassTolerance,
                 doPrecursorDeconvolution: deconvolutePrecursors.IsChecked.Value,
                 useProvidedPrecursorInfo: useProvidedPrecursor.IsChecked.Value,
@@ -357,15 +358,8 @@ namespace MetaMorpheusGUI
                 totalPartitions: int.Parse(numberOfDatabaseSearchesTextBox.Text, CultureInfo.InvariantCulture),
                 listOfModsVariable: listOfModsVariable,
                 listOfModsFixed: listOfModsFixed);
-            if (OutputFileNameTextBox.Text != "")
-            {
-                CommonParamsToSave.TaskDescriptor = OutputFileNameTextBox.Text;
-            }
-            else
-            {
-                CommonParamsToSave.TaskDescriptor = "XLSearchTask";
-            }
-            TheTask.CommonParameters = CommonParamsToSave;
+
+            TheTask.CommonParameters = commonParamsToSave;
 
             DialogResult = true;
         }

--- a/TaskLayer/CalibrationTask/CalibrationTask.cs
+++ b/TaskLayer/CalibrationTask/CalibrationTask.cs
@@ -123,18 +123,18 @@ namespace TaskLayer
 
                     if (i == 1) // failed round 1
                     {
-                        this.CommonParameters.SetPrecursorMassTolerance(new PpmTolerance(20));
-                        this.CommonParameters.SetProductMassTolerance(new PpmTolerance(50));
+                        CommonParameters.PrecursorMassTolerance = new PpmTolerance(20);
+                        CommonParameters.ProductMassTolerance = new PpmTolerance(50);
                     }
                     else if (i == 2) // failed round 2
                     {
-                        this.CommonParameters.SetPrecursorMassTolerance(new PpmTolerance(30));
-                        this.CommonParameters.SetProductMassTolerance(new PpmTolerance(100));
+                        CommonParameters.PrecursorMassTolerance = new PpmTolerance(30);
+                        CommonParameters.ProductMassTolerance = new PpmTolerance(100);
                     }
                     else if (i == 3) // failed round 3
                     {
-                        this.CommonParameters.SetPrecursorMassTolerance(new PpmTolerance(40));
-                        this.CommonParameters.SetProductMassTolerance(new PpmTolerance(150));
+                        CommonParameters.PrecursorMassTolerance = new PpmTolerance(40);
+                        CommonParameters.ProductMassTolerance = new PpmTolerance(150);
                     }
                     else // failed round 4
                     {


### PR DESCRIPTION
This one makes all fields have private setters where possible and explicit public setters where necessary. This will at least reduce the work in maintaining the Clone() method, which will automatically repopulate the properties of the clone. This also cleans up the GUI code for TaskDescriptor a bit.