### PR TITLE
bugfixes for the GUI

### DIFF
--- a/EngineLayer/PsmTsv/PsmFromTsv.cs
+++ b/EngineLayer/PsmTsv/PsmFromTsv.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
 using EngineLayer.GlycoSearch;
+using System.IO;
 
 namespace EngineLayer
 {
@@ -18,7 +19,7 @@ namespace EngineLayer
 
         public string FullSequence { get; }
         public int Ms2ScanNumber { get; }
-        public string Filename { get; }
+        public string FileNameWithoutExtension { get; }
         public int PrecursorScanNum { get; }
         public int PrecursorCharge { get; }
         public double PrecursorMz { get; }
@@ -87,7 +88,7 @@ namespace EngineLayer
             var spl = line.Split(split);
 
             //Required properties
-            Filename = spl[parsedHeader[PsmTsvHeader.FileName]].Trim();
+            FileNameWithoutExtension = Path.GetFileNameWithoutExtension(spl[parsedHeader[PsmTsvHeader.FileName]].Trim());
             Ms2ScanNumber = int.Parse(spl[parsedHeader[PsmTsvHeader.Ms2ScanNumber]]);
 
             // this will probably not be known in an .mgf data file

--- a/GUI/MainWindow.xaml
+++ b/GUI/MainWindow.xaml
@@ -529,17 +529,19 @@
                     <Grid Grid.Row="0" Background="{StaticResource BackgroundColor}">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="5*" />
+                            <ColumnDefinition Width="5" />
                             <ColumnDefinition Width="4*" />
                         </Grid.ColumnDefinitions>
 
                         <Grid Grid.Column="0" Background="{StaticResource BackgroundColor}">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="1*" />
+                                <RowDefinition Height="5" />
                                 <RowDefinition Height="1*" />
                             </Grid.RowDefinitions>
 
                             <!--Protein DB Summary-->
-                            <DataGrid Name="proteinDbSummaryDataGrid" ItemsSource="{Binding}" Grid.Row="0" Margin="20,10,5,5" 
+                            <DataGrid Name="proteinDbSummaryDataGrid" ItemsSource="{Binding}" Grid.Row="0" Margin="20,10,0,0" 
                               Style="{StaticResource x:DataGridStyle}" ColumnHeaderStyle="{StaticResource DataGridColumnHeaderStyle}">
                                 <DataGrid.RowStyle>
                                     <Style TargetType="{x:Type DataGridRow}" BasedOn="{StaticResource DatabaseDataGridItemStyle}" >
@@ -555,11 +557,18 @@
                                     <DataGridTextColumn Header="Contaminant?" Binding="{Binding Contaminant, Mode=OneWay}" Width="180" />
                                 </DataGrid.Columns>
                             </DataGrid>
-                            <Button Name="MiniAddProteinDbButton" Grid.Row="0" Width="20" Height="20" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,0,6,6" Content="+" 
+                            <Button Name="MiniAddProteinDbButton" Grid.Row="0" Width="20" Height="20" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,0,1,1" Content="+" 
                                 VerticalContentAlignment="Top" Style="{StaticResource ImportantButtonStyle}" Click="AddProteinDatabase_Click"/>
 
+                            <GridSplitter Grid.Row="1"
+                                VerticalAlignment="Center"
+                                HorizontalAlignment="Stretch"
+                                Background="Transparent"
+                                Height="5"
+                                Margin="20,0,0,0"/>
+                            
                             <!--Spectra file Summary-->
-                            <DataGrid Name="spectraFileSummaryDataGrid" ItemsSource="{Binding}" Grid.Row="1" Margin="20,5,5,10" 
+                            <DataGrid Name="spectraFileSummaryDataGrid" ItemsSource="{Binding}" Grid.Row="2" Margin="20,0,0,10" 
                               Style="{StaticResource x:DataGridStyle}" ColumnHeaderStyle="{StaticResource DataGridColumnHeaderStyle}">
                                 <DataGrid.RowStyle>
                                     <Style TargetType="{x:Type DataGridRow}" BasedOn="{StaticResource SpectraFileDataGridItemStyle}">
@@ -575,20 +584,27 @@
                                     <DataGridTextColumn Header="File-Specific Parameters" Binding="{Binding Parameters, Mode=OneWay}" Width="180" />
                                 </DataGrid.Columns>
                             </DataGrid>
-                            <Button Name="MiniAddSpectraButton" Grid.Row="1" Width="20" Height="20" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,0,6,11" Content="+" 
+                            <Button Name="MiniAddSpectraButton" Grid.Row="2" Width="20" Height="20" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,0,1,11" Content="+" 
                                 VerticalContentAlignment="Top" Style="{StaticResource ImportantButtonStyle}" Click="AddSpectraFile_Click"/>
                         </Grid>
 
+                        <GridSplitter Grid.Column="1"
+                            VerticalAlignment="Stretch"
+                            HorizontalAlignment="Center"
+                            Background="Transparent"
+                            Width="10"
+                            Margin="0,10,0,10"/>
+
                         <!--Task Summary-->
-                        <TreeView Name="taskSummary" ItemsSource="{Binding}" Grid.Column="2" Margin="2,10,20,10" MouseDoubleClick="TasksTreeView_MouseDoubleClick">
+                        <TreeView Name="taskSummary" ItemsSource="{Binding}" Grid.Column="2" Margin="0,10,20,10" MouseDoubleClick="TasksTreeView_MouseDoubleClick">
                             <TreeView.ItemContainerStyle>
                                 <Style TargetType="{x:Type TreeViewItem}">
-                                    <Setter Property="FontSize" Value="11" />
+                                    <Setter Property="FontSize" Value="13" />
                                     <Setter Property="FontWeight" Value="SemiBold" />
                                 </Style>
                             </TreeView.ItemContainerStyle>
                         </TreeView>
-                        <Button Name="MiniAddTaskButton" Grid.Column="1" Width="20" Height="20" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,0,21,11" Content="+" 
+                        <Button Name="MiniAddTaskButton" Grid.Column="2" Width="20" Height="20" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,0,21,11" Content="+" 
                                 VerticalContentAlignment="Top" Style="{StaticResource ImportantButtonStyle}" Click="AddTask_Click"/>
                     </Grid>
 

--- a/GUI/MainWindow.xaml
+++ b/GUI/MainWindow.xaml
@@ -137,6 +137,7 @@
                 <MenuItem Header="Open file" Click="OpenFile_Click"/>
                 <MenuItem Header="Open containing folder" Click="OpenContainingFolder_Click" />
                 <MenuItem Header="Delete" Click="Delete_Click" />
+                <MenuItem Header="Delete all" Click="DeleteAll_Click" />
             </ContextMenu>
 
             <!--Defines the context menu when a spectra file is right-clicked-->
@@ -145,13 +146,17 @@
                 <MenuItem Header="Open file" Click="OpenFile_Click"/>
                 <MenuItem Header="Open containing folder" Click="OpenContainingFolder_Click" />
                 <MenuItem Header="Delete" Click="Delete_Click" />
+                <MenuItem Header="Delete all" Click="DeleteAll_Click" />
             </ContextMenu>
 
             <!--Defines the context menu when a task is right-clicked-->
             <ContextMenu x:Key="TaskContextMenu" Style="{StaticResource ContextMenuStyle}">
                 <MenuItem Header="Edit task" Click="EditTask_Click"/>
                 <MenuItem Header="Save as .toml" Click="SaveTaskAsToml_Click" />
+                <MenuItem Header="Move task up" Click="MoveTaskUp_Click" />
+                <MenuItem Header="Move task down" Click="MoveTaskDown_Click" />
                 <MenuItem Header="Delete" Click="Delete_Click" />
+                <MenuItem Header="Delete all" Click="DeleteAll_Click" />
             </ContextMenu>
 
             <!--Defines the context menu when a written file is right-clicked-->

--- a/GUI/MainWindow.xaml
+++ b/GUI/MainWindow.xaml
@@ -7,7 +7,7 @@
         mc:Ignorable="d"
         Drop="Window_Drop" AllowDrop="true" Background="{StaticResource BackgroundColor}" WindowStartupLocation="CenterScreen" MinHeight="400" 
         MinWidth="800" Height="550" Width="950"
-        Loaded="MyWindow_Loaded">
+        Loaded="MyWindow_Loaded" PreviewKeyDown="Window_PreviewKeyDown">
 
     <Window.Resources>
         <ResourceDictionary>
@@ -542,6 +542,9 @@
                                         <Setter Property="FontWeight" Value="SemiBold" />
                                     </Style>
                                 </DataGrid.RowStyle>
+                                <DataGrid.CellStyle>
+                                    <Style TargetType="{x:Type DataGridCell}" BasedOn="{StaticResource DataGridCellStyle}" />
+                                </DataGrid.CellStyle>
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Header="File" Binding="{Binding FileName, Mode=OneWay}" Width="240" />
                                     <DataGridTextColumn Header="Contaminant?" Binding="{Binding Contaminant, Mode=OneWay}" Width="180" />
@@ -572,7 +575,7 @@
                         </Grid>
 
                         <!--Task Summary-->
-                        <TreeView Name="taskSummary" ItemsSource="{Binding}" Grid.Column="2" Margin="2,10,20,10">
+                        <TreeView Name="taskSummary" ItemsSource="{Binding}" Grid.Column="2" Margin="2,10,20,10" MouseDoubleClick="TasksTreeView_MouseDoubleClick">
                             <TreeView.ItemContainerStyle>
                                 <Style TargetType="{x:Type TreeViewItem}">
                                     <Setter Property="FontSize" Value="11" />

--- a/GUI/MainWindow.xaml.cs
+++ b/GUI/MainWindow.xaml.cs
@@ -853,7 +853,7 @@ namespace MetaMorpheusGUI
 
             int oldPosition = PreRunTasks.IndexOf(taskToMove);
             int newPosition = oldPosition - 1;
-            if (moveTaskUp)
+            if (!moveTaskUp)
             {
                 newPosition = oldPosition + 1;
             }
@@ -1051,17 +1051,17 @@ namespace MetaMorpheusGUI
                     e.Handled = true;
                 }
 
-                // move task up
+                // move task down
                 if (e.Key == Key.Add || e.Key == Key.OemPlus)
                 {
-                    MoveSelectedTask_Click(sender, e, true);
+                    MoveSelectedTask_Click(sender, e, false);
                     e.Handled = true;
                 }
 
-                // move task down
+                // move task up
                 if (e.Key == Key.Subtract || e.Key == Key.OemMinus)
                 {
-                    MoveSelectedTask_Click(sender, e, false);
+                    MoveSelectedTask_Click(sender, e, true);
                     e.Handled = true;
                 }
             }
@@ -1202,6 +1202,36 @@ namespace MetaMorpheusGUI
         {
             var dialog = new CustomCrosslinkerWindow();
             dialog.ShowDialog();
+        }
+
+        private void MoveTaskUp_Click(object sender, RoutedEventArgs e)
+        {
+            var item = GetItemDataContext(sender, e).FirstOrDefault();
+            MoveSelectedTask_Click(item, null, moveTaskUp: true);
+        }
+
+        private void MoveTaskDown_Click(object sender, RoutedEventArgs e)
+        {
+            var item = GetItemDataContext(sender, e).FirstOrDefault();
+            MoveSelectedTask_Click(item, null, moveTaskUp: false);
+        }
+
+        private void DeleteAll_Click(object sender, RoutedEventArgs e)
+        {
+            var item = GetItemDataContext(sender, e).FirstOrDefault();
+
+            if (item is PreRunTask task)
+            {
+                PreRunTasks.Clear();
+            }
+            else if (item is ProteinDbForDataGrid db)
+            {
+                ProteinDatabases.Clear();
+            }
+            else if (item is RawDataForDataGrid spectra)
+            {
+                SpectraFiles.Clear();
+            }
         }
 
         #endregion
@@ -1821,6 +1851,7 @@ namespace MetaMorpheusGUI
                     case "Set as non-contaminant database": item.IsEnabled = enable; break;
                     case "Open file": item.IsEnabled = enable; break;
                     case "Delete": item.IsEnabled = enable; break;
+                    case "Delete all": item.IsEnabled = enable; break;
                 }
             }
 
@@ -1831,6 +1862,7 @@ namespace MetaMorpheusGUI
                     case "Set file-specific parameters": item.IsEnabled = enable; break;
                     case "Open file": item.IsEnabled = enable; break;
                     case "Delete": item.IsEnabled = enable; break;
+                    case "Delete all": item.IsEnabled = enable; break;
                 }
             }
 
@@ -1838,8 +1870,11 @@ namespace MetaMorpheusGUI
             {
                 switch (item.Header.ToString())
                 {
+                    case "Move task up": item.IsEnabled = enable; break;
+                    case "Move task down": item.IsEnabled = enable; break;
                     case "Edit task": item.IsEnabled = enable; break;
                     case "Delete": item.IsEnabled = enable; break;
+                    case "Delete all": item.IsEnabled = enable; break;
                 }
             }
 

--- a/GUI/MetaDraw/MetaDraw.xaml.cs
+++ b/GUI/MetaDraw/MetaDraw.xaml.cs
@@ -178,9 +178,9 @@ namespace MetaMorpheusGUI
             try
             {
                 // TODO: print warnings
-                foreach (var psm in PsmTsvReader.ReadTsv(psmtsvFileName, out List<string> warnings))
+                foreach (PsmFromTsv psm in PsmTsvReader.ReadTsv(psmtsvFileName, out List<string> warnings))
                 {
-                    if (loadPsmsOfAllSpectraFiles || fileNamesWithExtension.Contains(psm.Filename) || fileNamesWithoutExtension.Contains(psm.Filename) || potentiallyCalibratedFileNames.Contains(psm.Filename)) // in case results are from a calibrated file
+                    if (loadPsmsOfAllSpectraFiles || fileNamesWithExtension.Contains(psm.FileNameWithoutExtension) || fileNamesWithoutExtension.Contains(psm.FileNameWithoutExtension) || potentiallyCalibratedFileNames.Contains(psm.FileNameWithoutExtension)) // in case results are from a calibrated file
                     {
                         allPsms.Add(psm);
                     }
@@ -216,14 +216,14 @@ namespace MetaMorpheusGUI
 
             foreach (PsmFromTsv psm in filteredListOfPsms)
             {
-                if (psmsBySourceFile.Keys.Contains(psm.Filename))
+                if (psmsBySourceFile.Keys.Contains(psm.FileNameWithoutExtension))
                 {
-                    psmsBySourceFile[psm.Filename].Add(psm);
+                    psmsBySourceFile[psm.FileNameWithoutExtension].Add(psm);
                 }
                 else
                 {
-                    psmsBySourceFile.Add(psm.Filename, new ObservableCollection<PsmFromTsv> { psm });
-                    sourceFilesList.Add(psm.Filename);
+                    psmsBySourceFile.Add(psm.FileNameWithoutExtension, new ObservableCollection<PsmFromTsv> { psm });
+                    sourceFilesList.Add(psm.FileNameWithoutExtension);
                 }
             }
         }
@@ -382,7 +382,7 @@ namespace MetaMorpheusGUI
             }
             dataGridProperties.Items.Refresh();
             itemsControlSampleViewModel.Data.Clear();
-            DrawPsm(row.Ms2ScanNumber, row.Filename, row.FullSequence);
+            DrawPsm(row.Ms2ScanNumber, row.FileNameWithoutExtension, row.FullSequence);
         }
 
         private void selectSpectraFileButton_Click(object sender, RoutedEventArgs e)
@@ -819,7 +819,7 @@ namespace MetaMorpheusGUI
                         tempPsm = psm;
                     }
 
-                    var file = MsDataFiles.First(p => Path.GetFileNameWithoutExtension(p.FilePath) == psm.Filename);
+                    var file = MsDataFiles.First(p => Path.GetFileNameWithoutExtension(p.FilePath) == psm.FileNameWithoutExtension);
 
                     MsDataScan msDataScanToDraw = file.GetOneBasedScanFromDynamicConnection(psm.Ms2ScanNumber);
 
@@ -888,7 +888,7 @@ namespace MetaMorpheusGUI
                 dataGridScanNums.SelectedItem = dataGridScanNums.SelectedItem;
 
                 itemsControlSampleViewModel.Data.Clear();
-                DrawPsm(tempPsm.Ms2ScanNumber, tempPsm.Filename, tempPsm.FullSequence);
+                DrawPsm(tempPsm.Ms2ScanNumber, tempPsm.FileNameWithoutExtension, tempPsm.FullSequence);
 
                 MessageBox.Show(string.Format("{0} PDFs exported to " + directoryPath, numberOfScansToExport));
             }

--- a/GUI/MetaDraw/MetaDraw.xaml.cs
+++ b/GUI/MetaDraw/MetaDraw.xaml.cs
@@ -48,6 +48,8 @@ namespace MetaMorpheusGUI
         private SolidColorBrush modificationAnnotationColor;
         private Regex illegalInFileName = new Regex(@"[\\/:*?""<>|]");
         private ObservableCollection<string> plotTypes;
+        private static List<string> AcceptedSpectraFormats = new List<string> { ".mzml", ".raw", ".mgf" };
+        private static List<string> AcceptedResultsFormats = new List<string> { ".psmtsv", ".tsv" };
 
         public MetaDraw()
         {
@@ -126,45 +128,42 @@ namespace MetaMorpheusGUI
         {
             var theExtension = Path.GetExtension(filePath).ToLower();
 
-            switch (theExtension)
+            if (AcceptedSpectraFormats.Contains(theExtension))
             {
-                case ".raw":
-                case ".mzml":
-                case ".mgf":
-                    if (!spectraFilePaths.Contains(filePath))
-                    {
-                        spectraFilePaths.Add(filePath);
+                if (!spectraFilePaths.Contains(filePath))
+                {
+                    spectraFilePaths.Add(filePath);
 
-                        if (spectraFilePaths.Count == 1)
-                        {
-                            spectraFileNameLabel.Text = filePath;
-                        }
-                        else
-                        {
-                            spectraFileNameLabel.Text = "[Mouse over to view files]";
-                        }
-
-                        spectraFileNameLabel.ToolTip = string.Join("\n", spectraFilePaths);
-                        resetSpectraFileButton.IsEnabled = true;
-                    }
-                    break;
-                case ".tsv":
-                case ".psmtsv":
-                    if (tsvResultsFilePath == null || !tsvResultsFilePath.Equals(filePath))
+                    if (spectraFilePaths.Count == 1)
                     {
-                        resetFilesButton_Click(resetPsmFileButton, null);
-                        tsvResultsFilePath = filePath;
-                        psmFileNameLabel.Text = filePath;
-                        psmFileNameLabel.ToolTip = filePath;
-                        psmFileNameLabelStat.Text = filePath;
-                        psmFileNameLabelStat.ToolTip = filePath;
-                        resetPsmFileButton.IsEnabled = true;
-                        resetPsmFileButtonStat.IsEnabled = true;
+                        spectraFileNameLabel.Text = filePath;
                     }
-                    break;
-                default:
-                    MessageBox.Show("Cannot read file type: " + theExtension);
-                    break;
+                    else
+                    {
+                        spectraFileNameLabel.Text = "[Mouse over to view files]";
+                    }
+
+                    spectraFileNameLabel.ToolTip = string.Join("\n", spectraFilePaths);
+                    resetSpectraFileButton.IsEnabled = true;
+                }
+            }
+            else if (AcceptedResultsFormats.Contains(theExtension))
+            {
+                if (tsvResultsFilePath == null || !tsvResultsFilePath.Equals(filePath))
+                {
+                    resetFilesButton_Click(resetPsmFileButton, null);
+                    tsvResultsFilePath = filePath;
+                    psmFileNameLabel.Text = filePath;
+                    psmFileNameLabel.ToolTip = filePath;
+                    psmFileNameLabelStat.Text = filePath;
+                    psmFileNameLabelStat.ToolTip = filePath;
+                    resetPsmFileButton.IsEnabled = true;
+                    resetPsmFileButtonStat.IsEnabled = true;
+                }
+            }
+            else
+            {
+                MessageBox.Show("Cannot read file type: " + theExtension);
             }
         }
 
@@ -388,9 +387,11 @@ namespace MetaMorpheusGUI
 
         private void selectSpectraFileButton_Click(object sender, RoutedEventArgs e)
         {
+            string filterString = string.Join(";", AcceptedSpectraFormats.Select(p => "*" + p));
+
             Microsoft.Win32.OpenFileDialog openFileDialog1 = new Microsoft.Win32.OpenFileDialog
             {
-                Filter = "Spectra Files(*.raw;*.mzML)|*.raw;*.mzML",
+                Filter = "Spectra Files(" + filterString + ")|" + filterString,
                 FilterIndex = 1,
                 RestoreDirectory = true,
                 Multiselect = true
@@ -406,9 +407,11 @@ namespace MetaMorpheusGUI
 
         private void selectPsmFileButton_Click(object sender, RoutedEventArgs e)
         {
+            string filterString = string.Join(";", AcceptedResultsFormats.Select(p => "*" + p));
+
             Microsoft.Win32.OpenFileDialog openFileDialog1 = new Microsoft.Win32.OpenFileDialog
             {
-                Filter = "Result Files(*.psmtsv)|*.psmtsv",
+                Filter = "Result Files(" + filterString + ")|" + filterString,
                 FilterIndex = 1,
                 RestoreDirectory = true,
                 Multiselect = false
@@ -804,7 +807,7 @@ namespace MetaMorpheusGUI
             else
             {
                 int numberOfScansToExport = dataGridScanNums.SelectedItems.Count;
-                string directoryPath = Path.Combine(Path.GetDirectoryName(tsvResultsFilePath), "MetaDrawExport", 
+                string directoryPath = Path.Combine(Path.GetDirectoryName(tsvResultsFilePath), "MetaDrawExport",
                     DateTime.Now.ToString("yyyy-MM-dd-HH-mm-ss", CultureInfo.InvariantCulture));
 
                 foreach (object selectedItem in dataGridScanNums.SelectedItems)

--- a/Test/MetaDrawTest.cs
+++ b/Test/MetaDrawTest.cs
@@ -102,10 +102,10 @@ namespace Test
                 IEnumerable<string> actualIons = psms[i].VariantCrossingIons.Select(p => p.NeutralTheoreticalProduct.Annotation);
                 foreach (string expectedIon in expected[i])
                     Assert.IsTrue(actualIons.Contains(expectedIon),
-                       "VariantCrossingIons should contain ion " + expectedIon + " in file " + psms[i].Filename + ".");
+                       "VariantCrossingIons should contain ion " + expectedIon + " in file " + psms[i].FileNameWithoutExtension + ".");
                 foreach (string actualIon in actualIons)
                     Assert.IsTrue(expected[i].Contains(actualIon),
-                        "VariantCrossingIons should not contain ion " + actualIon + " in file " + psms[i].Filename + ".");
+                        "VariantCrossingIons should not contain ion " + actualIon + " in file " + psms[i].FileNameWithoutExtension + ".");
             }
         }
     }

--- a/Test/SearchEngineTests.cs
+++ b/Test/SearchEngineTests.cs
@@ -80,7 +80,7 @@ namespace Test
             Assert.AreEqual("T", psm.DecoyContamTarget);
             Assert.AreEqual(502.117, psm.DeltaScore);
             Assert.AreEqual("EIADGLCLEVEGK", psm.EssentialSeq);
-            Assert.AreEqual("sliced_b6", psm.Filename);
+            Assert.AreEqual("sliced_b6", psm.FileNameWithoutExtension);
             Assert.AreEqual("EIADGLC[Common Fixed:Carbamidomethyl on C]LEVEGK", psm.FullSequence);
             Assert.AreEqual("primary:Tpt1, synonym:Trt", psm.GeneName);
             Assert.AreEqual("", psm.IdentifiedSequenceVariations);


### PR DESCRIPTION
#1958 

- Can select multiple DB/spectra files and delete them
- Delete key on the keyboard will delete tasks
- Plus or minus keys will move tasks up or down
- Double-clicking a file or task will open it
- If all spectra files are deleted, the output file path is cleared
- Can right click -> Delete All for spectra, protein DBs, tasks
- Can right click -> Move task up or Move task down
- Clicking the "Select" button in MetaDraw (to add a spectra file or results file) will correctly display .mgf and .tsv as options
- Fixed a crash loading XL Task results in MetaDraw
- Increased the font size of the tasks in the Run tab from 11 to 13
- Added grid splitters to the Run tab so that the DB/spectra/tasks areas can be resized