### PR TITLE
custom file extension getter

### DIFF
--- a/EngineLayer/GlobalVariables.cs
+++ b/EngineLayer/GlobalVariables.cs
@@ -249,7 +249,7 @@ namespace EngineLayer
         }
 
         /// <summary>
-        /// Gets the file name with extension, keeping .gz appended for compressed files
+        /// Gets the file extension, keeping .gz appended for compressed files
         /// </summary>
         public static string GetFileExtension(string fileWithExtension)
         {

--- a/EngineLayer/GlobalVariables.cs
+++ b/EngineLayer/GlobalVariables.cs
@@ -253,6 +253,7 @@ namespace EngineLayer
         /// </summary>
         public static string GetFileExtension(string fileWithExtension)
         {
+            string extension = string.Empty;
             StringBuilder sb = new StringBuilder();
 
             for (int i = fileWithExtension.Length - 1; i >= 0; i--)
@@ -261,15 +262,18 @@ namespace EngineLayer
 
                 sb.Append(c);
 
-                if (c == '.' && new string(sb.ToString().Reverse().ToArray()) != ".gz")
+                if (c == '.')
                 {
-                    break;
+                    extension = new string(sb.ToString().Reverse().ToArray());
+
+                    if (extension != ".gz" || !fileWithExtension.Substring(0, i).Contains('.'))
+                    {
+                        break;
+                    }
                 }
             }
 
-            string extension = new string(sb.ToString().Reverse().ToArray());
-
-            return extension.Length == fileWithExtension.Length ? "" : extension;
+            return extension;
         }
 
         private static void SetMetaMorpheusVersion()

--- a/EngineLayer/GlobalVariables.cs
+++ b/EngineLayer/GlobalVariables.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using UsefulProteomicsDatabases;
 
 namespace EngineLayer
@@ -245,6 +246,30 @@ namespace EngineLayer
             {
                 file.CopyTo(Path.Combine(target.FullName, file.Name));
             }
+        }
+
+        /// <summary>
+        /// Gets the file name with extension, keeping .gz appended for compressed files
+        /// </summary>
+        public static string GetFileExtension(string fileWithExtension)
+        {
+            StringBuilder sb = new StringBuilder();
+
+            for (int i = fileWithExtension.Length - 1; i >= 0; i--)
+            {
+                char c = fileWithExtension[i];
+
+                sb.Append(c);
+
+                if (c == '.' && new string(sb.ToString().Reverse().ToArray()) != ".gz")
+                {
+                    break;
+                }
+            }
+
+            string extension = new string(sb.ToString().Reverse().ToArray());
+
+            return extension.Length == fileWithExtension.Length ? "" : extension;
         }
 
         private static void SetMetaMorpheusVersion()

--- a/EngineLayer/PsmTsv/PsmFromTsv.cs
+++ b/EngineLayer/PsmTsv/PsmFromTsv.cs
@@ -88,13 +88,24 @@ namespace EngineLayer
             var spl = line.Split(split);
 
             //Required properties
-            FileNameWithoutExtension = Path.GetFileNameWithoutExtension(spl[parsedHeader[PsmTsvHeader.FileName]].Trim());
+            FileNameWithoutExtension = spl[parsedHeader[PsmTsvHeader.FileName]].Trim();
+            
+            // remove file format, e.g., .raw, .mzML, .mgf
+            // this is more robust but slower than Path.GetFileNameWithoutExtension
+            if (FileNameWithoutExtension.Contains('.'))
+            {
+                foreach (var knownSpectraFileExtension in GlobalVariables.AcceptedSpectraFormats)
+                {
+                    FileNameWithoutExtension.Replace(knownSpectraFileExtension, string.Empty, StringComparison.InvariantCultureIgnoreCase);
+                }
+            }
+
             Ms2ScanNumber = int.Parse(spl[parsedHeader[PsmTsvHeader.Ms2ScanNumber]]);
 
             // this will probably not be known in an .mgf data file
             if (int.TryParse(spl[parsedHeader[PsmTsvHeader.PrecursorScanNum]].Trim(), out int result))
             {
-                PrecursorScanNum = result; 
+                PrecursorScanNum = result;
             }
             else
             {

--- a/GUI/MetaDraw/MetaDraw.xaml.cs
+++ b/GUI/MetaDraw/MetaDraw.xaml.cs
@@ -126,7 +126,7 @@ namespace MetaMorpheusGUI
 
         private void LoadFile(string filePath)
         {
-            var theExtension = Path.GetExtension(filePath).ToLower();
+            var theExtension = GlobalVariables.GetFileExtension(filePath).ToLowerInvariant();
 
             if (AcceptedSpectraFormats.Contains(theExtension))
             {

--- a/Test/GlobalVariablesTest.cs
+++ b/Test/GlobalVariablesTest.cs
@@ -54,5 +54,18 @@ namespace Test
 
             Directory.Delete(customDataDir, true);
         }
+
+        [Test]
+        public static void TestCustomFileExtensionGetter()
+        {
+            string test1 = @"C:\myFile.fasta";
+            Assert.That(GlobalVariables.GetFileExtension(test1) == ".fasta");
+
+            string test2 = @"C:\myFile.fasta.gz";
+            Assert.That(GlobalVariables.GetFileExtension(test2) == ".fasta.gz");
+
+            string test3 = @"C:\myFile.11.1.mzML";
+            Assert.That(GlobalVariables.GetFileExtension(test3) == ".mzML");
+        }
     }
 }

--- a/Test/GlobalVariablesTest.cs
+++ b/Test/GlobalVariablesTest.cs
@@ -66,6 +66,12 @@ namespace Test
 
             string test3 = @"C:\myFile.11.1.mzML";
             Assert.That(GlobalVariables.GetFileExtension(test3) == ".mzML");
+
+            string test4 = @"C:\myFile.gz";
+            Assert.That(GlobalVariables.GetFileExtension(test4) == ".gz");
+
+            string test5 = @"C:\myFile";
+            Assert.That(GlobalVariables.GetFileExtension(test5) == string.Empty);
         }
     }
 }


### PR DESCRIPTION
custom file extension getter that is more reliable than the microsoft one.
- can handle compressed files like .fasta.gz
- ignores periods in file names
- this change allows MetaDraw to load data from spectra files with periods in the name. related to #1974 