### PR TITLE
small experimental design GUI changes

### DIFF
--- a/GUI/ExperimentalDesignWindow.xaml
+++ b/GUI/ExperimentalDesignWindow.xaml
@@ -7,6 +7,17 @@
         mc:Ignorable="d"
         KeyDown="KeyPressed"
         Title="Experimental Design" Height="400" Width="650" WindowStartupLocation="CenterScreen">
+
+    <Window.Resources>
+        <ResourceDictionary>
+            <!--Styling for the grid that defines each page-->
+            <Style x:Key="DataGridCellStyle" TargetType="DataGridCell">
+                <Setter Property="Background" Value="{StaticResource DataGridHeaderColor}"/>
+                <Setter Property="TextBox.IsReadOnly" Value="True"/>
+            </Style>
+        </ResourceDictionary>
+    </Window.Resources>
+    
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="1*" />
@@ -17,7 +28,7 @@
         <DataGrid x:Name="DgQuant" ItemsSource="{Binding}" Grid.Row="0" VerticalAlignment="Stretch" CanUserDeleteRows="False" 
                   CanUserAddRows="False" CanUserReorderColumns="False" AutoGenerateColumns="False" SelectionUnit="Cell">
             <DataGrid.Columns>
-                <DataGridTextColumn Header="File" Binding="{Binding FileNameWithExtension}" Width="200" />
+                <DataGridTextColumn Header="File" Binding="{Binding FileNameWithExtension, Mode=OneWay}" Width="200" CellStyle="{StaticResource DataGridCellStyle}" />
                 <DataGridTextColumn Header="Condition" Binding="{Binding Condition, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="100" />
                 <DataGridTextColumn Header="Biological Rep" Binding="{Binding Biorep, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="100" />
                 <DataGridTextColumn Header="Fraction" Binding="{Binding Fraction, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="100" />

--- a/GUI/ExperimentalDesignWindow.xaml
+++ b/GUI/ExperimentalDesignWindow.xaml
@@ -8,20 +8,28 @@
         KeyDown="KeyPressed"
         Title="Experimental Design" Height="400" Width="650" WindowStartupLocation="CenterScreen">
     <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="1*" />
+            <RowDefinition Height="22"/>
+        </Grid.RowDefinitions>
+        
         <!--Data grid-->
-        <DataGrid x:Name="DgQuant" ItemsSource="{Binding}" Grid.Row="1" VerticalAlignment="Stretch" CanUserDeleteRows="False" CanUserAddRows="False" CanUserReorderColumns="False"
-                  AutoGenerateColumns="False" KeyDown="DgQuant_KeyDown">
+        <DataGrid x:Name="DgQuant" ItemsSource="{Binding}" Grid.Row="0" VerticalAlignment="Stretch" CanUserDeleteRows="False" 
+                  CanUserAddRows="False" CanUserReorderColumns="False" AutoGenerateColumns="False" SelectionUnit="Cell">
             <DataGrid.Columns>
                 <DataGridTextColumn Header="File" Binding="{Binding FileNameWithExtension}" Width="200" />
-                <DataGridTextColumn Header="Condition" Binding="{Binding Condition}" Width="100" />
-                <DataGridTextColumn Header="Biological Rep" Binding="{Binding Biorep}" Width="100" />
-                <DataGridTextColumn Header="Fraction" Binding="{Binding Fraction}" Width="100" />
-                <DataGridTextColumn Header="Technical Rep" Binding="{Binding Techrep}" Width="100" />
+                <DataGridTextColumn Header="Condition" Binding="{Binding Condition, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="100" />
+                <DataGridTextColumn Header="Biological Rep" Binding="{Binding Biorep, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="100" />
+                <DataGridTextColumn Header="Fraction" Binding="{Binding Fraction, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="100" />
+                <DataGridTextColumn Header="Technical Rep" Binding="{Binding Techrep, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Width="100" />
             </DataGrid.Columns>
+            <DataGrid.CommandBindings>
+                <CommandBinding Command="{x:Static ApplicationCommands.Paste}" Executed="Paste"/>
+            </DataGrid.CommandBindings>
         </DataGrid>
 
         <!--Save/cancel buttons-->
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Grid.Row="3" Height="25" VerticalAlignment="Bottom">
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Grid.Row="2" VerticalAlignment="Bottom">
             <Button x:Name="BtnSaveQuant" Content="Save Experimental Design" Click="BtnSaveQuant_Click"/>
             <Button x:Name="DeleteExperDesignButton" Content="Clear" Click="DeleteExperDesignButton_Click"/>
             <Button x:Name="BtnCancelQuant" Content="Cancel" Click="BtnCancelQuant_Click"/>

--- a/GUI/ExperimentalDesignWindow.xaml.cs
+++ b/GUI/ExperimentalDesignWindow.xaml.cs
@@ -200,6 +200,14 @@ namespace MetaMorpheusGUI
 
                     try
                     {
+                        // selected cell is in the "File" column
+                        if (columnIndex == 0)
+                        {
+                            listOfSpectraFiles[i + rowIndex].Condition = pastedCells[1];
+                            listOfSpectraFiles[i + rowIndex].Biorep = pastedCells[2];
+                            listOfSpectraFiles[i + rowIndex].Fraction = pastedCells[3];
+                            listOfSpectraFiles[i + rowIndex].Techrep = pastedCells[4];
+                        }
                         // selected cell is in the "Condition" column
                         if (columnIndex == 1)
                         {

--- a/GUI/ExperimentalDesignWindow.xaml.cs
+++ b/GUI/ExperimentalDesignWindow.xaml.cs
@@ -166,9 +166,73 @@ namespace MetaMorpheusGUI
             InitializeExperDesign();
         }
 
-        private void DgQuant_KeyDown(object sender, KeyEventArgs e)
+        private void Paste(object sender, ExecutedRoutedEventArgs e)
         {
+            var selectedCell = DgQuant.SelectedCells.FirstOrDefault();
+            if (selectedCell == null)
+            {
+                return;
+            }
 
+            var selectedSpectraFile = (ExperimentalDesignForDataGrid)selectedCell.Item;
+            var listOfSpectraFiles = DgQuant.ItemContainerGenerator.Items.Select(p => (ExperimentalDesignForDataGrid)p).ToList();
+
+            int rowIndex = listOfSpectraFiles.IndexOf(selectedSpectraFile);
+            int columnIndex = DgQuant.Columns.IndexOf(selectedCell.Column);
+
+            // get data from clipboard in text format
+            // clipboardRawData will be null if the data on the clipboard is not text
+            object clipboardRawData = System.Windows.Clipboard.GetDataObject().GetData(DataFormats.Text);
+
+            if (clipboardRawData != null)
+            {
+                string pastedText = clipboardRawData as string;
+
+                // each line is delimited by a newline and/or return character
+                var pastedLines = pastedText.Split(new char[] { '\r', '\n' }).Where(p => !string.IsNullOrWhiteSpace(p)).ToList();
+
+                for (int i = 0; i < pastedLines.Count && i + rowIndex < listOfSpectraFiles.Count; i++)
+                {
+                    var pastedLine = pastedLines[i];
+
+                    // each element in the line is delimited by tabs or commas
+                    var pastedCells = pastedLine.Split(new char[] { '\t', ',' });
+
+                    try
+                    {
+                        // selected cell is in the "Condition" column
+                        if (columnIndex == 1)
+                        {
+                            listOfSpectraFiles[i + rowIndex].Condition = pastedCells[0];
+                            listOfSpectraFiles[i + rowIndex].Biorep = pastedCells[1];
+                            listOfSpectraFiles[i + rowIndex].Fraction = pastedCells[2];
+                            listOfSpectraFiles[i + rowIndex].Techrep = pastedCells[3];
+                        }
+                        // selected cell is in the "Biorep" column
+                        if (columnIndex == 2)
+                        {
+                            listOfSpectraFiles[i + rowIndex].Biorep = pastedCells[0];
+                            listOfSpectraFiles[i + rowIndex].Fraction = pastedCells[1];
+                            listOfSpectraFiles[i + rowIndex].Techrep = pastedCells[2];
+                        }
+                        // selected cell is in the "Fraction" column
+                        if (columnIndex == 3)
+                        {
+                            listOfSpectraFiles[i + rowIndex].Fraction = pastedCells[0];
+                            listOfSpectraFiles[i + rowIndex].Techrep = pastedCells[1];
+                        }
+                        // selected cell is in the "Techrep" column
+                        if (columnIndex == 4)
+                        {
+                            listOfSpectraFiles[i + rowIndex].Techrep = pastedCells[0];
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        // don't really need to print a warning
+                    }
+                }
+            }
         }
     }
 }

--- a/GUI/ForDisplayingInDataGrids/ExperimentalDesignForDataGrid.cs
+++ b/GUI/ForDisplayingInDataGrids/ExperimentalDesignForDataGrid.cs
@@ -4,10 +4,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.IO;
+using System.ComponentModel;
 
 namespace MetaMorpheusGUI
 {
-    public class ExperimentalDesignForDataGrid
+    public class ExperimentalDesignForDataGrid : INotifyPropertyChanged
     {
         public ExperimentalDesignForDataGrid(string fullFilePathWithExtension)
         {
@@ -17,9 +18,23 @@ namespace MetaMorpheusGUI
 
         public string FullFilePathWithExtension { get; private set; }
         public string FileNameWithExtension { get; private set; }
-        public string Condition { get; set; }
-        public string Biorep { get; set; }
-        public string Fraction { get; set; }
-        public string Techrep { get; set; }
+        public string Condition { get { return _condition; } set { _condition = value; RaisePropertyChanged("Condition"); } }
+        public string Biorep { get { return _biorep; } set { _biorep = value; RaisePropertyChanged("Biorep"); } }
+        public string Fraction { get { return _fraction; } set { _fraction = value; RaisePropertyChanged("Fraction"); } }
+        public string Techrep { get { return _techrep; } set { _techrep = value; RaisePropertyChanged("Techrep"); } }
+
+        private string _condition;
+        private string _biorep;
+        private string _fraction;
+        private string _techrep;
+
+        public event PropertyChangedEventHandler PropertyChanged;
+        private void RaisePropertyChanged(string propertyName)
+        {
+            if (this.PropertyChanged != null)
+            {
+                this.PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+            }
+        }
     }
 }


### PR DESCRIPTION
- Add ability to copy+paste tab- or comma-delimited cells into the Experimental Design window, e.g. from Excel (currently only w/ the ctrl+V keyboard shortcut)
- Fix an issue in the experimental design GUI where the buttons at the bottom of the window obscured data cells