### PR TITLE
Delete global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "3.1.102",
-    "rollForward": "latestFeature"
-  }
-}


### PR DESCRIPTION
#1981 seems to be resolved. testing to see if appveyor builds without global.json.

https://help.appveyor.com/discussions/problems/28561-build-failing-projectassetsjson-doesnt-have-a-target-for-net48

https://developercommunity.visualstudio.com/content/problem/1248649/error-netsdk1005-assets-file-projectassetsjson-doe.html