### PR TITLE
fix issue #1713

### DIFF
--- a/GUI/CalibrateTaskWindow.xaml.cs
+++ b/GUI/CalibrateTaskWindow.xaml.cs
@@ -319,6 +319,10 @@ namespace MetaMorpheusGUI
 
         private void OnClosing(object sender, CancelEventArgs e)
         {
+            SearchModifications.Timer.Tick -= new EventHandler(TextChangeTimerHandler);
+            // remove event handler from timer
+            // keeping it will trigger an exception because the closed window stops existing
+
             CustomFragmentationWindow.Close();
         }
 

--- a/GUI/GPTMDTaskWindow.xaml.cs
+++ b/GUI/GPTMDTaskWindow.xaml.cs
@@ -475,6 +475,10 @@ namespace MetaMorpheusGUI
 
         private void OnClosing(object sender, CancelEventArgs e)
         {
+            SearchModifications.Timer.Tick -= new EventHandler(TextChangeTimerHandler);
+            // remove event handler from timer
+            // keeping it will trigger an exception because the closed window stops existing
+
             CustomFragmentationWindow.Close();
         }
     }

--- a/GUI/SearchTaskWindow.xaml.cs
+++ b/GUI/SearchTaskWindow.xaml.cs
@@ -877,6 +877,10 @@ namespace MetaMorpheusGUI
 
         private void OnClosing(object sender, CancelEventArgs e)
         {
+            SearchModifications.Timer.Tick -= new EventHandler(TextChangeTimerHandler);
+            // remove event handler from timer
+            // keeping it will trigger an exception because the closed window stops existing
+
             CustomFragmentationWindow.Close();
         }
 

--- a/GUI/XLSearchTaskWindow.xaml.cs
+++ b/GUI/XLSearchTaskWindow.xaml.cs
@@ -408,6 +408,10 @@ namespace MetaMorpheusGUI
 
         private void OnClosing(object sender, CancelEventArgs e)
         {
+            SearchModifications.Timer.Tick -= new EventHandler(TextChangeTimerHandler);
+            // remove event handler from timer
+            // keeping it will trigger an exception because the closed window stops existing
+
             CustomFragmentationWindow.Close();
         }
         


### PR DESCRIPTION
The TextChangedTimerHandler events were not being removed from the static timer, which seemed to cause this issue. Removing them on window close solves it.
