### PR TITLE
[WIP] install bash and procps in docker version for nextflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,11 @@ FROM mcr.microsoft.com/dotnet/core/runtime:3.1-alpine AS build
 ## Copies contents of the build folder into the Docker image
 ADD CMD/bin/Release/netcoreapp3.1/ /metamorpheus/
 
+## Installs bash (seemingly necessary for NextFlow)
+RUN apk add --no-cache bash
+
+## Installs procps
+RUN apk add --no-cache procps
+
 ## Set the entrypoint of the Docker image to CMD.dll
 ENTRYPOINT ["dotnet", "/metamorpheus/CMD.dll"]


### PR DESCRIPTION
this PR installs bash and procps in the Linux docker image. bash is required to run metamorpheus in a nextflow pipeline, and procps lets nextflow monitor computational resources used by the image.