### PR TITLE
Remove high q-value Targets from PEP training

### DIFF
--- a/EngineLayer/FdrAnalysis/PEPValueAnalysisGeneric.cs
+++ b/EngineLayer/FdrAnalysis/PEPValueAnalysisGeneric.cs
@@ -540,7 +540,7 @@ namespace EngineLayer
                             CrosslinkSpectralMatch csm = (CrosslinkSpectralMatch)psms[i];
 
                             bool label;
-                            if (csm.IsDecoy || csm.BetaPeptide.IsDecoy || psm.FdrInfo.QValue > 0.25)
+                            if (csm.IsDecoy || csm.BetaPeptide.IsDecoy)
                             {
                                 label = false;
                                 newPsmData = CreateOnePsmDataEntry(searchType, fileSpecificParameters, psm, sequenceToPsmCount, timeDependantHydrophobicityAverageAndDeviation_unmodified, timeDependantHydrophobicityAverageAndDeviation_modified, fileSpecificMedianFragmentMassErrors, chargeStateMode, csm.BestMatchingPeptides.First().Peptide, trainingVariables, 0, label);
@@ -560,7 +560,7 @@ namespace EngineLayer
                             {
                                 bool label;
                                 double bmpc = psm.BestMatchingPeptides.Count();
-                                if (peptideWithSetMods.Protein.IsDecoy || psm.FdrInfo.QValue > 0.25)
+                                if (peptideWithSetMods.Protein.IsDecoy)
                                 {
                                     label = false;
                                     newPsmData = CreateOnePsmDataEntry(searchType, fileSpecificParameters, psm, sequenceToPsmCount, timeDependantHydrophobicityAverageAndDeviation_unmodified, timeDependantHydrophobicityAverageAndDeviation_modified, fileSpecificMedianFragmentMassErrors, chargeStateMode, peptideWithSetMods, trainingVariables, notch, label);

--- a/Test/XLTest.cs
+++ b/Test/XLTest.cs
@@ -759,7 +759,7 @@ namespace Test
             }
 
             Assert.AreEqual(0, unnasignedCrossType);
-            Assert.AreEqual(42, inter);
+            Assert.AreEqual(41, inter);
             Assert.AreEqual(74, intra);
             Assert.AreEqual(233, single);
             Assert.AreEqual(8, loop);


### PR DESCRIPTION
Now that PEP is stabilized, I'm going to look at some small adjustments. In this first commit, I ran three separate large searches to compare test metrics of PEP between keeping high q-value Targets in the false training set or using only decoys. I found in all three cases that using only decoys for the false set produced superior recall results. Therefore, I am eliminating the high q-value targets from training. Anyway, there are a bazillion decoys to choose from. 