### PR TITLE
updated metamorpheus to mzlib nuget package release 475

### DIFF
--- a/CMD/CMD.csproj
+++ b/CMD/CMD.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.ML" Version="1.3.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="1.3.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.474" />
+    <PackageReference Include="mzLib" Version="1.0.475" />
     <PackageReference Include="Nett" Version="0.13.0" />
   </ItemGroup>
 

--- a/EngineLayer/EngineLayer.csproj
+++ b/EngineLayer/EngineLayer.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.ML" Version="1.3.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="1.3.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.474" />
+    <PackageReference Include="mzLib" Version="1.0.475" />
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="Nett" Version="0.13.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.ML.DataView" Version="1.3.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="1.3.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.474" />
+    <PackageReference Include="mzLib" Version="1.0.475" />
     <PackageReference Include="Nett" Version="0.13.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0" />

--- a/TaskLayer/TaskLayer.csproj
+++ b/TaskLayer/TaskLayer.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.ML" Version="1.3.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="1.3.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.474" />
+    <PackageReference Include="mzLib" Version="1.0.475" />
     <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="Nett" Version="0.13.0" />
   </ItemGroup>

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.ML" Version="1.3.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="1.3.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.474" />
+    <PackageReference Include="mzLib" Version="1.0.475" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />


### PR DESCRIPTION
i added the ability to download a database from uniprot to this version of mzlib. i plan to add that functionality to metamorpheus. This pull request is to update metamorpheus to the newest mzlib release 475.

I tested calibration,gptmd and search with a raw file from the vignette. Seems to work just fine.