### PR TITLE
generate glyco default toml via CMD

### DIFF
--- a/CMD/CommandLineSettings.cs
+++ b/CMD/CommandLineSettings.cs
@@ -143,6 +143,9 @@ namespace MetaMorpheusCommandLine
 
                 XLSearchTask xl = new XLSearchTask();
                 Toml.WriteFile(xl, Path.Combine(folderLocation, @"XLSearchTask.toml"), MetaMorpheusTask.tomlConfig);
+
+                GlycoSearchTask glyco = new GlycoSearchTask();
+                Toml.WriteFile(glyco, Path.Combine(folderLocation, @"GlycoSearchTask.toml"), MetaMorpheusTask.tomlConfig);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
**pull request type:**
bugfix

**problem:**
the command-line version of MM generates default .toml files for each task with the `-g` flag. the glyco search was not included in this, making it dependent on the GUI version to generate its .toml files.

**solution:**
added the glyco search task to the list of .toml files generated by the `-g` flag.

**repercussions of solution:**
none