### PR TITLE
issue 1872

### DIFF
--- a/EngineLayer/GlobalVariables.cs
+++ b/EngineLayer/GlobalVariables.cs
@@ -345,26 +345,20 @@ namespace EngineLayer
         // Does the same thing as Process.Start() except it works on .NET Core
         public static void StartProcess(string path, bool useNotepadToOpenToml = false)
         {
+            var p = new Process();
+
+            p.StartInfo = new ProcessStartInfo()
+            {
+                UseShellExecute = true,
+            };
+
             if (useNotepadToOpenToml && Path.GetExtension(path) == ".toml" && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                var p = new Process();
-                p.StartInfo = new ProcessStartInfo()
-                {
-                    UseShellExecute = true,
-                    FileName = "notepad.exe",
-                    Arguments = path
-                };
-                p.Start();
+                p.StartInfo.FileName = "notepad.exe";
+                p.StartInfo.Arguments = path;
             }
-            else
-            {
-                var p = new Process();
-                p.StartInfo = new ProcessStartInfo(path)
-                {
-                    UseShellExecute = true
-                };
-                p.Start();
-            }
+
+            p.Start();
         }
     }
 }

--- a/EngineLayer/GlobalVariables.cs
+++ b/EngineLayer/GlobalVariables.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 namespace EngineLayer
 {
@@ -342,14 +343,28 @@ namespace EngineLayer
         }
 
         // Does the same thing as Process.Start() except it works on .NET Core
-        public static void StartProcess(string path)
+        public static void StartProcess(string path, bool useNotepadToOpenToml = false)
         {
-            var p = new Process();
-            p.StartInfo = new ProcessStartInfo(path)
+            if (useNotepadToOpenToml && Path.GetExtension(path) == ".toml" && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
-                UseShellExecute = true
-            };
-            p.Start();
+                var p = new Process();
+                p.StartInfo = new ProcessStartInfo()
+                {
+                    UseShellExecute = true,
+                    FileName = "notepad.exe",
+                    Arguments = path
+                };
+                p.Start();
+            }
+            else
+            {
+                var p = new Process();
+                p.StartInfo = new ProcessStartInfo(path)
+                {
+                    UseShellExecute = true
+                };
+                p.Start();
+            }
         }
     }
 }

--- a/EngineLayer/GlobalVariables.cs
+++ b/EngineLayer/GlobalVariables.cs
@@ -350,6 +350,7 @@ namespace EngineLayer
             p.StartInfo = new ProcessStartInfo()
             {
                 UseShellExecute = true,
+                FileName = path
             };
 
             if (useNotepadToOpenToml && Path.GetExtension(path) == ".toml" && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/GUI/MainWindow.xaml.cs
+++ b/GUI/MainWindow.xaml.cs
@@ -1507,13 +1507,13 @@ namespace MetaMorpheusGUI
 
         private void MenuItem_Click_3(object sender, RoutedEventArgs e)
         {
-            GlobalVariables.StartProcess(Path.Combine(GlobalVariables.DataDir, @"settings.toml"));
+            GlobalVariables.StartProcess(Path.Combine(GlobalVariables.DataDir, @"settings.toml"), useNotepadToOpenToml: true);
             Application.Current.Shutdown();
         }
 
         private void MenuItem_Click_7(object sender, RoutedEventArgs e)
         {
-            GlobalVariables.StartProcess(Path.Combine(GlobalVariables.DataDir, @"GUIsettings.toml"));
+            GlobalVariables.StartProcess(Path.Combine(GlobalVariables.DataDir, @"GUIsettings.toml"), useNotepadToOpenToml: true);
             Application.Current.Shutdown();
         }
 


### PR DESCRIPTION
#1872 

**problem:**
when a program is not associated with .toml, going to settings -> close MM and open settings, MM is closed but the .toml is not opened. this gives the appearance of a crash, and does not let the user edit the settings as expected. windows does not prompt for a program to open .toml with in some cases, though this appears to be variable.

**solution:**
notepad is used as the default .toml editor in specific cases (editing settings.toml or GUIsettings.toml).

**created problems:**
- user may not want to use notepad as .toml editor to edit settings.toml or GUIsettings.toml.
- other .toml files are not affected, possibly creating confusion; .tomls are edited by notepad in some places but do not open at all in other places which can give the appearance of a bug. we could use notepad as the default .toml editor everywhere but personally I would find this more annoying than helpful.