### PR TITLE
ability to add spectra file directory in CMD

### DIFF
--- a/CMD/CommandLineSettings.cs
+++ b/CMD/CommandLineSettings.cs
@@ -127,7 +127,7 @@ namespace MetaMorpheusCommandLine
 
             foreach (string filename in Tasks)
             {
-                string ext = GlobalVariables.GetFileExtension(filename).ToLowerInvariant();
+                string ext = Path.GetExtension(filename).ToLowerInvariant();
 
                 if (ext != ".toml")
                 {
@@ -137,7 +137,9 @@ namespace MetaMorpheusCommandLine
 
             foreach (string filename in Databases)
             {
-                string ext = GlobalVariables.GetFileExtension(filename, getUncompressedExtension: true).ToLowerInvariant();
+                string ext = Path.GetExtension(filename).ToLowerInvariant();
+                bool compressed = ext.EndsWith("gz"); // allows for .bgz and .tgz, too which are used on occasion
+                ext = compressed ? Path.GetExtension(Path.GetFileNameWithoutExtension(filename)).ToLowerInvariant() : ext;
 
                 if (!GlobalVariables.AcceptedDatabaseFormats.Contains(ext))
                 {
@@ -147,7 +149,7 @@ namespace MetaMorpheusCommandLine
 
             foreach (string filename in Spectra)
             {
-                string ext = GlobalVariables.GetFileExtension(filename).ToLowerInvariant();
+                string ext = Path.GetExtension(filename).ToLowerInvariant();
 
                 if (!GlobalVariables.AcceptedSpectraFormats.Contains(ext))
                 {

--- a/EngineLayer/GlobalVariables.cs
+++ b/EngineLayer/GlobalVariables.cs
@@ -226,7 +226,7 @@ namespace EngineLayer
                 FileName = path
             };
 
-            if (useNotepadToOpenToml && Path.GetExtension(path) == ".toml" && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (useNotepadToOpenToml && Path.GetExtension(path).ToLowerInvariant() == ".toml" && RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 p.StartInfo.FileName = "notepad.exe";
                 p.StartInfo.Arguments = path;
@@ -249,9 +249,9 @@ namespace EngineLayer
         }
 
         /// <summary>
-        /// Gets the file extension, keeping .gz appended for compressed files
+        /// Gets the file extension, with the option to keep .gz appended for compressed files
         /// </summary>
-        public static string GetFileExtension(string fileWithExtension)
+        public static string GetFileExtension(string fileWithExtension, bool getUncompressedExtension = true)
         {
             string extension = string.Empty;
             StringBuilder sb = new StringBuilder();
@@ -266,14 +266,42 @@ namespace EngineLayer
                 {
                     extension = new string(sb.ToString().Reverse().ToArray());
 
-                    if (extension != ".gz" || !fileWithExtension.Substring(0, i).Contains('.'))
+                    if (!extension.ToLowerInvariant().EndsWith("gz") || extension.Count(p => p == '.') >= 2)
                     {
                         break;
                     }
                 }
             }
 
+            if (getUncompressedExtension && extension.ToLowerInvariant().EndsWith("gz"))
+            {
+                int indexOfGz = extension.ToLowerInvariant().IndexOf("gz");
+
+                for (int i = indexOfGz; i >= 0; i--)
+                {
+                    if (extension[i] == '.')
+                    {
+                        extension = extension.Substring(0, i);
+                        break;
+                    }
+                }
+            }
+
             return extension;
+        }
+
+        public static string GetFilenameWithoutExtension(string path)
+        {
+            Path.GetFileNameWithoutExtension("");
+            var filename = Path.GetFileName(path);
+            string extension = GetFileExtension(filename, getUncompressedExtension: false);
+
+            if (extension == string.Empty)
+            {
+                return filename;
+            }
+
+            return filename.Replace(extension, string.Empty);
         }
 
         private static void SetMetaMorpheusVersion()

--- a/Test/GlobalVariablesTest.cs
+++ b/Test/GlobalVariablesTest.cs
@@ -59,19 +59,39 @@ namespace Test
         public static void TestCustomFileExtensionGetter()
         {
             string test1 = @"C:\myFile.fasta";
-            Assert.That(GlobalVariables.GetFileExtension(test1) == ".fasta");
+            Assert.That(GlobalVariables.GetFileExtension(test1, getUncompressedExtension: false) == ".fasta");
+            Assert.That(GlobalVariables.GetFileExtension(test1, getUncompressedExtension: true) == ".fasta");
+            Assert.That(GlobalVariables.GetFilenameWithoutExtension(test1) == "myFile");
 
             string test2 = @"C:\myFile.fasta.gz";
-            Assert.That(GlobalVariables.GetFileExtension(test2) == ".fasta.gz");
+            Assert.That(GlobalVariables.GetFileExtension(test2, getUncompressedExtension: false) == ".fasta.gz");
+            Assert.That(GlobalVariables.GetFileExtension(test2, getUncompressedExtension: true) == ".fasta");
+            Assert.That(GlobalVariables.GetFilenameWithoutExtension(test2) == "myFile");
 
             string test3 = @"C:\myFile.11.1.mzML";
-            Assert.That(GlobalVariables.GetFileExtension(test3) == ".mzML");
+            Assert.That(GlobalVariables.GetFileExtension(test3, getUncompressedExtension: false) == ".mzML");
+            Assert.That(GlobalVariables.GetFileExtension(test3, getUncompressedExtension: true) == ".mzML");
+            Assert.That(GlobalVariables.GetFilenameWithoutExtension(test3) == "myFile.11.1");
 
             string test4 = @"C:\myFile.gz";
-            Assert.That(GlobalVariables.GetFileExtension(test4) == ".gz");
+            Assert.That(GlobalVariables.GetFileExtension(test4, getUncompressedExtension: false) == ".gz");
+            Assert.That(GlobalVariables.GetFileExtension(test4, getUncompressedExtension: true) == string.Empty);
+            Assert.That(GlobalVariables.GetFilenameWithoutExtension(test4) == "myFile");
 
             string test5 = @"C:\myFile";
-            Assert.That(GlobalVariables.GetFileExtension(test5) == string.Empty);
+            Assert.That(GlobalVariables.GetFileExtension(test5, getUncompressedExtension: false) == string.Empty);
+            Assert.That(GlobalVariables.GetFileExtension(test5, getUncompressedExtension: true) == string.Empty);
+            Assert.That(GlobalVariables.GetFilenameWithoutExtension(test5) == "myFile");
+
+            string test6 = @"C:\my.Fi.le.fasta.gz";
+            Assert.That(GlobalVariables.GetFileExtension(test6, getUncompressedExtension: false) == ".fasta.gz");
+            Assert.That(GlobalVariables.GetFileExtension(test6, getUncompressedExtension: true) == ".fasta");
+            Assert.That(GlobalVariables.GetFilenameWithoutExtension(test6) == "my.Fi.le");
+
+            string test7 = @"C:\my.Fi.le.fasta.bGZ";
+            Assert.That(GlobalVariables.GetFileExtension(test7, getUncompressedExtension: false) == ".fasta.bGZ");
+            Assert.That(GlobalVariables.GetFileExtension(test7, getUncompressedExtension: true) == ".fasta");
+            Assert.That(GlobalVariables.GetFilenameWithoutExtension(test7) == "my.Fi.le");
         }
     }
 }


### PR DESCRIPTION
can specify a directory of spectra files. fixes #1901 .

unfortunately, no unit test for the new CMD option as this seems to not play well w/ appveyor. but I did manually test it.