### PR TITLE
fixed pruned db bug

### DIFF
--- a/TaskLayer/SearchTask/PostSearchAnalysisTask.cs
+++ b/TaskLayer/SearchTask/PostSearchAnalysisTask.cs
@@ -843,7 +843,7 @@ namespace TaskLayer
                             }
                         }
 
-                        if (proteinToConfidentBaseSequences.ContainsKey(nonVariantProtein.NonVariantProtein))
+                     //   if (proteinToConfidentBaseSequences.ContainsKey(nonVariantProtein.NonVariantProtein))
                         {
                             // adds confidently localized and identified mods
                             nonVariantProtein.OneBasedPossibleLocalizedModifications.Clear();


### PR DESCRIPTION
We were requiring a protein to be ID'd to have the pruned DB code work on it. This is why the protein pruned DB worked but the full database with only mods pruned didn't. 