### PR TITLE
Bugfixes

### DIFF
--- a/EngineLayer/MetaMorpheusEngine.cs
+++ b/EngineLayer/MetaMorpheusEngine.cs
@@ -93,8 +93,8 @@ namespace EngineLayer
 
                 foreach (Product product in theoreticalProducts)
                 {
-                    // unknown fragment mass; this only happens rarely for sequences with unknown amino acids
-                    if (double.IsNaN(product.NeutralMass))
+                    // unknown fragment mass or diagnostic ion or precursor; skip those
+                    if (double.IsNaN(product.NeutralMass) || product.ProductType == ProductType.D || product.ProductType == ProductType.M)
                     {
                         continue;
                     }

--- a/GUI/MainWindow.xaml.cs
+++ b/GUI/MainWindow.xaml.cs
@@ -1161,7 +1161,14 @@ namespace MetaMorpheusGUI
 
             if (a.SelectedItem is OutputFileForTreeView fileThing)
             {
-                System.Diagnostics.Process.Start(fileThing.FullPath);
+                if (File.Exists(fileThing.FullPath))
+                {
+                    System.Diagnostics.Process.Start(fileThing.FullPath);
+                }
+                else
+                {
+                    MessageBox.Show("File " + Path.GetFileName(fileThing.FullPath) + " does not exist");
+                }
             }
         }
 

--- a/GUI/MetaDraw.xaml.cs
+++ b/GUI/MetaDraw.xaml.cs
@@ -71,8 +71,8 @@ namespace MetaMorpheusGUI
             productTypeToYOffset = ((ProductType[])Enum.GetValues(typeof(ProductType))).ToDictionary(p => p, p => 0.0);
             productTypeToYOffset[ProductType.b] = 50;
             productTypeToYOffset[ProductType.y] = 0;
-            productTypeToYOffset[ProductType.zPlusOne] = 50;
-            productTypeToYOffset[ProductType.c] = 0;
+            productTypeToYOffset[ProductType.c] = 50;
+            productTypeToYOffset[ProductType.zPlusOne] = 0;
         }
 
         private void Window_Drop(object sender, DragEventArgs e)


### PR DESCRIPTION
- fix crash when opening nonexistent file in the GUI
- skip looking for comp. ions of diagnostic and precursor ions in MS2 spectra