### PR TITLE
appveyor/dotnet fix

### DIFF
--- a/GUI/MetaDraw/MetaDraw.xaml.cs
+++ b/GUI/MetaDraw/MetaDraw.xaml.cs
@@ -360,7 +360,7 @@ namespace MetaMorpheusGUI
                 return;
             }
 
-            // draw the selected PSM
+            // draw the selected PSM 
             propertyView.Clear();
             PsmFromTsv row = (PsmFromTsv)dataGridScanNums.SelectedItem;
             System.Reflection.PropertyInfo[] temp = row.GetType().GetProperties();

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "3.1.102",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
appveyor is failing and i think it's on their end. .NET seems to have been updated.

edit: seems to be a microsoft issue. https://help.appveyor.com/discussions/problems/28561-build-failing-projectassetsjson-doesnt-have-a-target-for-net48

see also: https://www.appveyor.com/updates/2020/11/14/