### PR TITLE
Incorporation of Rescue and Resolve Protein Inference Algorithm

### DIFF
--- a/CMD/Program.cs
+++ b/CMD/Program.cs
@@ -313,7 +313,7 @@ namespace MetaMorpheusCommandLine
                 }
             }
 
-            EverythingRunnerEngine a = new EverythingRunnerEngine(taskList, startingRawFilenameList, startingXmlDbFilenameList, settings.OutputFolder);
+            EverythingRunnerEngine a = new EverythingRunnerEngine(taskList, startingRawFilenameList, startingXmlDbFilenameList, settings.OutputFolder, settings.CPM, settings.OrfCallingTables);
 
             try
             {

--- a/EngineLayer/GlobalVariables.cs
+++ b/EngineLayer/GlobalVariables.cs
@@ -17,6 +17,13 @@ namespace EngineLayer
 {
     public static class GlobalVariables
     {
+
+        // this is kind of hacky to have a global dictionary for this info.. it would be
+        // better to edit the protein object to have its own proteogenomic long read info
+        // but this would require editing mzLib which is more work than it's worth at this stage.
+        // TODO: change this so the protein object in mzLib has long read info as a variable
+        public static Dictionary<string, LongReadInfo> ProteinToProteogenomicInfo;
+
         // for now, these are only used for error-checking in the command-line version.
         // compressed versions of the protein databases (e.g., .xml.gz) are also supported
         public static List<string> AcceptedDatabaseFormats { get; private set; }

--- a/EngineLayer/LongReadInfo.cs
+++ b/EngineLayer/LongReadInfo.cs
@@ -1,0 +1,56 @@
+﻿using Proteomics;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace EngineLayer
+{
+    public class LongReadInfo
+    {
+        // protein inference weight for proteins w/ no corresponding ORF calling data.
+        // this would be used if UniProt proteins are added for genes that weren't observed in the transcriptomics data
+        public static readonly double ProteinInferenceWeightForNoTranscriptomicsData = 0.5;
+
+        public readonly string ProteinAccession;
+        public readonly double CPM;
+        public readonly double ProteinInferenceWeight;
+
+        public LongReadInfo(string protein, double cpm)
+        {
+            this.ProteinAccession = protein;
+            this.CPM = cpm;
+            ProteinInferenceWeight = CalculateProteinInferenceWeight();
+        }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder();
+
+            sb.Append(CPM.ToString("F2"));
+
+            return sb.ToString();
+        }
+
+        private double CalculateProteinInferenceWeight()
+        {
+            if (CPM < 0.5)
+            {
+                return 0.1;
+            }
+            else if (CPM < 1)
+            {
+                return 0.3;
+            }
+            else if (CPM < 5)
+            {
+                return 0.5;
+            }
+            else if (CPM < 10)
+            {
+                return 0.7;
+            }
+
+            return 1;
+        }
+    }
+}

--- a/GUI/MainWindow.xaml.cs
+++ b/GUI/MainWindow.xaml.cs
@@ -985,7 +985,7 @@ namespace MetaMorpheusGUI
             EverythingRunnerEngine a = new EverythingRunnerEngine(InProgressTasks.Select(b => (b.DisplayName, b.Task)).ToList(),
                 SpectraFiles.Where(b => b.Use).Select(b => b.FilePath).ToList(),
                 ProteinDatabases.Where(b => b.Use).Select(b => new DbForTask(b.FilePath, b.Contaminant)).ToList(),
-                outputFolder);
+                outputFolder, 25.0);
 
             var t = new Task(a.Run);
             t.ContinueWith(EverythingRunnerExceptionHandler, TaskContinuationOptions.OnlyOnFaulted);

--- a/TaskLayer/CalibrationTask/CalibrationTask.cs
+++ b/TaskLayer/CalibrationTask/CalibrationTask.cs
@@ -33,7 +33,7 @@ namespace TaskLayer
 
         public CalibrationParameters CalibrationParameters { get; set; }
 
-        protected override MyTaskResults RunSpecific(string OutputFolder, List<DbForTask> dbFilenameList, List<string> currentRawFileList, string taskId, FileSpecificParameters[] fileSettingsList)
+        protected override MyTaskResults RunSpecific(string OutputFolder, List<DbForTask> dbFilenameList, List<string> currentRawFileList, string taskId, FileSpecificParameters[] fileSettingsList, double cpmThreshold, List<string> orfCallingTables = null)
         {
             LoadModifications(taskId, out var variableModifications, out var fixedModifications, out var localizeableModificationTypes);
 

--- a/TaskLayer/EverythingRunnerEngine.cs
+++ b/TaskLayer/EverythingRunnerEngine.cs
@@ -26,8 +26,7 @@ namespace TaskLayer
             CurrentRawDataFilenameList = startingRawFilenameList;
             CurrentXmlDbFilenameList = startingXmlDbFilenameList;
             OrfCallingTables = orfCallingTables;
-            CPM = cpmThreshold;
-            Console.WriteLine("Test 1:" + CPM);
+            CPM = cpmThreshold;            
         }
 
         public static event EventHandler<StringEventArgs> FinishedWritingAllResultsFileHandler;

--- a/TaskLayer/EverythingRunnerEngine.cs
+++ b/TaskLayer/EverythingRunnerEngine.cs
@@ -15,14 +15,19 @@ namespace TaskLayer
         private string OutputFolder;
         private List<string> CurrentRawDataFilenameList;
         private List<DbForTask> CurrentXmlDbFilenameList;
+        private List<string> OrfCallingTables;
+        private double CPM;
 
-        public EverythingRunnerEngine(List<(string, MetaMorpheusTask)> taskList, List<string> startingRawFilenameList, List<DbForTask> startingXmlDbFilenameList, string outputFolder)
+        public EverythingRunnerEngine(List<(string, MetaMorpheusTask)> taskList, List<string> startingRawFilenameList, List<DbForTask> startingXmlDbFilenameList, string outputFolder, double cpmThreshold, List<string> orfCallingTables = null)
         {
             TaskList = taskList;
             OutputFolder = outputFolder.Trim('"');
 
             CurrentRawDataFilenameList = startingRawFilenameList;
             CurrentXmlDbFilenameList = startingXmlDbFilenameList;
+            OrfCallingTables = orfCallingTables;
+            CPM = cpmThreshold;
+            Console.WriteLine("Test 1:" + CPM);
         }
 
         public static event EventHandler<StringEventArgs> FinishedWritingAllResultsFileHandler;
@@ -83,7 +88,7 @@ namespace TaskLayer
                     Directory.CreateDirectory(outputFolderForThisTask);
 
                 // Actual task running code
-                var myTaskResults = ok.Item2.RunTask(outputFolderForThisTask, CurrentXmlDbFilenameList, CurrentRawDataFilenameList, ok.Item1);
+                var myTaskResults = ok.Item2.RunTask(outputFolderForThisTask, CurrentXmlDbFilenameList, CurrentRawDataFilenameList, ok.Item1, CPM, OrfCallingTables);
 
                 if (myTaskResults.NewDatabases != null)
                 {

--- a/TaskLayer/GPTMDTask/GPTMDTask.cs
+++ b/TaskLayer/GPTMDTask/GPTMDTask.cs
@@ -27,7 +27,7 @@ namespace TaskLayer
 
         public GptmdParameters GptmdParameters { get; set; }
 
-        protected override MyTaskResults RunSpecific(string OutputFolder, List<DbForTask> dbFilenameList, List<string> currentRawFileList, string taskId, FileSpecificParameters[] fileSettingsList)
+        protected override MyTaskResults RunSpecific(string OutputFolder, List<DbForTask> dbFilenameList, List<string> currentRawFileList, string taskId, FileSpecificParameters[] fileSettingsList, double cpmThreshold, List<string> orfCallingTables = null)
         {
             LoadModifications(taskId, out var variableModifications, out var fixedModifications, out var localizeableModificationTypes);
 

--- a/TaskLayer/GlycoSearchTask/GlycoSearchTask.cs
+++ b/TaskLayer/GlycoSearchTask/GlycoSearchTask.cs
@@ -40,7 +40,7 @@ namespace TaskLayer
 
         public GlycoSearchParameters _glycoSearchParameters { get; set; }
 
-        protected override MyTaskResults RunSpecific(string OutputFolder, List<DbForTask> dbFilenameList, List<string> currentRawFileList, string taskId, FileSpecificParameters[] fileSettingsList)
+        protected override MyTaskResults RunSpecific(string OutputFolder, List<DbForTask> dbFilenameList, List<string> currentRawFileList, string taskId, FileSpecificParameters[] fileSettingsList, double cpmThreshold, List<string> orfCallingTables = null)
         {
             MyTaskResults = new MyTaskResults(this);
             List<List<GlycoSpectralMatch>> ListOfGsmsPerMS2Scan = new List<List<GlycoSpectralMatch>>();

--- a/TaskLayer/GlycoSearchTask/PostGlycoSearchAnalysisTask.cs
+++ b/TaskLayer/GlycoSearchTask/PostGlycoSearchAnalysisTask.cs
@@ -15,7 +15,7 @@ namespace TaskLayer
         {
         }
 
-        protected override MyTaskResults RunSpecific(string OutputFolder, List<DbForTask> dbFilenameList, List<string> currentRawFileList, string taskId, FileSpecificParameters[] fileSettingsList)
+        protected override MyTaskResults RunSpecific(string OutputFolder, List<DbForTask> dbFilenameList, List<string> currentRawFileList, string taskId, FileSpecificParameters[] fileSettingsList, double cpmThreshold, List<string> orfCallingTables = null)
         {
             return null;
         }

--- a/TaskLayer/MetaMorpheusTask.cs
+++ b/TaskLayer/MetaMorpheusTask.cs
@@ -448,8 +448,7 @@ namespace TaskLayer
                 }
 
                 if (this is SearchTask s)
-                {
-                    Console.WriteLine("Test2:" + cpmThreshold);
+                {                    
                     s.RunSpecific(output_folder, currentProteinDbFilenameList, currentRawDataFilepathList, displayName, fileSettingsList, cpmThreshold, orfCallingTables);                    
                 }
                 else

--- a/TaskLayer/SearchTask/PostSearchAnalysisTask.cs
+++ b/TaskLayer/SearchTask/PostSearchAnalysisTask.cs
@@ -81,7 +81,7 @@ namespace TaskLayer
             return Parameters.SearchTaskResults;
         }
 
-        protected override MyTaskResults RunSpecific(string OutputFolder, List<DbForTask> dbFilenameList, List<string> currentRawFileList, string taskId, FileSpecificParameters[] fileSettingsList)
+        protected override MyTaskResults RunSpecific(string OutputFolder, List<DbForTask> dbFilenameList, List<string> currentRawFileList, string taskId, FileSpecificParameters[] fileSettingsList, double cpmThreshold, List<string> orfCallingTables = null)
         {
             MyTaskResults = new MyTaskResults(this);
             return null;
@@ -128,7 +128,7 @@ namespace TaskLayer
             List<PeptideSpectralMatch> psmsForProteinParsimony = Parameters.AllPsms;
 
             // run parsimony
-            ProteinParsimonyResults proteinAnalysisResults = (ProteinParsimonyResults)(new ProteinParsimonyEngine(psmsForProteinParsimony, Parameters.SearchParameters.ModPeptidesAreDifferent, CommonParameters, this.FileSpecificParameters, new List<string> { Parameters.SearchTaskId }).Run());
+            ProteinParsimonyResults proteinAnalysisResults = (ProteinParsimonyResults)(new ProteinParsimonyEngine(psmsForProteinParsimony, Parameters.SearchParameters.ModPeptidesAreDifferent, CommonParameters, this.FileSpecificParameters, Parameters.SearchParameters.UseOrfCallingInfoInProteinInference, Parameters.SearchParameters.CPMThreshold, new List<string> { Parameters.SearchTaskId }).Run());
 
             // score protein groups and calculate FDR
             ProteinScoringAndFdrResults proteinScoringAndFdrResults = (ProteinScoringAndFdrResults)new ProteinScoringAndFdrEngine(proteinAnalysisResults.ProteinGroups, psmsForProteinParsimony,

--- a/TaskLayer/SearchTask/SearchParameters.cs
+++ b/TaskLayer/SearchTask/SearchParameters.cs
@@ -54,6 +54,8 @@ namespace TaskLayer
             WriteIndividualFiles = true;
             LocalFdrCategories = new List<FdrCategory> { FdrCategory.FullySpecific };
             TCAmbiguity = TargetContaminantAmbiguity.RemoveContaminant;
+            UseOrfCallingInfoInProteinInference = false;
+            CPMThreshold = 25.0;
         }
 
         public bool DisposeOfFileWhenDone { get; set; }
@@ -88,5 +90,7 @@ namespace TaskLayer
         public SilacLabel StartTurnoverLabel { get; set; } //used for SILAC turnover experiments
         public SilacLabel EndTurnoverLabel { get; set; } //used for SILAC turnover experiments
         public TargetContaminantAmbiguity TCAmbiguity { get; set; }
+        public bool UseOrfCallingInfoInProteinInference { get; set; }
+        public double CPMThreshold { get; set; }
     }
 }

--- a/TaskLayer/SearchTask/SearchTask.cs
+++ b/TaskLayer/SearchTask/SearchTask.cs
@@ -81,7 +81,7 @@ namespace TaskLayer
             }
         }
 
-        protected override MyTaskResults RunSpecific(string OutputFolder, List<DbForTask> dbFilenameList, List<string> currentRawFileList, string taskId, FileSpecificParameters[] fileSettingsList)
+        protected override MyTaskResults RunSpecific(string OutputFolder, List<DbForTask> dbFilenameList, List<string> currentRawFileList, string taskId, FileSpecificParameters[] fileSettingsList, double cpmThreshold, List<string> orfCallingTables = null)
         {
             if (SearchParameters.DoQuantification)
             {
@@ -137,7 +137,8 @@ namespace TaskLayer
             LoadModifications(taskId, out var variableModifications, out var fixedModifications, out var localizeableModificationTypes);
 
             // load proteins
-            List<Protein> proteinList = LoadProteins(taskId, dbFilenameList, SearchParameters.SearchTarget, SearchParameters.DecoyType, localizeableModificationTypes, CommonParameters);
+            List<Protein> proteinList = LoadProteins(taskId, dbFilenameList, SearchParameters.SearchTarget, SearchParameters.DecoyType, localizeableModificationTypes, CommonParameters,
+                 orfCallingTables);
             SanitizeProteinDatabase(proteinList, SearchParameters.TCAmbiguity);
 
             // load spectral libraries
@@ -369,6 +370,8 @@ namespace TaskLayer
             {
                 allPsms = NonSpecificEnzymeSearchEngine.ResolveFdrCategorySpecificPsms(allCategorySpecificPsms, numNotches, taskId, CommonParameters, FileSpecificParameters);
             }
+
+            SearchParameters.CPMThreshold = cpmThreshold;
 
             PostSearchAnalysisParameters parameters = new PostSearchAnalysisParameters
             {

--- a/TaskLayer/XLSearchTask/PostXLSearchAnalysisTask.cs
+++ b/TaskLayer/XLSearchTask/PostXLSearchAnalysisTask.cs
@@ -16,7 +16,7 @@ namespace TaskLayer
         {
         }
 
-        protected override MyTaskResults RunSpecific(string OutputFolder, List<DbForTask> dbFilenameList, List<string> currentRawFileList, string taskId, FileSpecificParameters[] fileSettingsList)
+        protected override MyTaskResults RunSpecific(string OutputFolder, List<DbForTask> dbFilenameList, List<string> currentRawFileList, string taskId, FileSpecificParameters[] fileSettingsList, double cpmThreshold, List<string> orfCallingTables = null)
         {
             return null;
         }

--- a/TaskLayer/XLSearchTask/XLSearchTask.cs
+++ b/TaskLayer/XLSearchTask/XLSearchTask.cs
@@ -36,7 +36,7 @@ namespace TaskLayer
 
         public XlSearchParameters XlSearchParameters { get; set; }
 
-        protected override MyTaskResults RunSpecific(string OutputFolder, List<DbForTask> dbFilenameList, List<string> currentRawFileList, string taskId, FileSpecificParameters[] fileSettingsList)
+        protected override MyTaskResults RunSpecific(string OutputFolder, List<DbForTask> dbFilenameList, List<string> currentRawFileList, string taskId, FileSpecificParameters[] fileSettingsList, double cpmThreshold, List<string> orfCallingTables = null)
         {
             MyTaskResults = new MyTaskResults(this);
             List<List<CrosslinkSpectralMatch>> ListOfCsmsPerMS2Scan = new List<List<CrosslinkSpectralMatch>>();

--- a/Test/AmbiguityTest.cs
+++ b/Test/AmbiguityTest.cs
@@ -91,7 +91,7 @@ namespace Test
             SearchTask modernTask = new SearchTask();
             modernTask.SearchParameters = modernSearchParams;
 
-            EverythingRunnerEngine engine = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("task1", modernTask) }, new List<string> { mzmlName }, new List<DbForTask> { new DbForTask(xmlName, false), new DbForTask(xmlName, true) }, outputFolder);
+            EverythingRunnerEngine engine = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("task1", modernTask) }, new List<string> { mzmlName }, new List<DbForTask> { new DbForTask(xmlName, false), new DbForTask(xmlName, true) }, outputFolder, 25.0);
             engine.Run();
             //run the modern search again now that it's reading the index instead of writing it.
             engine.Run();
@@ -110,7 +110,7 @@ namespace Test
             modernTask = new SearchTask();
             modernTask.SearchParameters = modernSearchParams;
 
-            engine = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("task1", modernTask) }, new List<string> { mzmlName }, new List<DbForTask> { new DbForTask(xmlName, false), new DbForTask(xmlName, true) }, outputFolder);
+            engine = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("task1", modernTask) }, new List<string> { mzmlName }, new List<DbForTask> { new DbForTask(xmlName, false), new DbForTask(xmlName, true) }, outputFolder, 25.0);
             engine.Run();
             //run the modern search again now that it's reading the index instead of writing it.
             engine.Run();
@@ -129,7 +129,7 @@ namespace Test
             modernTask = new SearchTask();
             modernTask.SearchParameters = modernSearchParams;
 
-            engine = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("task1", modernTask) }, new List<string> { mzmlName }, new List<DbForTask> { new DbForTask(xmlName, false), new DbForTask(xmlName, true) }, outputFolder);
+            engine = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("task1", modernTask) }, new List<string> { mzmlName }, new List<DbForTask> { new DbForTask(xmlName, false), new DbForTask(xmlName, true) }, outputFolder, 25.0);
             engine.Run();
             //run the modern search again now that it's reading the index instead of writing it.
             engine.Run();

--- a/Test/AnalysisEngineTest.cs
+++ b/Test/AnalysisEngineTest.cs
@@ -105,7 +105,7 @@ namespace Test
         {
             //code coverage unit test for an unused abstract method in post search analysis
             var task = new PostSearchAnalysisTask();
-            task.RunTask(TestContext.CurrentContext.TestDirectory, new List<DbForTask>(), new List<string>(), "");
+            task.RunTask(TestContext.CurrentContext.TestDirectory, new List<DbForTask>(), new List<string>(), "", 25.0);
         }
     }
 }

--- a/Test/BinGenerationTest.cs
+++ b/Test/BinGenerationTest.cs
@@ -66,7 +66,7 @@ namespace Test
                 output_folder,
                 new List<DbForTask> { new DbForTask(proteinDbFilePath, false) },
                 new List<string> { mzmlFilePath },
-                null);
+                null, 25.0);
 
             Assert.AreEqual(3, File.ReadLines(Path.Combine(output_folder, @"MassDifferenceHistogram.tsv")).Count());
             Directory.Delete(output_folder, true);
@@ -131,7 +131,7 @@ namespace Test
                 output_folder,
                 new List<DbForTask> { new DbForTask(proteinDbFilePath, false) },
                 new List<string> { mzmlFilePath1, mzmlFilePath2, },
-                null);
+                null, 25.0);
             Directory.Delete(output_folder, true);
             File.Delete(proteinDbFilePath);
             File.Delete(mzmlFilePath1);

--- a/Test/CalibrationTests.cs
+++ b/Test/CalibrationTests.cs
@@ -35,7 +35,7 @@ namespace Test
 
             // run calibration
             CalibrationTask calibrationTask = new CalibrationTask();
-            calibrationTask.RunTask(outputFolder, new List<DbForTask> { new DbForTask(myDatabase, false) }, new List<string> { nonCalibratedFilePath }, "test");
+            calibrationTask.RunTask(outputFolder, new List<DbForTask> { new DbForTask(myDatabase, false) }, new List<string> { nonCalibratedFilePath }, "test", 25.0);
 
             // test new experimental design written by calibration
             var newExpDesignPath = Path.Combine(outputFolder, @"ExperimentalDesign.tsv");
@@ -81,7 +81,7 @@ namespace Test
             string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\LowResSnip_B6_mouse_11700_117500pruned.xml");
             Directory.CreateDirectory(outputFolder);
 
-            calibrationTask.RunTask(outputFolder, new List<DbForTask> { new DbForTask(myDatabase, false) }, new List<string> { myFile }, "test");
+            calibrationTask.RunTask(outputFolder, new List<DbForTask> { new DbForTask(myDatabase, false) }, new List<string> { myFile }, "test", 25.0);
             Assert.That(File.Exists(Path.Combine(outputFolder, @"sliced_b6-calib.mzML")));
             Assert.That(File.Exists(Path.Combine(outputFolder, @"sliced_b6-calib.toml")));
             var lines = File.ReadAllLines(Path.Combine(outputFolder, @"sliced_b6-calib.toml"));
@@ -125,7 +125,7 @@ namespace Test
                 new List<(string, MetaMorpheusTask)> { ("", calibrationTask), ("", searchTask) }, 
                 new List<string> { nonCalibratedFilePath }, 
                 new List<DbForTask> { new DbForTask(myDatabase, false) },
-                outputFolder);
+                outputFolder, 25.0);
 
             a.Run();
 

--- a/Test/CustomFragmentationTest.cs
+++ b/Test/CustomFragmentationTest.cs
@@ -28,7 +28,7 @@ namespace Test
             // run all tasks
             DbForTask db = new DbForTask(myDatabase, false);
             List<(string, MetaMorpheusTask)> taskList = new List<(string, MetaMorpheusTask)> { ("TestSearchBY", task1), ("TestSearchCZ", task2), ("TestSearchBCZ", task3) };
-            var engine = new EverythingRunnerEngine(taskList, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, false) }, outputFolder);
+            var engine = new EverythingRunnerEngine(taskList, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, false) }, outputFolder, 25.0);
             engine.Run();
 
             // read generated toml settings and make sure custom fragmentations match are handled properly for each task

--- a/Test/GPTMDengineTest.cs
+++ b/Test/GPTMDengineTest.cs
@@ -190,7 +190,7 @@ namespace Test
 
             //run!
             var engine = new EverythingRunnerEngine(taskList, new List<string> { mzmlName },
-                new List<DbForTask> { new DbForTask(xmlName, false) }, Environment.CurrentDirectory);
+                new List<DbForTask> { new DbForTask(xmlName, false) }, Environment.CurrentDirectory, 25.0);
             engine.Run();
         }
 

--- a/Test/MetaDrawTest.cs
+++ b/Test/MetaDrawTest.cs
@@ -31,7 +31,7 @@ namespace Test
             DbForTask db = new DbForTask(myDatabase, false);
             Directory.CreateDirectory(folderPath);
 
-            searchTask.RunTask(folderPath, new List<DbForTask> { db }, new List<string> { myFile }, "metadraw");
+            searchTask.RunTask(folderPath, new List<DbForTask> { db }, new List<string> { myFile }, "metadraw", 25.0);
             string psmFile = Directory.GetFiles(folderPath).First(f => f.Contains("AllPSMs.psmtsv"));
 
             List<PsmFromTsv> parsedPsms = PsmTsvReader.ReadTsv(psmFile, out var warnings);
@@ -63,7 +63,7 @@ namespace Test
             DbForTask db = new DbForTask(myDatabase, false);
             Directory.CreateDirectory(folderPath);
 
-            searchTask.RunTask(folderPath, new List<DbForTask> { db }, new List<string> { myFile }, "metadraw");
+            searchTask.RunTask(folderPath, new List<DbForTask> { db }, new List<string> { myFile }, "metadraw", 25.0);
 
             string psmFile = Directory.GetFiles(folderPath).First(f => f.Contains("XL_Intralinks.tsv"));
 
@@ -129,7 +129,7 @@ namespace Test
 
             // run search task
             var searchtask = new SearchTask();
-            searchtask.RunTask(outputFolder, new List<DbForTask> { new DbForTask(proteinDatabase, false) }, new List<string> { spectraFile }, "");
+            searchtask.RunTask(outputFolder, new List<DbForTask> { new DbForTask(proteinDatabase, false) }, new List<string> { spectraFile }, "", 25.0);
 
             var psmFile = Path.Combine(outputFolder, @"AllPSMs.psmtsv");
 
@@ -246,7 +246,7 @@ namespace Test
 
             Directory.CreateDirectory(outputFolder);
             var xlSearchTask = new XLSearchTask() { CommonParameters = commonParameters };
-            xlSearchTask.RunTask(outputFolder, new List<DbForTask> { new DbForTask(proteinDatabase, false) }, new List<string> { spectraFile }, "");
+            xlSearchTask.RunTask(outputFolder, new List<DbForTask> { new DbForTask(proteinDatabase, false) }, new List<string> { spectraFile }, "", 25.0);
 
             //TODO: test other files (XL_Interlinks.tsv, Deadends.tsv, Looplinks.tsv, SinglePeptides.tsv)
             var csmFile = Path.Combine(outputFolder, @"XL_Intralinks.tsv");
@@ -381,7 +381,7 @@ namespace Test
 
             Directory.CreateDirectory(outputFolder);
             var glycoSearchTask = new GlycoSearchTask() { CommonParameters = commonParameters };
-            glycoSearchTask.RunTask(outputFolder, new List<DbForTask> { new DbForTask(proteinDatabase, false) }, new List<string> { spectraFile }, "");
+            glycoSearchTask.RunTask(outputFolder, new List<DbForTask> { new DbForTask(proteinDatabase, false) }, new List<string> { spectraFile }, "", 25.0);
 
             var psmFile = Path.Combine(outputFolder, @"oglyco.psmtsv");
 
@@ -516,7 +516,7 @@ namespace Test
 
             // run search task
             var searchtask = new SearchTask();
-            searchtask.RunTask(outputFolder, new List<DbForTask> { new DbForTask(proteinDatabase, false) }, new List<string> { spectraFile }, "");
+            searchtask.RunTask(outputFolder, new List<DbForTask> { new DbForTask(proteinDatabase, false) }, new List<string> { spectraFile }, "", 25.0);
 
             var psmFile = Path.Combine(outputFolder, @"AllPSMs.psmtsv");
 
@@ -569,7 +569,7 @@ namespace Test
 
             // run search task
             var searchtask = new SearchTask();
-            searchtask.RunTask(outputFolder, new List<DbForTask> { new DbForTask(proteinDatabase, false) }, new List<string> { spectraFile }, "");
+            searchtask.RunTask(outputFolder, new List<DbForTask> { new DbForTask(proteinDatabase, false) }, new List<string> { spectraFile }, "", 25.0);
 
             var psmFile = Path.Combine(outputFolder, @"AllPSMs.psmtsv");
 
@@ -622,7 +622,7 @@ namespace Test
                     new DbForTask(library1, false),
                     new DbForTask(library2, false),
                 },
-                new List<string> { spectraFile }, "");
+                new List<string> { spectraFile }, "", 25.0);
 
             var psmFile = Path.Combine(outputFolder, @"AllPSMs.psmtsv");
 
@@ -689,7 +689,7 @@ namespace Test
                 {
                     new DbForTask(proteinDatabase, false),
                 },
-                new List<string> { spectraFile }, "");
+                new List<string> { spectraFile }, "", 25.0);
 
             var psmFile = Path.Combine(outputFolder, @"AllPSMs.psmtsv");
 

--- a/Test/MsDataFileTest.cs
+++ b/Test/MsDataFileTest.cs
@@ -41,7 +41,7 @@ namespace Test
             };
             //run!
 
-            var engine = new EverythingRunnerEngine(taskList, new List<string> { mgfName }, new List<DbForTask> { new DbForTask(xmlName, false) }, outputFolder);
+            var engine = new EverythingRunnerEngine(taskList, new List<string> { mgfName }, new List<DbForTask> { new DbForTask(xmlName, false) }, outputFolder, 25.0);
             engine.Run();
             //Just don't crash! There should also be at least one psm at 1% FDR, but can't check for that.
             Directory.Delete(outputFolder, true);

--- a/Test/MultiProteaseParsimonyTest.cs
+++ b/Test/MultiProteaseParsimonyTest.cs
@@ -72,7 +72,7 @@ namespace Test
             Modification mod2 = new Modification(_originalId: "Oxidation of M", _modificationType: "Common Variable", _target: motif2, _locationRestriction: "Anyhwere.", _monoisotopicMass: 15.99491461957);
             List<Modification> modFixedList = new List<Modification> { mod };
 
-            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, null);
+            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, false, 25.0, null);
             var proteinAnalysisResults = (ProteinParsimonyResults)ppe.Run();
 
             // score protein groups and merge indistinguishable ones
@@ -160,7 +160,7 @@ namespace Test
             Modification mod2 = new Modification(_originalId: "Oxidation of M", _modificationType: "Common Variable", _target: motif2, _locationRestriction: "Anyhwere.", _monoisotopicMass: 15.99491461957);
             List<Modification> modFixedList = new List<Modification> { mod };
 
-            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, null);
+            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, false, 25.0, null);
             var proteinAnalysisResults = (ProteinParsimonyResults)ppe.Run();
 
             // score protein groups and merge indistinguishable ones
@@ -238,7 +238,7 @@ namespace Test
             Modification mod2 = new Modification(_originalId: "Oxidation of M", _modificationType: "Common Variable", _target: motif2, _locationRestriction: "Anyhwere.", _monoisotopicMass: 15.99491461957);
             List<Modification> modFixedList = new List<Modification> { mod };
 
-            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, null);
+            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, false,25.0, null);
             var proteinAnalysisResults = (ProteinParsimonyResults)ppe.Run();
 
             // score protein groups and merge indistinguishable ones
@@ -329,7 +329,7 @@ namespace Test
             psms.ForEach(h => h.ResolveAllAmbiguities());
             psms.ForEach(h => h.SetFdrValues(1, 0, 0, 1, 0, 0, 0, 0));
 
-            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, null);
+            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, false, 25.0, null);
             var proteinAnalysisResults = (ProteinParsimonyResults)ppe.Run();
 
             // score protein groups and merge indistinguishable ones
@@ -421,7 +421,7 @@ namespace Test
                 psms.Last().ResolveAllAmbiguities();
             }
 
-            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, null);
+            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, false, 25.0, null);
             var proteinAnalysisResults = (ProteinParsimonyResults)ppe.Run();
 
             // score protein groups and merge indistinguishable ones
@@ -485,7 +485,7 @@ namespace Test
             psms.ForEach(h => h.ResolveAllAmbiguities());
             psms.ForEach(h => h.SetFdrValues(1, 0, 0, 1, 0, 0, 0, 0));
 
-            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, null);
+            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, false, 25.0, null);
             var proteinAnalysisResults = (ProteinParsimonyResults)ppe.Run();
 
             // score protein groups and merge indistinguishable ones
@@ -577,7 +577,7 @@ namespace Test
                 psms.Last().ResolveAllAmbiguities();
             }
 
-            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, null);
+            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, false,25.0, null);
             var proteinAnalysisResults = (ProteinParsimonyResults)ppe.Run();
 
             // score protein groups and merge indistinguishable ones
@@ -693,7 +693,7 @@ namespace Test
                 psms.Last().ResolveAllAmbiguities();
             }
 
-            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, null);
+            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, false,25.0, null);
             var proteinAnalysisResults = (ProteinParsimonyResults)ppe.Run();
 
             // score protein groups and merge indistinguishable ones
@@ -758,7 +758,7 @@ namespace Test
             string fastaName = @"TestData\DbForPrunedDb.fasta";
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestPSMFdrFiltering_RealFileTest");
 
-            var engine = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("TestPSMFdrFiltering_RealFile", Task1) }, new List<string> { mzmlName }, new List<DbForTask> { new DbForTask(fastaName, false) }, outputFolder);
+            var engine = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("TestPSMFdrFiltering_RealFile", Task1) }, new List<string> { mzmlName }, new List<DbForTask> { new DbForTask(fastaName, false) }, outputFolder, 25.0);
             engine.Run();
 
             var thisTaskOutputFolder = Path.Combine(MySetUpClass.outputFolder, @"TestPSMFdrFiltering_RealFile");
@@ -836,7 +836,7 @@ namespace Test
             Modification mod2 = new Modification(_originalId: "Oxidation of M", _modificationType: "Common Variable", _target: motif2, _locationRestriction: "Anyhwere.", _monoisotopicMass: 15.99491461957);
             List<Modification> modFixedList = new List<Modification> { mod };
 
-            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, null);
+            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, false, 25.0, null);
             var proteinAnalysisResults = (ProteinParsimonyResults)ppe.Run();
 
             // score protein groups and merge indistinguishable ones
@@ -909,7 +909,7 @@ namespace Test
             Modification mod2 = new Modification(_originalId: "Oxidation of M", _modificationType: "Common Variable", _target: motif2, _locationRestriction: "Anyhwere.", _monoisotopicMass: 15.99491461957);
             List<Modification> modFixedList = new List<Modification> { mod };
 
-            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, null);
+            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, false, 25.0, null);
             var proteinAnalysisResults = (ProteinParsimonyResults)ppe.Run();
 
             // score protein groups and merge indistinguishable ones
@@ -979,7 +979,7 @@ namespace Test
             Modification mod2 = new Modification(_originalId: "Oxidation of M", _modificationType: "Common Variable", _target: motif2, _locationRestriction: "Anyhwere.", _monoisotopicMass: 15.99491461957);
             List<Modification> modFixedList = new List<Modification> { mod };
 
-            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, null);
+            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, false, 25.0, null);
             var proteinAnalysisResults = (ProteinParsimonyResults)ppe.Run();
 
             // score protein groups and merge indistinguishable ones

--- a/Test/MyTaskTest.cs
+++ b/Test/MyTaskTest.cs
@@ -98,7 +98,7 @@ namespace Test
 
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestEverythingRunner");
             // RUN!
-            var engine = new EverythingRunnerEngine(taskList, new List<string> { mzmlName }, new List<DbForTask> { new DbForTask(xmlName, false) }, outputFolder);
+            var engine = new EverythingRunnerEngine(taskList, new List<string> { mzmlName }, new List<DbForTask> { new DbForTask(xmlName, false) }, outputFolder, 25.0);
             engine.Run();
             File.Delete(Path.Combine(TestContext.CurrentContext.TestDirectory, mzmlName));
             File.Delete(Path.Combine(TestContext.CurrentContext.TestDirectory, xmlName));
@@ -199,7 +199,7 @@ namespace Test
 
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestMultipleFilesRunner");
             // RUN!
-            var engine = new EverythingRunnerEngine(taskList, new List<string> { mzmlName1, mzmlName2 }, new List<DbForTask> { new DbForTask(xmlName, false) }, outputFolder);
+            var engine = new EverythingRunnerEngine(taskList, new List<string> { mzmlName1, mzmlName2 }, new List<DbForTask> { new DbForTask(xmlName, false) }, outputFolder, 25.0);
             engine.Run();
             Directory.Delete(outputFolder, true);
             File.Delete(xmlName);
@@ -274,7 +274,7 @@ namespace Test
             Directory.CreateDirectory(outputFolder);
 
             // RUN!
-            var theStringResult = task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1").ToString();
+            var theStringResult = task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1", 25.0).ToString();
             Assert.IsTrue(theStringResult.Contains("All target PSMS within 1% FDR: 1"));
             Directory.Delete(outputFolder, true);
             File.Delete(xmlName);
@@ -337,7 +337,7 @@ namespace Test
             Directory.CreateDirectory(outputFolder);
 
             // RUN!
-            var theStringResult = task1.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1").ToString();
+            var theStringResult = task1.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1", 25.0).ToString();
             Assert.IsTrue(theStringResult.Contains("Modifications added: 1"));
             Directory.Delete(outputFolder, true);
             File.Delete(xmlName);
@@ -414,7 +414,7 @@ namespace Test
             IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, mzmlName, false);
 
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestMultipleFilesRunner");
-            var engine = new EverythingRunnerEngine(taskList, new List<string> { mzmlName }, new List<DbForTask> { new DbForTask(xmlName, false) }, outputFolder);
+            var engine = new EverythingRunnerEngine(taskList, new List<string> { mzmlName }, new List<DbForTask> { new DbForTask(xmlName, false) }, outputFolder, 25.0);
             engine.Run();
 
             string line;
@@ -449,8 +449,8 @@ namespace Test
             DbForTask db2 = new DbForTask(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", @"DbForPrunedDb.fasta"), false);
             string raw = Path.Combine(TestContext.CurrentContext.TestDirectory, @"sliced-raw.mzML");
             string raw2 = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", @"PrunedDbSpectra.mzml");
-            EverythingRunnerEngine singleMassSpectraFile = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("SingleMassSpectraFileOutput", task) }, new List<string> { raw }, new List<DbForTask> { db }, thisTaskOutputFolder);
-            EverythingRunnerEngine multipleMassSpectraFiles = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("MultipleMassSpectraFileOutput", task) }, new List<string> { raw, raw2 }, new List<DbForTask> { db, db2 }, thisTaskOutputFolder);
+            EverythingRunnerEngine singleMassSpectraFile = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("SingleMassSpectraFileOutput", task) }, new List<string> { raw }, new List<DbForTask> { db }, thisTaskOutputFolder, 25.0);
+            EverythingRunnerEngine multipleMassSpectraFiles = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("MultipleMassSpectraFileOutput", task) }, new List<string> { raw, raw2 }, new List<DbForTask> { db, db2 }, thisTaskOutputFolder, 25.0);
 
             singleMassSpectraFile.Run();
             multipleMassSpectraFiles.Run();
@@ -546,7 +546,7 @@ namespace Test
             string fastaName = @"TestData\DbForPrunedDb.fasta";
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestPepXmlOutput");
 
-            var engine = new EverythingRunnerEngine(taskList, new List<string> { mzmlName }, new List<DbForTask> { new DbForTask(fastaName, false) }, outputFolder);
+            var engine = new EverythingRunnerEngine(taskList, new List<string> { mzmlName }, new List<DbForTask> { new DbForTask(fastaName, false) }, outputFolder, 25.0);
             engine.Run();
 
             string outputPepXmlPath = Path.Combine(outputFolder, @"TestPepXmlOutput\PrunedDbSpectra.pep.XML");
@@ -574,7 +574,7 @@ namespace Test
             string fastaName = @"TestData\DbForPrunedDb.fasta";
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestPepXmlOutput");
 
-            var engine = new EverythingRunnerEngine(taskList, new List<string> { mzmlName }, new List<DbForTask> { new DbForTask(fastaName, false) }, outputFolder);
+            var engine = new EverythingRunnerEngine(taskList, new List<string> { mzmlName }, new List<DbForTask> { new DbForTask(fastaName, false) }, outputFolder, 25.0);
             engine.Run();
 
             string classicPath = Path.Combine(outputFolder, @"ClassicSearch\AllPSMs.psmtsv");

--- a/Test/OutputTest.cs
+++ b/Test/OutputTest.cs
@@ -49,7 +49,7 @@ namespace Test
             MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(datafile, pathOne, false);
             MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(datafile, pathTwo, false);
 
-            new EverythingRunnerEngine(tasks, new List<string> { pathOne, pathTwo }, new List<DbForTask> { db }, outputFolder).Run();
+            new EverythingRunnerEngine(tasks, new List<string> { pathOne, pathTwo }, new List<DbForTask> { db }, outputFolder, 25.0).Run();
 
             //check that the first task wrote everything fine
             HashSet<string> expectedFiles = new HashSet<string>
@@ -89,7 +89,7 @@ namespace Test
             SearchTask weirdTask = new SearchTask();
             weirdTask.SearchParameters.CompressIndividualFiles = true;
             weirdTask.SearchParameters.WriteMzId = false;
-            new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("weird", weirdTask) }, new List<string> { pathOne }, new List<DbForTask> { db }, outputFolder).Run();
+            new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("weird", weirdTask) }, new List<string> { pathOne }, new List<DbForTask> { db }, outputFolder, 25.0).Run();
             //check that a zip was not created
             writtenFiles = new HashSet<string>(Directory.GetFiles(Path.Combine(outputFolder, "weird")));
             Assert.IsFalse(writtenFiles.Contains("Individual File Results.zip"));
@@ -106,7 +106,7 @@ namespace Test
             Directory.CreateDirectory(currentDirecotry);
             DbForTask db = new DbForTask(Path.Combine(TestContext.CurrentContext.TestDirectory, @"GlycoTestData/P16150.fasta"), false);
             string spectraFile = Path.Combine(TestContext.CurrentContext.TestDirectory, @"GlycoTestData\2019_09_16_StcEmix_35trig_EThcD25_rep1_9906.mgf");
-            new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("Task", task) }, new List<string> { spectraFile }, new List<DbForTask> { db }, currentDirecotry).Run();
+            new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("Task", task) }, new List<string> { spectraFile }, new List<DbForTask> { db }, currentDirecotry, 25.0).Run();
 
             string outputDirectory = Path.Combine(currentDirecotry, @"Task");
 

--- a/Test/ProteinLoaderTest.cs
+++ b/Test/ProteinLoaderTest.cs
@@ -44,10 +44,10 @@ namespace Test
 
             public void Run(string dbPath)
             {
-                RunSpecific("", new List<DbForTask> { new DbForTask(dbPath, false) }, null, "", null);
+                RunSpecific("", new List<DbForTask> { new DbForTask(dbPath, false) }, null, "", null, 25.0);
             }
 
-            protected override MyTaskResults RunSpecific(string OutputFolder, List<DbForTask> dbFilenameList, List<string> currentRawFileList, string taskId, FileSpecificParameters[] fileSettingsList)
+            protected override MyTaskResults RunSpecific(string OutputFolder, List<DbForTask> dbFilenameList, List<string> currentRawFileList, string taskId, FileSpecificParameters[] fileSettingsList, double cpmThreshold, List<string> orfData = null)
             {
                 LoadProteins("", dbFilenameList, true, DecoyType.None, new List<string>(), new CommonParameters());
                 return null;

--- a/Test/RescueAnResolveTest.cs
+++ b/Test/RescueAnResolveTest.cs
@@ -1,0 +1,672 @@
+﻿using EngineLayer;
+using MassSpectrometry;
+using NUnit.Framework;
+using Proteomics;
+using Proteomics.Fragmentation;
+using Proteomics.ProteolyticDigestion;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Test
+{
+    [TestFixture]
+    public static class RescueAndResolveTest
+    {
+        [Test]
+        public static void rescueCase1_true()
+        {
+
+            string[] sequences = {
+                "PEPTIDEKPEPTIDESRPEPTIDESK",
+                "PEPTIDESRPEPTIDESK"
+            };
+
+            var p = new List<Protein>();
+            List<Tuple<string, string>> gn = new List<Tuple<string, string>>();
+            for (int i = 0; i < sequences.Length; i++)
+            {
+                p.Add(new Protein(sequences[i], (i + 1).ToString(), null, gn, new Dictionary<int, List<Modification>>()));
+            }
+            LongReadInfo prot1 = new LongReadInfo(p.ElementAt(0).Accession, 30.0);
+            LongReadInfo prot2 = new LongReadInfo(p.ElementAt(1).Accession, 30.0);
+
+            Dictionary<string, LongReadInfo> proteinToProteogenomicInfo = new Dictionary<string, LongReadInfo>();
+            proteinToProteogenomicInfo.Add(p.ElementAt(0).Accession, prot1);
+            proteinToProteogenomicInfo.Add(p.ElementAt(1).Accession, prot2);
+
+            GlobalVariables.ProteinToProteogenomicInfo = proteinToProteogenomicInfo;
+
+            CommonParameters commonParameters_Tryp = new CommonParameters(digestionParams: new DigestionParams(protease: "trypsin", minPeptideLength: 1));
+
+            PeptideWithSetModifications prot1_unique = new PeptideWithSetModifications(protein: p.ElementAt(0), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 1, oneBasedEndResidueInProtein: 8, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDEK", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot1_shared1 = new PeptideWithSetModifications(protein: p.ElementAt(0), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 9, oneBasedEndResidueInProtein: 17, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESR", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot1_shared2 = new PeptideWithSetModifications(protein: p.ElementAt(0), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 18, oneBasedEndResidueInProtein: 26, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESK", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot2_shared1 = new PeptideWithSetModifications(protein: p.ElementAt(1), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 1, oneBasedEndResidueInProtein: 9, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESR", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot2_shared2 = new PeptideWithSetModifications(protein: p.ElementAt(1), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 10, oneBasedEndResidueInProtein: 18, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESK", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+
+
+            MsDataScan dfb = new MsDataScan(new MzSpectrum(new double[] { 1 }, new double[] { 1 }, false), 0, 1, true, Polarity.Positive, double.NaN, null, null, MZAnalyzerType.Orbitrap, double.NaN, null, null, "scan=1", double.NaN, null, null, double.NaN, null, DissociationType.AnyActivationType, 0, null);
+            Ms2ScanWithSpecificMass scan = new Ms2ScanWithSpecificMass(dfb, 2, 0, "File", new CommonParameters());
+
+            PeptideSpectralMatch psmShared1 = new PeptideSpectralMatch(prot1_shared1, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+            psmShared1.AddOrReplace(prot2_shared1, 10, 0, true, new List<MatchedFragmentIon>(), 0);
+            PeptideSpectralMatch psmShared2 = new PeptideSpectralMatch(prot1_shared2, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+            psmShared2.AddOrReplace(prot2_shared2, 10, 0, true, new List<MatchedFragmentIon>(), 0);
+            PeptideSpectralMatch psmUnique1 = new PeptideSpectralMatch(prot1_unique, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+
+            List<PeptideSpectralMatch> psms = new List<PeptideSpectralMatch> { psmShared1, psmShared2, psmUnique1 };
+            psms.ForEach(j => j.ResolveAllAmbiguities());
+            psms.ForEach(j => j.SetFdrValues(1, 0, 0, 1, 0, 0, 0, 0));
+
+            ModificationMotif.TryGetMotif("M", out ModificationMotif motif1);
+            Modification mod = new Modification(_originalId: "Oxidation of M", _modificationType: "Common Variable", _target: motif1, _locationRestriction: "Anywhere.", _monoisotopicMass: 15.99491461957);
+            List<Modification> modVarList = new List<Modification> { mod };
+
+            ModificationMotif.TryGetMotif("M", out ModificationMotif motif2);
+            Modification mod2 = new Modification(_originalId: "Oxidation of M", _modificationType: "Common Variable", _target: motif2, _locationRestriction: "Anywhere.", _monoisotopicMass: 15.99491461957);
+            List<Modification> modFixedList = new List<Modification> { mod };
+
+            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, true, 25.0, null);
+            var proteinAnalysisResults = (ProteinParsimonyResults)ppe.Run();
+
+            // score protein groups and merge indistinguishable ones
+            ProteinScoringAndFdrEngine proteinScoringEngine = new ProteinScoringAndFdrEngine(proteinAnalysisResults.ProteinGroups, psms, false, true, true, new CommonParameters(), null, new List<string>());
+            var results = (ProteinScoringAndFdrResults)proteinScoringEngine.Run();
+
+            Assert.AreEqual(2, results.SortedAndScoredProteinGroups.Count);
+            Assert.AreEqual("1", results.SortedAndScoredProteinGroups[0].ProteinGroupName);
+            Assert.AreEqual(3, results.SortedAndScoredProteinGroups[0].AllPeptides.Count);
+            Assert.AreEqual("2", results.SortedAndScoredProteinGroups[1].ProteinGroupName);
+            Assert.AreEqual(2, results.SortedAndScoredProteinGroups[1].AllPeptides.Count);
+        }
+
+        [Test]
+        public static void rescueCase1_false()
+        {
+
+            string[] sequences = {
+                "PEPTIDEKPEPTIDESRPEPTIDESK",
+                "PEPTIDESRPEPTIDESK"
+            };
+
+            var p = new List<Protein>();
+            List<Tuple<string, string>> gn = new List<Tuple<string, string>>();
+            for (int i = 0; i < sequences.Length; i++)
+            {
+                p.Add(new Protein(sequences[i], (i + 1).ToString(), null, gn, new Dictionary<int, List<Modification>>()));
+            }
+            LongReadInfo prot1 = new LongReadInfo(p.ElementAt(0).Accession, 5.0);
+            LongReadInfo prot2 = new LongReadInfo(p.ElementAt(1).Accession, 5.0);
+
+            Dictionary<string, LongReadInfo> proteinToProteogenomicInfo = new Dictionary<string, LongReadInfo>();
+            proteinToProteogenomicInfo.Add(p.ElementAt(0).Accession, prot1);
+            proteinToProteogenomicInfo.Add(p.ElementAt(1).Accession, prot2);
+
+            GlobalVariables.ProteinToProteogenomicInfo = proteinToProteogenomicInfo;
+
+            CommonParameters commonParameters_Tryp = new CommonParameters(digestionParams: new DigestionParams(protease: "trypsin", minPeptideLength: 1));
+
+            PeptideWithSetModifications prot1_unique = new PeptideWithSetModifications(protein: p.ElementAt(0), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 1, oneBasedEndResidueInProtein: 8, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDEK", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot1_shared1 = new PeptideWithSetModifications(protein: p.ElementAt(0), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 9, oneBasedEndResidueInProtein: 17, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESR", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot1_shared2 = new PeptideWithSetModifications(protein: p.ElementAt(0), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 18, oneBasedEndResidueInProtein: 26, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESK", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot2_shared1 = new PeptideWithSetModifications(protein: p.ElementAt(1), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 1, oneBasedEndResidueInProtein: 9, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESR", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot2_shared2 = new PeptideWithSetModifications(protein: p.ElementAt(1), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 10, oneBasedEndResidueInProtein: 18, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESK", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+
+
+            MsDataScan dfb = new MsDataScan(new MzSpectrum(new double[] { 1 }, new double[] { 1 }, false), 0, 1, true, Polarity.Positive, double.NaN, null, null, MZAnalyzerType.Orbitrap, double.NaN, null, null, "scan=1", double.NaN, null, null, double.NaN, null, DissociationType.AnyActivationType, 0, null);
+            Ms2ScanWithSpecificMass scan = new Ms2ScanWithSpecificMass(dfb, 2, 0, "File", new CommonParameters());
+
+            PeptideSpectralMatch psmShared1 = new PeptideSpectralMatch(prot1_shared1, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+            psmShared1.AddOrReplace(prot2_shared1, 10, 0, true, new List<MatchedFragmentIon>(), 0);
+            PeptideSpectralMatch psmShared2 = new PeptideSpectralMatch(prot1_shared2, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+            psmShared2.AddOrReplace(prot2_shared2, 10, 0, true, new List<MatchedFragmentIon>(), 0);
+            PeptideSpectralMatch psmUnique1 = new PeptideSpectralMatch(prot1_unique, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+
+            List<PeptideSpectralMatch> psms = new List<PeptideSpectralMatch> { psmShared1, psmShared2, psmUnique1 };
+            psms.ForEach(j => j.ResolveAllAmbiguities());
+            psms.ForEach(j => j.SetFdrValues(1, 0, 0, 1, 0, 0, 0, 0));
+
+            ModificationMotif.TryGetMotif("M", out ModificationMotif motif1);
+            Modification mod = new Modification(_originalId: "Oxidation of M", _modificationType: "Common Variable", _target: motif1, _locationRestriction: "Anywhere.", _monoisotopicMass: 15.99491461957);
+            List<Modification> modVarList = new List<Modification> { mod };
+
+            ModificationMotif.TryGetMotif("M", out ModificationMotif motif2);
+            Modification mod2 = new Modification(_originalId: "Oxidation of M", _modificationType: "Common Variable", _target: motif2, _locationRestriction: "Anywhere.", _monoisotopicMass: 15.99491461957);
+            List<Modification> modFixedList = new List<Modification> { mod };
+
+            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, true, 25.0, null);
+            var proteinAnalysisResults = (ProteinParsimonyResults)ppe.Run();
+
+            // score protein groups and merge indistinguishable ones
+            ProteinScoringAndFdrEngine proteinScoringEngine = new ProteinScoringAndFdrEngine(proteinAnalysisResults.ProteinGroups, psms, false, true, true, new CommonParameters(), null, new List<string>());
+            var results = (ProteinScoringAndFdrResults)proteinScoringEngine.Run();
+
+            Assert.AreEqual(1, results.SortedAndScoredProteinGroups.Count);
+            Assert.AreEqual("1", results.SortedAndScoredProteinGroups[0].ProteinGroupName);
+            Assert.AreEqual(3, results.SortedAndScoredProteinGroups[0].AllPeptides.Count);
+        }
+
+        [Test]
+        public static void rescueCase1_2_true()
+        {
+            string[] sequences = {
+                "PEPTIDEKPEPTIDESR",
+                "PEPTIDESR",
+                "PEPTIDESRPEPTIDESK"
+            };
+
+            var p = new List<Protein>();
+            List<Tuple<string, string>> gn = new List<Tuple<string, string>>();
+            for (int i = 0; i < sequences.Length; i++)
+            {
+                p.Add(new Protein(sequences[i], (i + 1).ToString(), null, gn, new Dictionary<int, List<Modification>>()));
+            }
+            LongReadInfo prot1 = new LongReadInfo(p.ElementAt(0).Accession, 25.0);
+            LongReadInfo prot2 = new LongReadInfo(p.ElementAt(1).Accession, 25.0);
+            LongReadInfo prot3 = new LongReadInfo(p.ElementAt(2).Accession, 25.0);
+
+            Dictionary<string, LongReadInfo> proteinToProteogenomicInfo = new Dictionary<string, LongReadInfo>();
+            proteinToProteogenomicInfo.Add(p.ElementAt(0).Accession, prot1);
+            proteinToProteogenomicInfo.Add(p.ElementAt(1).Accession, prot2);
+            proteinToProteogenomicInfo.Add(p.ElementAt(2).Accession, prot3);
+
+            GlobalVariables.ProteinToProteogenomicInfo = proteinToProteogenomicInfo;
+
+            CommonParameters commonParameters_Tryp = new CommonParameters(digestionParams: new DigestionParams(protease: "trypsin", minPeptideLength: 1));
+
+            PeptideWithSetModifications prot1_unique = new PeptideWithSetModifications(protein: p.ElementAt(0), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 1, oneBasedEndResidueInProtein: 8, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDEK", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot1_shared1 = new PeptideWithSetModifications(protein: p.ElementAt(0), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 9, oneBasedEndResidueInProtein: 17, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESR", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot2_shared1 = new PeptideWithSetModifications(protein: p.ElementAt(1), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 1, oneBasedEndResidueInProtein: 9, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESR", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot3_shared1 = new PeptideWithSetModifications(protein: p.ElementAt(2), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 1, oneBasedEndResidueInProtein: 9, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESR", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot3_unique = new PeptideWithSetModifications(protein: p.ElementAt(2), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 10, oneBasedEndResidueInProtein: 18, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESK", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+
+
+            MsDataScan dfb = new MsDataScan(new MzSpectrum(new double[] { 1 }, new double[] { 1 }, false), 0, 1, true, Polarity.Positive, double.NaN, null, null, MZAnalyzerType.Orbitrap, double.NaN, null, null, "scan=1", double.NaN, null, null, double.NaN, null, DissociationType.AnyActivationType, 0, null);
+            Ms2ScanWithSpecificMass scan = new Ms2ScanWithSpecificMass(dfb, 2, 0, "File", new CommonParameters());
+
+            PeptideSpectralMatch psmShared1 = new PeptideSpectralMatch(prot1_shared1, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+            psmShared1.AddOrReplace(prot2_shared1, 10, 0, true, new List<MatchedFragmentIon>(), 0);
+            psmShared1.AddOrReplace(prot3_shared1, 10, 0, true, new List<MatchedFragmentIon>(), 0);
+            PeptideSpectralMatch psmUnique3 = new PeptideSpectralMatch(prot3_unique, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+            PeptideSpectralMatch psmUnique1 = new PeptideSpectralMatch(prot1_unique, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+
+            List<PeptideSpectralMatch> psms = new List<PeptideSpectralMatch> { psmShared1, psmUnique3, psmUnique1 };
+            psms.ForEach(j => j.ResolveAllAmbiguities());
+            psms.ForEach(j => j.SetFdrValues(1, 0, 0, 1, 0, 0, 0, 0));
+
+            ModificationMotif.TryGetMotif("M", out ModificationMotif motif1);
+            Modification mod = new Modification(_originalId: "Oxidation of M", _modificationType: "Common Variable", _target: motif1, _locationRestriction: "Anywhere.", _monoisotopicMass: 15.99491461957);
+            List<Modification> modVarList = new List<Modification> { mod };
+
+            ModificationMotif.TryGetMotif("M", out ModificationMotif motif2);
+            Modification mod2 = new Modification(_originalId: "Oxidation of M", _modificationType: "Common Variable", _target: motif2, _locationRestriction: "Anywhere.", _monoisotopicMass: 15.99491461957);
+            List<Modification> modFixedList = new List<Modification> { mod };
+
+            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, true, 25.0, null);
+            var proteinAnalysisResults = (ProteinParsimonyResults)ppe.Run();
+
+            // score protein groups and merge indistinguishable ones
+            ProteinScoringAndFdrEngine proteinScoringEngine = new ProteinScoringAndFdrEngine(proteinAnalysisResults.ProteinGroups, psms, false, true, true, new CommonParameters(), null, new List<string>());
+            var results = (ProteinScoringAndFdrResults)proteinScoringEngine.Run();
+
+            Assert.AreEqual(3, results.SortedAndScoredProteinGroups.Count);
+            Assert.AreEqual("1", results.SortedAndScoredProteinGroups[0].ProteinGroupName);
+            Assert.AreEqual(2, results.SortedAndScoredProteinGroups[0].AllPeptides.Count);
+            Assert.AreEqual("2", results.SortedAndScoredProteinGroups[1].ProteinGroupName);
+            Assert.AreEqual(1, results.SortedAndScoredProteinGroups[1].AllPeptides.Count);
+            Assert.AreEqual("3", results.SortedAndScoredProteinGroups[2].ProteinGroupName);
+            Assert.AreEqual(2, results.SortedAndScoredProteinGroups[2].AllPeptides.Count);
+        }
+
+        [Test]
+        public static void rescueCase1_2_false()
+        {
+            string[] sequences = {
+                "PEPTIDEKPEPTIDESR",
+                "PEPTIDESR",
+                "PEPTIDESRPEPTIDESK"
+            };
+
+            var p = new List<Protein>();
+            List<Tuple<string, string>> gn = new List<Tuple<string, string>>();
+            for (int i = 0; i < sequences.Length; i++)
+            {
+                p.Add(new Protein(sequences[i], (i + 1).ToString(), null, gn, new Dictionary<int, List<Modification>>()));
+            }
+            LongReadInfo prot1 = new LongReadInfo(p.ElementAt(0).Accession, 25.0);
+            LongReadInfo prot2 = new LongReadInfo(p.ElementAt(1).Accession, 5.0);
+            LongReadInfo prot3 = new LongReadInfo(p.ElementAt(2).Accession, 25.0);
+
+            Dictionary<string, LongReadInfo> proteinToProteogenomicInfo = new Dictionary<string, LongReadInfo>();
+            proteinToProteogenomicInfo.Add(p.ElementAt(0).Accession, prot1);
+            proteinToProteogenomicInfo.Add(p.ElementAt(1).Accession, prot2);
+            proteinToProteogenomicInfo.Add(p.ElementAt(2).Accession, prot3);
+
+            GlobalVariables.ProteinToProteogenomicInfo = proteinToProteogenomicInfo;
+
+            CommonParameters commonParameters_Tryp = new CommonParameters(digestionParams: new DigestionParams(protease: "trypsin", minPeptideLength: 1));
+
+            PeptideWithSetModifications prot1_unique = new PeptideWithSetModifications(protein: p.ElementAt(0), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 1, oneBasedEndResidueInProtein: 8, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDEK", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot1_shared1 = new PeptideWithSetModifications(protein: p.ElementAt(0), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 9, oneBasedEndResidueInProtein: 17, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESR", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot2_shared1 = new PeptideWithSetModifications(protein: p.ElementAt(1), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 1, oneBasedEndResidueInProtein: 9, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESR", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot3_shared1 = new PeptideWithSetModifications(protein: p.ElementAt(2), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 1, oneBasedEndResidueInProtein: 9, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESR", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot3_unique = new PeptideWithSetModifications(protein: p.ElementAt(2), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 10, oneBasedEndResidueInProtein: 18, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESK", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+
+
+            MsDataScan dfb = new MsDataScan(new MzSpectrum(new double[] { 1 }, new double[] { 1 }, false), 0, 1, true, Polarity.Positive, double.NaN, null, null, MZAnalyzerType.Orbitrap, double.NaN, null, null, "scan=1", double.NaN, null, null, double.NaN, null, DissociationType.AnyActivationType, 0, null);
+            Ms2ScanWithSpecificMass scan = new Ms2ScanWithSpecificMass(dfb, 2, 0, "File", new CommonParameters());
+
+            PeptideSpectralMatch psmShared1 = new PeptideSpectralMatch(prot1_shared1, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+            psmShared1.AddOrReplace(prot2_shared1, 10, 0, true, new List<MatchedFragmentIon>(), 0);
+            psmShared1.AddOrReplace(prot3_shared1, 10, 0, true, new List<MatchedFragmentIon>(), 0);
+            PeptideSpectralMatch psmUnique3 = new PeptideSpectralMatch(prot3_unique, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+            PeptideSpectralMatch psmUnique1 = new PeptideSpectralMatch(prot1_unique, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+
+            List<PeptideSpectralMatch> psms = new List<PeptideSpectralMatch> { psmShared1, psmUnique3, psmUnique1 };
+            psms.ForEach(j => j.ResolveAllAmbiguities());
+            psms.ForEach(j => j.SetFdrValues(1, 0, 0, 1, 0, 0, 0, 0));
+
+            ModificationMotif.TryGetMotif("M", out ModificationMotif motif1);
+            Modification mod = new Modification(_originalId: "Oxidation of M", _modificationType: "Common Variable", _target: motif1, _locationRestriction: "Anywhere.", _monoisotopicMass: 15.99491461957);
+            List<Modification> modVarList = new List<Modification> { mod };
+
+            ModificationMotif.TryGetMotif("M", out ModificationMotif motif2);
+            Modification mod2 = new Modification(_originalId: "Oxidation of M", _modificationType: "Common Variable", _target: motif2, _locationRestriction: "Anywhere.", _monoisotopicMass: 15.99491461957);
+            List<Modification> modFixedList = new List<Modification> { mod };
+
+            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, true, 25.0, null);
+            var proteinAnalysisResults = (ProteinParsimonyResults)ppe.Run();
+
+            // score protein groups and merge indistinguishable ones
+            ProteinScoringAndFdrEngine proteinScoringEngine = new ProteinScoringAndFdrEngine(proteinAnalysisResults.ProteinGroups, psms, false, true, true, new CommonParameters(), null, new List<string>());
+            var results = (ProteinScoringAndFdrResults)proteinScoringEngine.Run();
+
+            Assert.AreEqual(2, results.SortedAndScoredProteinGroups.Count);
+            Assert.AreEqual("1", results.SortedAndScoredProteinGroups[0].ProteinGroupName);
+            Assert.AreEqual(2, results.SortedAndScoredProteinGroups[0].AllPeptides.Count);
+            Assert.AreEqual("3", results.SortedAndScoredProteinGroups[1].ProteinGroupName);
+            Assert.AreEqual(2, results.SortedAndScoredProteinGroups[1].AllPeptides.Count);
+
+        }
+
+        [Test]
+        public static void rescueCase2_true()
+        {
+            string[] sequences = {
+                "PEPTIDEKPEPTIDESR",
+                "PEPTIDESRPAPTIDESR",
+                "PAPTIDESRPEPTADESK"
+            };
+
+            var p = new List<Protein>();
+            List<Tuple<string, string>> gn = new List<Tuple<string, string>>();
+            for (int i = 0; i < sequences.Length; i++)
+            {
+                p.Add(new Protein(sequences[i], (i + 1).ToString(), null, gn, new Dictionary<int, List<Modification>>()));
+            }
+            LongReadInfo prot1 = new LongReadInfo(p.ElementAt(0).Accession, 25.0);
+            LongReadInfo prot2 = new LongReadInfo(p.ElementAt(1).Accession, 25.0);
+            LongReadInfo prot3 = new LongReadInfo(p.ElementAt(2).Accession, 25.0);
+
+            Dictionary<string, LongReadInfo> proteinToProteogenomicInfo = new Dictionary<string, LongReadInfo>();
+            proteinToProteogenomicInfo.Add(p.ElementAt(0).Accession, prot1);
+            proteinToProteogenomicInfo.Add(p.ElementAt(1).Accession, prot2);
+            proteinToProteogenomicInfo.Add(p.ElementAt(2).Accession, prot3);
+
+            GlobalVariables.ProteinToProteogenomicInfo = proteinToProteogenomicInfo;
+
+            CommonParameters commonParameters_Tryp = new CommonParameters(digestionParams: new DigestionParams(protease: "trypsin", minPeptideLength: 1));
+
+            PeptideWithSetModifications prot1_unique = new PeptideWithSetModifications(protein: p.ElementAt(0), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 1, oneBasedEndResidueInProtein: 8, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDEK", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot1_shared1 = new PeptideWithSetModifications(protein: p.ElementAt(0), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 9, oneBasedEndResidueInProtein: 17, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESR", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot2_shared1 = new PeptideWithSetModifications(protein: p.ElementAt(1), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 1, oneBasedEndResidueInProtein: 9, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESR", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot2_shared2 = new PeptideWithSetModifications(protein: p.ElementAt(1), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 10, oneBasedEndResidueInProtein: 18, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESR", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot3_shared2 = new PeptideWithSetModifications(protein: p.ElementAt(2), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 1, oneBasedEndResidueInProtein: 9, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESR", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot3_unique = new PeptideWithSetModifications(protein: p.ElementAt(2), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 10, oneBasedEndResidueInProtein: 18, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESK", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+
+
+            MsDataScan dfb = new MsDataScan(new MzSpectrum(new double[] { 1 }, new double[] { 1 }, false), 0, 1, true, Polarity.Positive, double.NaN, null, null, MZAnalyzerType.Orbitrap, double.NaN, null, null, "scan=1", double.NaN, null, null, double.NaN, null, DissociationType.AnyActivationType, 0, null);
+            Ms2ScanWithSpecificMass scan = new Ms2ScanWithSpecificMass(dfb, 2, 0, "File", new CommonParameters());
+
+            PeptideSpectralMatch psmShared1 = new PeptideSpectralMatch(prot1_shared1, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+            psmShared1.AddOrReplace(prot2_shared1, 10, 0, true, new List<MatchedFragmentIon>(), 0);
+            PeptideSpectralMatch psmShared2 = new PeptideSpectralMatch(prot2_shared2, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+            psmShared2.AddOrReplace(prot3_shared2, 10, 0, true, new List<MatchedFragmentIon>(), 0);
+            PeptideSpectralMatch psmUnique3 = new PeptideSpectralMatch(prot3_unique, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+            PeptideSpectralMatch psmUnique1 = new PeptideSpectralMatch(prot1_unique, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+
+            List<PeptideSpectralMatch> psms = new List<PeptideSpectralMatch> { psmShared1, psmUnique3, psmUnique1, psmShared2 };
+            psms.ForEach(j => j.ResolveAllAmbiguities());
+            psms.ForEach(j => j.SetFdrValues(1, 0, 0, 1, 0, 0, 0, 0));
+
+            ModificationMotif.TryGetMotif("M", out ModificationMotif motif1);
+            Modification mod = new Modification(_originalId: "Oxidation of M", _modificationType: "Common Variable", _target: motif1, _locationRestriction: "Anywhere.", _monoisotopicMass: 15.99491461957);
+            List<Modification> modVarList = new List<Modification> { mod };
+
+            ModificationMotif.TryGetMotif("M", out ModificationMotif motif2);
+            Modification mod2 = new Modification(_originalId: "Oxidation of M", _modificationType: "Common Variable", _target: motif2, _locationRestriction: "Anywhere.", _monoisotopicMass: 15.99491461957);
+            List<Modification> modFixedList = new List<Modification> { mod };
+
+            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, true, 25.0, null);
+            var proteinAnalysisResults = (ProteinParsimonyResults)ppe.Run();
+
+            // score protein groups and merge indistinguishable ones
+            ProteinScoringAndFdrEngine proteinScoringEngine = new ProteinScoringAndFdrEngine(proteinAnalysisResults.ProteinGroups, psms, false, true, true, new CommonParameters(), null, new List<string>());
+            var results = (ProteinScoringAndFdrResults)proteinScoringEngine.Run();
+
+            Assert.AreEqual(3, results.SortedAndScoredProteinGroups.Count);
+            Assert.AreEqual("1", results.SortedAndScoredProteinGroups[0].ProteinGroupName);
+            Assert.AreEqual(2, results.SortedAndScoredProteinGroups[0].AllPeptides.Count);
+            Assert.AreEqual("2", results.SortedAndScoredProteinGroups[1].ProteinGroupName);
+            Assert.AreEqual(2, results.SortedAndScoredProteinGroups[1].AllPeptides.Count);
+            Assert.AreEqual("3", results.SortedAndScoredProteinGroups[2].ProteinGroupName);
+            Assert.AreEqual(2, results.SortedAndScoredProteinGroups[2].AllPeptides.Count);
+        }
+
+        [Test]
+        public static void rescueCase2_false()
+        {
+            string[] sequences = {
+                "PEPTIDEKPEPTIDESR",
+                "PEPTIDESRPAPTIDESR",
+                "PAPTIDESRPEPTADESK"
+            };
+
+            var p = new List<Protein>();
+            List<Tuple<string, string>> gn = new List<Tuple<string, string>>();
+            for (int i = 0; i < sequences.Length; i++)
+            {
+                p.Add(new Protein(sequences[i], (i + 1).ToString(), null, gn, new Dictionary<int, List<Modification>>()));
+            }
+            LongReadInfo prot1 = new LongReadInfo(p.ElementAt(0).Accession, 25.0);
+            LongReadInfo prot2 = new LongReadInfo(p.ElementAt(1).Accession, 10.0);
+            LongReadInfo prot3 = new LongReadInfo(p.ElementAt(2).Accession, 25.0);
+
+            Dictionary<string, LongReadInfo> proteinToProteogenomicInfo = new Dictionary<string, LongReadInfo>();
+            proteinToProteogenomicInfo.Add(p.ElementAt(0).Accession, prot1);
+            proteinToProteogenomicInfo.Add(p.ElementAt(1).Accession, prot2);
+            proteinToProteogenomicInfo.Add(p.ElementAt(2).Accession, prot3);
+
+            GlobalVariables.ProteinToProteogenomicInfo = proteinToProteogenomicInfo;
+
+            CommonParameters commonParameters_Tryp = new CommonParameters(digestionParams: new DigestionParams(protease: "trypsin", minPeptideLength: 1));
+
+            PeptideWithSetModifications prot1_unique = new PeptideWithSetModifications(protein: p.ElementAt(0), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 1, oneBasedEndResidueInProtein: 8, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDEK", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot1_shared1 = new PeptideWithSetModifications(protein: p.ElementAt(0), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 9, oneBasedEndResidueInProtein: 17, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESR", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot2_shared1 = new PeptideWithSetModifications(protein: p.ElementAt(1), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 1, oneBasedEndResidueInProtein: 9, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESR", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot2_shared2 = new PeptideWithSetModifications(protein: p.ElementAt(1), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 10, oneBasedEndResidueInProtein: 18, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESR", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot3_shared2 = new PeptideWithSetModifications(protein: p.ElementAt(2), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 1, oneBasedEndResidueInProtein: 9, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESR", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot3_unique = new PeptideWithSetModifications(protein: p.ElementAt(2), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 10, oneBasedEndResidueInProtein: 18, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESK", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+
+
+            MsDataScan dfb = new MsDataScan(new MzSpectrum(new double[] { 1 }, new double[] { 1 }, false), 0, 1, true, Polarity.Positive, double.NaN, null, null, MZAnalyzerType.Orbitrap, double.NaN, null, null, "scan=1", double.NaN, null, null, double.NaN, null, DissociationType.AnyActivationType, 0, null);
+            Ms2ScanWithSpecificMass scan = new Ms2ScanWithSpecificMass(dfb, 2, 0, "File", new CommonParameters());
+
+            PeptideSpectralMatch psmShared1 = new PeptideSpectralMatch(prot1_shared1, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+            psmShared1.AddOrReplace(prot2_shared1, 10, 0, true, new List<MatchedFragmentIon>(), 0);
+            PeptideSpectralMatch psmShared2 = new PeptideSpectralMatch(prot2_shared2, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+            psmShared2.AddOrReplace(prot3_shared2, 10, 0, true, new List<MatchedFragmentIon>(), 0);
+            PeptideSpectralMatch psmUnique3 = new PeptideSpectralMatch(prot3_unique, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+            PeptideSpectralMatch psmUnique1 = new PeptideSpectralMatch(prot1_unique, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+
+            List<PeptideSpectralMatch> psms = new List<PeptideSpectralMatch> { psmShared1, psmUnique3, psmUnique1, psmShared2 };
+            psms.ForEach(j => j.ResolveAllAmbiguities());
+            psms.ForEach(j => j.SetFdrValues(1, 0, 0, 1, 0, 0, 0, 0));
+
+            ModificationMotif.TryGetMotif("M", out ModificationMotif motif1);
+            Modification mod = new Modification(_originalId: "Oxidation of M", _modificationType: "Common Variable", _target: motif1, _locationRestriction: "Anywhere.", _monoisotopicMass: 15.99491461957);
+            List<Modification> modVarList = new List<Modification> { mod };
+
+            ModificationMotif.TryGetMotif("M", out ModificationMotif motif2);
+            Modification mod2 = new Modification(_originalId: "Oxidation of M", _modificationType: "Common Variable", _target: motif2, _locationRestriction: "Anywhere.", _monoisotopicMass: 15.99491461957);
+            List<Modification> modFixedList = new List<Modification> { mod };
+
+            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, true, 25.0, null);
+            var proteinAnalysisResults = (ProteinParsimonyResults)ppe.Run();
+
+            // score protein groups and merge indistinguishable ones
+            ProteinScoringAndFdrEngine proteinScoringEngine = new ProteinScoringAndFdrEngine(proteinAnalysisResults.ProteinGroups, psms, false, true, true, new CommonParameters(), null, new List<string>());
+            var results = (ProteinScoringAndFdrResults)proteinScoringEngine.Run();
+
+            Assert.AreEqual(2, results.SortedAndScoredProteinGroups.Count);
+            Assert.AreEqual("1", results.SortedAndScoredProteinGroups[0].ProteinGroupName);
+            Assert.AreEqual(2, results.SortedAndScoredProteinGroups[0].AllPeptides.Count);
+            Assert.AreEqual("3", results.SortedAndScoredProteinGroups[1].ProteinGroupName);
+            Assert.AreEqual(2, results.SortedAndScoredProteinGroups[1].AllPeptides.Count);
+        }
+
+        [Test]
+        public static void rescueCase3_true()
+        {
+            string[] sequences = {
+                "PEPTIDEKPEPTIDESRPEPTIDESK",
+                "PEPTIDESRPEPTIDESK",
+                "PEPTIDEKPEPTIDESR"
+            };
+
+            var p = new List<Protein>();
+            List<Tuple<string, string>> gn = new List<Tuple<string, string>>();
+            for (int i = 0; i < sequences.Length; i++)
+            {
+                p.Add(new Protein(sequences[i], (i + 1).ToString(), null, gn, new Dictionary<int, List<Modification>>()));
+            }
+            LongReadInfo prot1 = new LongReadInfo(p.ElementAt(0).Accession, 25.0);
+            LongReadInfo prot2 = new LongReadInfo(p.ElementAt(1).Accession, 25.0);
+            LongReadInfo prot3 = new LongReadInfo(p.ElementAt(2).Accession, 25.0);
+
+            Dictionary<string, LongReadInfo> proteinToProteogenomicInfo = new Dictionary<string, LongReadInfo>();
+            proteinToProteogenomicInfo.Add(p.ElementAt(0).Accession, prot1);
+            proteinToProteogenomicInfo.Add(p.ElementAt(1).Accession, prot2);
+            proteinToProteogenomicInfo.Add(p.ElementAt(2).Accession, prot3);
+
+            GlobalVariables.ProteinToProteogenomicInfo = proteinToProteogenomicInfo;
+
+            CommonParameters commonParameters_Tryp = new CommonParameters(digestionParams: new DigestionParams(protease: "trypsin", minPeptideLength: 1));
+
+            PeptideWithSetModifications prot1_shared1 = new PeptideWithSetModifications(protein: p.ElementAt(0), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 1, oneBasedEndResidueInProtein: 8, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDEK", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot1_shared2 = new PeptideWithSetModifications(protein: p.ElementAt(0), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 9, oneBasedEndResidueInProtein: 17, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESR", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot1_shared3 = new PeptideWithSetModifications(protein: p.ElementAt(0), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 18, oneBasedEndResidueInProtein: 26, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESK", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot2_shared2 = new PeptideWithSetModifications(protein: p.ElementAt(1), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 1, oneBasedEndResidueInProtein: 9, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESR", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot2_shared3 = new PeptideWithSetModifications(protein: p.ElementAt(1), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 10, oneBasedEndResidueInProtein: 18, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESK", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot3_shared2 = new PeptideWithSetModifications(protein: p.ElementAt(2), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 9, oneBasedEndResidueInProtein: 17, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESR", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot3_shared1 = new PeptideWithSetModifications(protein: p.ElementAt(2), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 1, oneBasedEndResidueInProtein: 8, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDEK", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+
+
+            MsDataScan dfb = new MsDataScan(new MzSpectrum(new double[] { 1 }, new double[] { 1 }, false), 0, 1, true, Polarity.Positive, double.NaN, null, null, MZAnalyzerType.Orbitrap, double.NaN, null, null, "scan=1", double.NaN, null, null, double.NaN, null, DissociationType.AnyActivationType, 0, null);
+            Ms2ScanWithSpecificMass scan = new Ms2ScanWithSpecificMass(dfb, 2, 0, "File", new CommonParameters());
+
+            PeptideSpectralMatch psmShared2 = new PeptideSpectralMatch(prot1_shared2, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+            psmShared2.AddOrReplace(prot2_shared2, 10, 0, true, new List<MatchedFragmentIon>(), 0);
+            psmShared2.AddOrReplace(prot3_shared2, 10, 0, true, new List<MatchedFragmentIon>(), 0);
+
+            PeptideSpectralMatch psmShared1 = new PeptideSpectralMatch(prot1_shared1, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+            psmShared1.AddOrReplace(prot3_shared1, 10, 0, true, new List<MatchedFragmentIon>(), 0);
+
+            PeptideSpectralMatch psmShared3 = new PeptideSpectralMatch(prot1_shared3, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+            psmShared3.AddOrReplace(prot2_shared3, 10, 0, true, new List<MatchedFragmentIon>(), 0);
+
+
+            List<PeptideSpectralMatch> psms = new List<PeptideSpectralMatch> { psmShared1, psmShared3, psmShared2 };
+            psms.ForEach(j => j.ResolveAllAmbiguities());
+            psms.ForEach(j => j.SetFdrValues(1, 0, 0, 1, 0, 0, 0, 0));
+
+            ModificationMotif.TryGetMotif("M", out ModificationMotif motif1);
+            Modification mod = new Modification(_originalId: "Oxidation of M", _modificationType: "Common Variable", _target: motif1, _locationRestriction: "Anywhere.", _monoisotopicMass: 15.99491461957);
+            List<Modification> modVarList = new List<Modification> { mod };
+
+            ModificationMotif.TryGetMotif("M", out ModificationMotif motif2);
+            Modification mod2 = new Modification(_originalId: "Oxidation of M", _modificationType: "Common Variable", _target: motif2, _locationRestriction: "Anywhere.", _monoisotopicMass: 15.99491461957);
+            List<Modification> modFixedList = new List<Modification> { mod };
+
+            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, true, 25.0, null);
+            var proteinAnalysisResults = (ProteinParsimonyResults)ppe.Run();
+
+            // score protein groups and merge indistinguishable ones
+            ProteinScoringAndFdrEngine proteinScoringEngine = new ProteinScoringAndFdrEngine(proteinAnalysisResults.ProteinGroups, psms, false, true, true, new CommonParameters(), null, new List<string>());
+            var results = (ProteinScoringAndFdrResults)proteinScoringEngine.Run();
+
+            Assert.AreEqual(3, results.SortedAndScoredProteinGroups.Count);
+            Assert.AreEqual("1", results.SortedAndScoredProteinGroups[0].ProteinGroupName);
+            Assert.AreEqual(3, results.SortedAndScoredProteinGroups[0].AllPeptides.Count);
+            Assert.AreEqual("3", results.SortedAndScoredProteinGroups[1].ProteinGroupName);
+            Assert.AreEqual(2, results.SortedAndScoredProteinGroups[1].AllPeptides.Count);
+            Assert.AreEqual("2", results.SortedAndScoredProteinGroups[2].ProteinGroupName);
+            Assert.AreEqual(2, results.SortedAndScoredProteinGroups[2].AllPeptides.Count);
+        }
+
+        [Test]
+        public static void rescueCase3_true_remove()
+        {
+            string[] sequences = {
+                "PEPTIDEKPEPTIDESRPEPTIDESK",
+                "PEPTIDESRPEPTIDESK",
+                "PEPTIDEKPEPTIDESR"
+            };
+
+            var p = new List<Protein>();
+            List<Tuple<string, string>> gn = new List<Tuple<string, string>>();
+            for (int i = 0; i < sequences.Length; i++)
+            {
+                p.Add(new Protein(sequences[i], (i + 1).ToString(), null, gn, new Dictionary<int, List<Modification>>()));
+            }
+            LongReadInfo prot1 = new LongReadInfo(p.ElementAt(0).Accession, 5.0);
+            LongReadInfo prot2 = new LongReadInfo(p.ElementAt(1).Accession, 25.0);
+            LongReadInfo prot3 = new LongReadInfo(p.ElementAt(2).Accession, 25.0);
+
+            Dictionary<string, LongReadInfo> proteinToProteogenomicInfo = new Dictionary<string, LongReadInfo>();
+            proteinToProteogenomicInfo.Add(p.ElementAt(0).Accession, prot1);
+            proteinToProteogenomicInfo.Add(p.ElementAt(1).Accession, prot2);
+            proteinToProteogenomicInfo.Add(p.ElementAt(2).Accession, prot3);
+
+            GlobalVariables.ProteinToProteogenomicInfo = proteinToProteogenomicInfo;
+
+            CommonParameters commonParameters_Tryp = new CommonParameters(digestionParams: new DigestionParams(protease: "trypsin", minPeptideLength: 1));
+
+            PeptideWithSetModifications prot1_shared1 = new PeptideWithSetModifications(protein: p.ElementAt(0), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 1, oneBasedEndResidueInProtein: 8, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDEK", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot1_shared2 = new PeptideWithSetModifications(protein: p.ElementAt(0), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 9, oneBasedEndResidueInProtein: 17, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESR", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot1_shared3 = new PeptideWithSetModifications(protein: p.ElementAt(0), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 18, oneBasedEndResidueInProtein: 26, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESK", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot2_shared2 = new PeptideWithSetModifications(protein: p.ElementAt(1), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 1, oneBasedEndResidueInProtein: 9, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESR", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot2_shared3 = new PeptideWithSetModifications(protein: p.ElementAt(1), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 10, oneBasedEndResidueInProtein: 18, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESK", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot3_shared2 = new PeptideWithSetModifications(protein: p.ElementAt(2), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 9, oneBasedEndResidueInProtein: 17, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESR", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot3_shared1 = new PeptideWithSetModifications(protein: p.ElementAt(2), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 1, oneBasedEndResidueInProtein: 8, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDEK", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+
+
+            MsDataScan dfb = new MsDataScan(new MzSpectrum(new double[] { 1 }, new double[] { 1 }, false), 0, 1, true, Polarity.Positive, double.NaN, null, null, MZAnalyzerType.Orbitrap, double.NaN, null, null, "scan=1", double.NaN, null, null, double.NaN, null, DissociationType.AnyActivationType, 0, null);
+            Ms2ScanWithSpecificMass scan = new Ms2ScanWithSpecificMass(dfb, 2, 0, "File", new CommonParameters());
+
+            PeptideSpectralMatch psmShared2 = new PeptideSpectralMatch(prot1_shared2, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+            psmShared2.AddOrReplace(prot2_shared2, 10, 0, true, new List<MatchedFragmentIon>(), 0);
+            psmShared2.AddOrReplace(prot3_shared2, 10, 0, true, new List<MatchedFragmentIon>(), 0);
+
+            PeptideSpectralMatch psmShared1 = new PeptideSpectralMatch(prot1_shared1, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+            psmShared1.AddOrReplace(prot3_shared1, 10, 0, true, new List<MatchedFragmentIon>(), 0);
+
+            PeptideSpectralMatch psmShared3 = new PeptideSpectralMatch(prot1_shared3, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+            psmShared3.AddOrReplace(prot2_shared3, 10, 0, true, new List<MatchedFragmentIon>(), 0);
+
+
+            List<PeptideSpectralMatch> psms = new List<PeptideSpectralMatch> { psmShared1, psmShared3, psmShared2 };
+            psms.ForEach(j => j.ResolveAllAmbiguities());
+            psms.ForEach(j => j.SetFdrValues(1, 0, 0, 1, 0, 0, 0, 0));
+
+            ModificationMotif.TryGetMotif("M", out ModificationMotif motif1);
+            Modification mod = new Modification(_originalId: "Oxidation of M", _modificationType: "Common Variable", _target: motif1, _locationRestriction: "Anywhere.", _monoisotopicMass: 15.99491461957);
+            List<Modification> modVarList = new List<Modification> { mod };
+
+            ModificationMotif.TryGetMotif("M", out ModificationMotif motif2);
+            Modification mod2 = new Modification(_originalId: "Oxidation of M", _modificationType: "Common Variable", _target: motif2, _locationRestriction: "Anywhere.", _monoisotopicMass: 15.99491461957);
+            List<Modification> modFixedList = new List<Modification> { mod };
+
+            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, true, 25.0, null);
+            var proteinAnalysisResults = (ProteinParsimonyResults)ppe.Run();
+
+            // score protein groups and merge indistinguishable ones
+            ProteinScoringAndFdrEngine proteinScoringEngine = new ProteinScoringAndFdrEngine(proteinAnalysisResults.ProteinGroups, psms, false, true, true, new CommonParameters(), null, new List<string>());
+            var results = (ProteinScoringAndFdrResults)proteinScoringEngine.Run();
+
+            Assert.AreEqual(2, results.SortedAndScoredProteinGroups.Count);
+            Assert.AreEqual("3", results.SortedAndScoredProteinGroups[0].ProteinGroupName);
+            Assert.AreEqual(2, results.SortedAndScoredProteinGroups[0].AllPeptides.Count);
+            Assert.AreEqual("2", results.SortedAndScoredProteinGroups[1].ProteinGroupName);
+            Assert.AreEqual(2, results.SortedAndScoredProteinGroups[1].AllPeptides.Count);
+        }
+
+        [Test]
+        public static void rescueCase3_false()
+        {
+            string[] sequences = {
+                "PEPTIDEKPEPTIDESRPEPTIDESK",
+                "PEPTIDESRPEPTIDESK",
+                "PEPTIDEKPEPTIDESR"
+            };
+
+            var p = new List<Protein>();
+            List<Tuple<string, string>> gn = new List<Tuple<string, string>>();
+            for (int i = 0; i < sequences.Length; i++)
+            {
+                p.Add(new Protein(sequences[i], (i + 1).ToString(), null, gn, new Dictionary<int, List<Modification>>()));
+            }
+            LongReadInfo prot1 = new LongReadInfo(p.ElementAt(0).Accession, 25.0);
+            LongReadInfo prot2 = new LongReadInfo(p.ElementAt(1).Accession, 5.0);
+            LongReadInfo prot3 = new LongReadInfo(p.ElementAt(2).Accession, 5.0);
+
+            Dictionary<string, LongReadInfo> proteinToProteogenomicInfo = new Dictionary<string, LongReadInfo>();
+            proteinToProteogenomicInfo.Add(p.ElementAt(0).Accession, prot1);
+            proteinToProteogenomicInfo.Add(p.ElementAt(1).Accession, prot2);
+            proteinToProteogenomicInfo.Add(p.ElementAt(2).Accession, prot3);
+
+            GlobalVariables.ProteinToProteogenomicInfo = proteinToProteogenomicInfo;
+
+            CommonParameters commonParameters_Tryp = new CommonParameters(digestionParams: new DigestionParams(protease: "trypsin", minPeptideLength: 1));
+
+            PeptideWithSetModifications prot1_shared1 = new PeptideWithSetModifications(protein: p.ElementAt(0), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 1, oneBasedEndResidueInProtein: 8, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDEK", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot1_shared2 = new PeptideWithSetModifications(protein: p.ElementAt(0), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 9, oneBasedEndResidueInProtein: 17, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESR", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot1_shared3 = new PeptideWithSetModifications(protein: p.ElementAt(0), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 18, oneBasedEndResidueInProtein: 26, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESK", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot2_shared2 = new PeptideWithSetModifications(protein: p.ElementAt(1), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 1, oneBasedEndResidueInProtein: 9, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESR", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot2_shared3 = new PeptideWithSetModifications(protein: p.ElementAt(1), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 10, oneBasedEndResidueInProtein: 18, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESK", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot3_shared2 = new PeptideWithSetModifications(protein: p.ElementAt(2), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 9, oneBasedEndResidueInProtein: 17, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDESR", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+            PeptideWithSetModifications prot3_shared1 = new PeptideWithSetModifications(protein: p.ElementAt(2), digestionParams: commonParameters_Tryp.DigestionParams, oneBasedStartResidueInProtein: 1, oneBasedEndResidueInProtein: 8, cleavageSpecificity: CleavageSpecificity.Full, peptideDescription: "PEPTIDEK", missedCleavages: 0, allModsOneIsNterminus: new Dictionary<int, Modification>(), numFixedMods: 0);
+
+
+            MsDataScan dfb = new MsDataScan(new MzSpectrum(new double[] { 1 }, new double[] { 1 }, false), 0, 1, true, Polarity.Positive, double.NaN, null, null, MZAnalyzerType.Orbitrap, double.NaN, null, null, "scan=1", double.NaN, null, null, double.NaN, null, DissociationType.AnyActivationType, 0, null);
+            Ms2ScanWithSpecificMass scan = new Ms2ScanWithSpecificMass(dfb, 2, 0, "File", new CommonParameters());
+
+            PeptideSpectralMatch psmShared2 = new PeptideSpectralMatch(prot1_shared2, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+            psmShared2.AddOrReplace(prot2_shared2, 10, 0, true, new List<MatchedFragmentIon>(), 0);
+            psmShared2.AddOrReplace(prot3_shared2, 10, 0, true, new List<MatchedFragmentIon>(), 0);
+
+            PeptideSpectralMatch psmShared1 = new PeptideSpectralMatch(prot1_shared1, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+            psmShared1.AddOrReplace(prot3_shared1, 10, 0, true, new List<MatchedFragmentIon>(), 0);
+
+            PeptideSpectralMatch psmShared3 = new PeptideSpectralMatch(prot1_shared3, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
+            psmShared3.AddOrReplace(prot2_shared3, 10, 0, true, new List<MatchedFragmentIon>(), 0);
+
+
+            List<PeptideSpectralMatch> psms = new List<PeptideSpectralMatch> { psmShared1, psmShared3, psmShared2 };
+            psms.ForEach(j => j.ResolveAllAmbiguities());
+            psms.ForEach(j => j.SetFdrValues(1, 0, 0, 1, 0, 0, 0, 0));
+
+            ModificationMotif.TryGetMotif("M", out ModificationMotif motif1);
+            Modification mod = new Modification(_originalId: "Oxidation of M", _modificationType: "Common Variable", _target: motif1, _locationRestriction: "Anywhere.", _monoisotopicMass: 15.99491461957);
+            List<Modification> modVarList = new List<Modification> { mod };
+
+            ModificationMotif.TryGetMotif("M", out ModificationMotif motif2);
+            Modification mod2 = new Modification(_originalId: "Oxidation of M", _modificationType: "Common Variable", _target: motif2, _locationRestriction: "Anywhere.", _monoisotopicMass: 15.99491461957);
+            List<Modification> modFixedList = new List<Modification> { mod };
+
+            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, true, 25.0, null);
+            var proteinAnalysisResults = (ProteinParsimonyResults)ppe.Run();
+
+            // score protein groups and merge indistinguishable ones
+            ProteinScoringAndFdrEngine proteinScoringEngine = new ProteinScoringAndFdrEngine(proteinAnalysisResults.ProteinGroups, psms, false, true, true, new CommonParameters(), null, new List<string>());
+            var results = (ProteinScoringAndFdrResults)proteinScoringEngine.Run();
+
+            Assert.AreEqual(1, results.SortedAndScoredProteinGroups.Count);
+            Assert.AreEqual("1", results.SortedAndScoredProteinGroups[0].ProteinGroupName);
+            Assert.AreEqual(3, results.SortedAndScoredProteinGroups[0].AllPeptides.Count);
+        }
+
+    }
+}

--- a/Test/RobTest.cs
+++ b/Test/RobTest.cs
@@ -113,7 +113,7 @@ namespace Test
             }
 
             // run parsimony
-            ProteinParsimonyEngine parsimonyEngine = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, new List<string>());
+            ProteinParsimonyEngine parsimonyEngine = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, false, 25.0, new List<string>());
             var parsimonyResults = (ProteinParsimonyResults)parsimonyEngine.Run();
             var proteinGroups = parsimonyResults.ProteinGroups;
 
@@ -243,7 +243,7 @@ namespace Test
 
             psms.ForEach(p => p.ResolveAllAmbiguities());
 
-            ProteinParsimonyEngine engine = new ProteinParsimonyEngine(psms, true, new CommonParameters(), null, new List<string> { "ff" });
+            ProteinParsimonyEngine engine = new ProteinParsimonyEngine(psms, true, new CommonParameters(), null, false,  25.0, new List<string> { "ff" });
             var cool = (ProteinParsimonyResults)engine.Run();
             var proteinGroups = cool.ProteinGroups;
 

--- a/Test/SearchEngineTests.cs
+++ b/Test/SearchEngineTests.cs
@@ -70,7 +70,7 @@ namespace Test
             string myFile = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\sliced_b6.mzML");
             string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\LowResSnip_B6_mouse_11700_117500pruned.xml");
 
-            var engineToml = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("SearchTOML", searchTaskLoaded) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, false) }, outputFolder);
+            var engineToml = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("SearchTOML", searchTaskLoaded) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, false) }, outputFolder, 25.0);
             engineToml.Run();
 
             string psmFile = Path.Combine(outputFolder, @"SearchTOML\AllPSMs.psmtsv");
@@ -132,7 +132,7 @@ namespace Test
             string myFile = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\sliced_b6.mzML");
             string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\LowResSnip_B6_mouse_11700_117500pruned.xml");
 
-            var engineToml = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("SearchTOML", searchTaskLoaded) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, false) }, outputFolder);
+            var engineToml = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("SearchTOML", searchTaskLoaded) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, false) }, outputFolder, 25.0);
             engineToml.Run();
 
             string psmFile = Path.Combine(outputFolder, @"SearchTOML\AllPSMs.psmtsv");
@@ -1832,7 +1832,7 @@ namespace Test
 
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"testFolder");
             Directory.CreateDirectory(outputFolder);
-            task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1").ToString();
+            task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1", 25.0).ToString();
 
             //do it for SILAC code, too
             //make heavy residue and add to search task
@@ -1846,7 +1846,7 @@ namespace Test
                     SilacLabels = new List<SilacLabel> { new SilacLabel(lightLysine.Letter, heavyLysine.Letter, heavyLysine.ThisChemicalFormula.Formula, heavyLysine.MonoisotopicMass - lightLysine.MonoisotopicMass) },
                 }
             };
-            task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1").ToString();
+            task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1", 25.0).ToString();
 
             //delete files
             Directory.Delete(outputFolder, true);

--- a/Test/SearchTaskTest.cs
+++ b/Test/SearchTaskTest.cs
@@ -109,7 +109,7 @@ namespace Test
             List<(string, MetaMorpheusTask)> taskList = new List<(string, MetaMorpheusTask)> { ("TestSemiSpecificSmall", searchTask) };
 
 
-            var engine = new EverythingRunnerEngine(taskList, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, false) }, Environment.CurrentDirectory);
+            var engine = new EverythingRunnerEngine(taskList, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, false) }, Environment.CurrentDirectory, 25.0);
             engine.Run();
 
             string outputPath = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestSemiSpecificSmall\AllPSMs.psmtsv");
@@ -158,7 +158,7 @@ namespace Test
 
                 List<(string, MetaMorpheusTask)> taskList = new List<(string, MetaMorpheusTask)> { ("TestSemiSpecific", searchTask) };
 
-                var engine = new EverythingRunnerEngine(taskList, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, false) }, outputFolder);
+                var engine = new EverythingRunnerEngine(taskList, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, false) }, outputFolder, 25.0);
                 engine.Run();
 
                 string outputPath = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestSemiSpecific\TestSemiSpecific\AllPSMs.psmtsv");
@@ -196,7 +196,7 @@ namespace Test
 
             // run the task
             Directory.CreateDirectory(folderPath);
-            searchTask.RunTask(folderPath, new List<DbForTask> { db }, new List<string> { myFile }, "normal");
+            searchTask.RunTask(folderPath, new List<DbForTask> { db }, new List<string> { myFile }, "normal", 25.0);
 
             Directory.Delete(folderPath, true);
 
@@ -205,7 +205,7 @@ namespace Test
 
             // run the task
             Directory.CreateDirectory(folderPath);
-            searchTask.RunTask(folderPath, new List<DbForTask> { db }, new List<string> { myFile }, "normal");
+            searchTask.RunTask(folderPath, new List<DbForTask> { db }, new List<string> { myFile }, "normal", 25.0);
 
             // PSMs should be present but no quant output
             Assert.That(!File.Exists(Path.Combine(folderPath, "AllQuantifiedPeptides.tsv")));
@@ -235,7 +235,7 @@ namespace Test
             DbForTask db = new DbForTask(myDatabase, false);
             Directory.CreateDirectory(folderPath);
 
-            searchTask.RunTask(folderPath, new List<DbForTask> { db }, new List<string> { myFile }, "normal");
+            searchTask.RunTask(folderPath, new List<DbForTask> { db }, new List<string> { myFile }, "normal", 25.0);
             Directory.Delete(folderPath, true);
         }
 
@@ -262,7 +262,7 @@ namespace Test
             DbForTask db = new DbForTask(myDatabase, true);
             Directory.CreateDirectory(folderPath);
 
-            searchTask.RunTask(folderPath, new List<DbForTask> { db }, new List<string> { myFile }, "normal");
+            searchTask.RunTask(folderPath, new List<DbForTask> { db }, new List<string> { myFile }, "normal", 25.0);
 
             Assert.That(File.ReadAllLines(Path.Combine(folderPath, @"DbForPrunedDbproteinPruned.xml")).Length > 0);
             Assert.That(File.ReadAllLines(Path.Combine(folderPath, @"DbForPrunedDbPruned.xml")).Length > 0);
@@ -284,7 +284,7 @@ namespace Test
             Directory.CreateDirectory(folderPath);
 
             // search something with multiple hits of the same peptide to see if peptide FDR is calculated at the end
-            new SearchTask().RunTask(folderPath, new List<DbForTask> { db }, new List<string> { myFile, myFile2 }, "normal");
+            new SearchTask().RunTask(folderPath, new List<DbForTask> { db }, new List<string> { myFile, myFile2 }, "normal", 25.0);
             List<string> columns = null;
             int cumDecoys = 0;
             int cumTargets = 0;

--- a/Test/SearchWithPeptidesAddedInParsimony.cs
+++ b/Test/SearchWithPeptidesAddedInParsimony.cs
@@ -79,7 +79,7 @@ namespace Test
 
             st.RunTask(outputFolder,
                 new List<DbForTask> { new DbForTask(xmlName, false) },
-                new List<string> { mzmlName }, "");
+                new List<string> { mzmlName }, "", 25.0);
             Directory.Delete(outputFolder, true);
             File.Delete(mzmlName);
             File.Delete(xmlName);

--- a/Test/SeqCoverageTest.cs
+++ b/Test/SeqCoverageTest.cs
@@ -77,7 +77,7 @@ namespace Test
 
             newPsms.ForEach(p => p.ResolveAllAmbiguities());
 
-            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(newPsms, true, new CommonParameters(), null, new List<string>());
+            ProteinParsimonyEngine ppe = new ProteinParsimonyEngine(newPsms, true, new CommonParameters(), null, false, 25.0, new List<string>());
             ProteinParsimonyResults fjkd = (ProteinParsimonyResults)ppe.Run();
 
             ProteinScoringAndFdrEngine psafe = new ProteinScoringAndFdrEngine(fjkd.ProteinGroups, newPsms, true, true, true, new CommonParameters(), null, new List<string>());

--- a/Test/SilacTest.cs
+++ b/Test/SilacTest.cs
@@ -50,7 +50,7 @@ namespace Test
 
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestSilac");
             Directory.CreateDirectory(outputFolder);
-            var theStringResult = task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1").ToString();
+            var theStringResult = task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1", 25.0).ToString();
 
             //test proteins
             string[] output = File.ReadAllLines(TestContext.CurrentContext.TestDirectory + @"/TestSilac/AllQuantifiedProteinGroups.tsv");
@@ -121,7 +121,7 @@ namespace Test
 
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestSilac");
             Directory.CreateDirectory(outputFolder);
-            task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1");
+            task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1", 25.0);
 
             //test proteins
             string[] output = File.ReadAllLines(TestContext.CurrentContext.TestDirectory + @"/TestSilac/AllQuantifiedProteinGroups.tsv");
@@ -163,7 +163,7 @@ namespace Test
             IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
 
             Directory.CreateDirectory(outputFolder);
-            task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1");
+            task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1", 25.0);
 
             //Clear the old files
             Directory.Delete(outputFolder, true);
@@ -204,7 +204,7 @@ namespace Test
 
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestSilac");
             Directory.CreateDirectory(outputFolder);
-            var theStringResult = task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName, mzmlName2 }, "taskId1").ToString();
+            var theStringResult = task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName, mzmlName2 }, "taskId1", 25.0).ToString();
 
             Assert.IsTrue(theStringResult.Contains("All target PSMS within 1% FDR: 2")); //it's not a psm, it's a MBR feature. 2 because there are two files, but not 4 because MBR != psm
 
@@ -250,7 +250,7 @@ namespace Test
             ProteinDbWriter.WriteXmlDatabase(new Dictionary<string, HashSet<Tuple<int, Modification>>>(), new List<Protein> { theProtein, theProtein2 }, xmlName);
 
             Directory.CreateDirectory(outputFolder);
-            theStringResult = task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1").ToString();
+            theStringResult = task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1", 25.0).ToString();
 
             output = File.ReadAllLines(TestContext.CurrentContext.TestDirectory + @"/TestSilac/AllPSMs.psmtsv");
             Assert.IsTrue(output[1].Contains("silac\t")); //test the filename was NOT modified (it was for proteins, but we don't want it for peptides)
@@ -269,7 +269,7 @@ namespace Test
             ProteinDbWriter.WriteXmlDatabase(new Dictionary<string, HashSet<Tuple<int, Modification>>>(), new List<Protein> { theProtein, theProtein2 }, xmlName);
 
             Directory.CreateDirectory(outputFolder);
-            theStringResult = task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1").ToString();
+            theStringResult = task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1", 25.0).ToString();
 
             output = File.ReadAllLines(TestContext.CurrentContext.TestDirectory + @"/TestSilac/AllPSMs.psmtsv");
             Assert.IsTrue(output[1].Contains("accession1|accession2")
@@ -314,7 +314,7 @@ namespace Test
 
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestSilac");
             Directory.CreateDirectory(outputFolder);
-            var theStringResult = task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1").ToString();
+            var theStringResult = task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1", 25.0).ToString();
             //No assertions, just checking it didn't crash
 
             //delete files
@@ -361,7 +361,7 @@ namespace Test
 
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestSilac");
             Directory.CreateDirectory(outputFolder);
-            task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName, mzmlName2 }, "taskId1").ToString();
+            task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName, mzmlName2 }, "taskId1", 25.0).ToString();
 
             string[] output = File.ReadAllLines(TestContext.CurrentContext.TestDirectory + @"/TestSilac/AllQuantifiedPeptides.tsv");
             Assert.IsTrue(output[1].Contains("PEPTKIDEK\t")); //test the unlabeled is present
@@ -397,7 +397,7 @@ namespace Test
 
             myMsDataFile1 = new TestDataFile(mixedPeptide, massDifferences);
             IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
-            task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1").ToString();
+            task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1", 25.0).ToString();
 
             output = File.ReadAllLines(TestContext.CurrentContext.TestDirectory + @"/TestSilac/AllQuantifiedPeptides.tsv");
             Assert.IsTrue(output[1].Contains("PEPTKIDEK\t")); //test the unlabeled is present
@@ -437,7 +437,7 @@ namespace Test
             };
             myMsDataFile1 = new TestDataFile(peptides, massDifferences, intensities);
             IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
-            task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1").ToString();
+            task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1", 25.0).ToString();
 
             output = File.ReadAllLines(TestContext.CurrentContext.TestDirectory + @"/TestSilac/AllQuantifiedPeptides.tsv");
             Assert.IsTrue(output[1].Contains("PEPEPEPTK\t")); //test the unlabeled is present
@@ -460,7 +460,7 @@ namespace Test
                     SearchType = SearchType.Modern
                 }
             };
-            task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1").ToString();
+            task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1", 25.0).ToString();
 
             //delete files
             Directory.Delete(outputFolder, true);
@@ -496,7 +496,7 @@ namespace Test
 
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestSilac");
             Directory.CreateDirectory(outputFolder);
-            var theStringResult = task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1").ToString();
+            var theStringResult = task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1", 25.0).ToString();
 
             string[] output = File.ReadAllLines(TestContext.CurrentContext.TestDirectory + @"/TestSilac/AllQuantifiedPeaks.tsv");
             Assert.IsTrue(output.Length == 4);
@@ -554,7 +554,7 @@ namespace Test
 
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestSilac");
             Directory.CreateDirectory(outputFolder);
-            task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1").ToString();
+            task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1", 25.0).ToString();
             //Just don't crash
             //This unit test doesn't (currently) include the array of peaks for the possible combinations of labels.
             //Only a single peak is found, and because there's no heavy/light, it's unable to produce a ratio, so NaN values are returned.
@@ -598,7 +598,7 @@ namespace Test
 
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestSilac");
             Directory.CreateDirectory(outputFolder);
-            task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1").ToString();
+            task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1", 25.0).ToString();
             string[] output = File.ReadAllLines(TestContext.CurrentContext.TestDirectory + @"/TestSilac/AllQuantifiedPeptides.tsv");
             Assert.IsTrue(output[1].Contains("\t12250000\t6125000\t")); //check that it's 2:1 and not 5:3 like it would be for apex
 
@@ -607,7 +607,7 @@ namespace Test
             massDifferences = new List<List<double>> { new List<double> { (heavyLysine.MonoisotopicMass - lightLysine.MonoisotopicMass) } }; //must be reset, since the method below edits it
             myMsDataFile1 = new TestDataFile(lightPeptide, massDifferences, precursorIntensities, 2);
             IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
-            task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1").ToString();
+            task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1", 25.0).ToString();
             output = File.ReadAllLines(TestContext.CurrentContext.TestDirectory + @"/TestSilac/AllQuantifiedPeptides.tsv");
             Assert.IsTrue(output[1].Contains("\t24500000\t12250000\t")); //intensities will be twice as large as before, but still the same ratio
 

--- a/Test/SlicedTest.cs
+++ b/Test/SlicedTest.cs
@@ -19,7 +19,7 @@ namespace Test
             DbForTask db = new DbForTask(Path.Combine(TestContext.CurrentContext.TestDirectory, @"sliced-db.fasta"), false);
             string raw = Path.Combine(TestContext.CurrentContext.TestDirectory, @"sliced-raw.mzML");
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestSlicedTest1");
-            EverythingRunnerEngine a = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("Task", task) }, new List<string> { raw }, new List<DbForTask> { db }, outputFolder);
+            EverythingRunnerEngine a = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("Task", task) }, new List<string> { raw }, new List<DbForTask> { db }, outputFolder, 25.0);
 
             a.Run();
 
@@ -46,7 +46,7 @@ namespace Test
             DbForTask db = new DbForTask(Path.Combine(TestContext.CurrentContext.TestDirectory, @"sliced-db.fa"), false);
             string raw = Path.Combine(TestContext.CurrentContext.TestDirectory, @"sliced-raw.mzML");
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"FaFormatTest");
-            EverythingRunnerEngine a = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("Task", task) }, new List<string> { raw }, new List<DbForTask> { db }, outputFolder);
+            EverythingRunnerEngine a = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("Task", task) }, new List<string> { raw }, new List<DbForTask> { db }, outputFolder, 25.0);
 
             a.Run();
 

--- a/Test/SpectralLibraryReaderTest.cs
+++ b/Test/SpectralLibraryReaderTest.cs
@@ -136,7 +136,7 @@ namespace Test
                     new DbForTask(fastaDb, false)
                 },
                 new List<string> { spectraFile },
-                "");
+                "", 25.0);
 
             var results = File.ReadAllLines(Path.Combine(outputDir, @"AllPSMs.psmtsv"));
             var split = results[0].Split('\t');

--- a/Test/StefanParsimonyTest.cs
+++ b/Test/StefanParsimonyTest.cs
@@ -62,7 +62,7 @@ namespace Test
             psmsForParsimony.Add(psm2);
 
             // apply parsimony
-            ProteinParsimonyEngine pae = new ProteinParsimonyEngine(psmsForParsimony, modPeptidesAreUnique, new CommonParameters(), null, new List<string>());
+            ProteinParsimonyEngine pae = new ProteinParsimonyEngine(psmsForParsimony, modPeptidesAreUnique, new CommonParameters(), null, false, 25.0, new List<string>());
 
             // because the two chosen peptides are the same, we should end up with both protein accessions still in the list
             var proteinParsimonyResult = (ProteinParsimonyResults)pae.Run();
@@ -129,7 +129,7 @@ namespace Test
             psmsForParsimony.Add(psm2);
 
             // apply parsimony
-            ProteinParsimonyEngine pae = new ProteinParsimonyEngine(psmsForParsimony, modPeptidesAreUnique, new CommonParameters(), null, new List<string>());
+            ProteinParsimonyEngine pae = new ProteinParsimonyEngine(psmsForParsimony, modPeptidesAreUnique, new CommonParameters(), null, false, 25.0, new List<string>());
 
             // because the two chosen peptides are the same, we should end up with both protein accessions still in the list
             var proteinParsimonyResult = (ProteinParsimonyResults)pae.Run();
@@ -177,7 +177,7 @@ namespace Test
             psms.ForEach(p => p.SetFdrValues(0, 0, 0, 0, 0, 0, 0, 0));
 
             // apply parsimony
-            ProteinParsimonyEngine pae = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, new List<string>());
+            ProteinParsimonyEngine pae = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, false, 25.0, new List<string>());
 
             // because the two chosen peptides are the same, we should end up with both protein accessions still in the list
             var proteinParsimonyResult = (ProteinParsimonyResults)pae.Run();
@@ -225,7 +225,7 @@ namespace Test
             psms.ForEach(p => p.SetFdrValues(0, 0, 0, 0, 0, 0, 0, 0));
 
             // apply parsimony
-            ProteinParsimonyEngine pae = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, new List<string>());
+            ProteinParsimonyEngine pae = new ProteinParsimonyEngine(psms, false, new CommonParameters(), null, false, 25.0, new List<string>());
             ProteinParsimonyResults proteinParsimonyResult = (ProteinParsimonyResults)pae.Run();
             ProteinScoringAndFdrEngine proteinScoringEngine = new ProteinScoringAndFdrEngine(proteinParsimonyResult.ProteinGroups, psms, false, true, true, new CommonParameters(), null, new List<string>());
             ProteinScoringAndFdrResults results = (ProteinScoringAndFdrResults)proteinScoringEngine.Run();

--- a/Test/TestPsm.cs
+++ b/Test/TestPsm.cs
@@ -84,14 +84,14 @@ namespace Test
             string myFile = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\PrunedDbSpectra.mzml");
             string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\DbForPrunedDb.fasta");
 
-            var engine = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("QValueTest", searchTask) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, false) }, outputFolder);
+            var engine = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("QValueTest", searchTask) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, false) }, outputFolder, 25.0);
             engine.Run();
 
             string psmFile = Path.Combine(outputFolder, @"QValueTest\AllPSMs.psmtsv");
             var lines = File.ReadAllLines(psmFile);
             Assert.That(lines.Length == 11);
 
-            var engine2 = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("QValueTest", searchTask2) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, false) }, outputFolder);
+            var engine2 = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("QValueTest", searchTask2) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, false) }, outputFolder, 25.0);
             engine2.Run();
 
             var lines2 = File.ReadAllLines(psmFile);
@@ -148,7 +148,7 @@ namespace Test
 
             searchTaskDecoy.SearchParameters.WriteDecoys = false;
 
-            var engineDecoy = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("DecoyTest", searchTaskDecoy) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, false) }, outputFolder);
+            var engineDecoy = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("DecoyTest", searchTaskDecoy) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, false) }, outputFolder, 25.0);
             engineDecoy.Run();
 
             string psmFileDecoy = Path.Combine(outputFolder, @"DecoyTest\AllPSMs.psmtsv");
@@ -160,7 +160,7 @@ namespace Test
 
             searchTaskContaminant.SearchParameters.WriteContaminants = false;
 
-            var engineContaminant = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("ContaminantTest", searchTaskContaminant) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, false) }, outputFolder);
+            var engineContaminant = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("ContaminantTest", searchTaskContaminant) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, false) }, outputFolder, 25.0);
             engineContaminant.Run();
 
             string psmFileContaminant = Path.Combine(outputFolder, @"ContaminantTest\AllPSMs.psmtsv");
@@ -171,7 +171,7 @@ namespace Test
             var linesContaminantProtein = File.ReadAllLines(proteinFileContaminant);
             Assert.That(linesContaminantProtein.Length == 7);
 
-            var engineContaminant2 = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("ContaminantTest", searchTaskContaminant) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, true) }, outputFolder);
+            var engineContaminant2 = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("ContaminantTest", searchTaskContaminant) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, true) }, outputFolder, 25.0);
             engineContaminant2.Run();
 
             var linesContaminant2 = File.ReadAllLines(psmFileContaminant);
@@ -187,14 +187,14 @@ namespace Test
             searchTaskDecoyContaminant2.SearchParameters.WriteContaminants = false;
             searchTaskDecoyContaminant2.SearchParameters.WriteDecoys = false;
 
-            var engineDecoyContaminant = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("DecoyContaminantTest", searchTaskDecoyContaminant) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, true) }, outputFolder);
+            var engineDecoyContaminant = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("DecoyContaminantTest", searchTaskDecoyContaminant) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, true) }, outputFolder, 25.0);
             engineContaminant.Run();
 
             string psmFileDecoyContaminant = Path.Combine(outputFolder, @"DecoyContaminantTest\AllPSMs.psmtsv");
             var linesDecoyContaminant = File.ReadAllLines(psmFileContaminant);
             Assert.That(linesContaminant.Length == 11);
 
-            var engineDecoyContaminant2 = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("DecoyContaminantTest", searchTaskDecoyContaminant2) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, true) }, outputFolder);
+            var engineDecoyContaminant2 = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("DecoyContaminantTest", searchTaskDecoyContaminant2) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, true) }, outputFolder, 25.0);
             engineContaminant2.Run();
 
             string psmFileDecoyContaminant2 = Path.Combine(outputFolder, @"DecoyContaminantTest\AllPSMs.psmtsv");
@@ -204,7 +204,7 @@ namespace Test
             //No filter
             SearchTask searchTask = new SearchTask();
 
-            var engine = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("NoFilterTest", searchTask) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, true) }, outputFolder);
+            var engine = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("NoFilterTest", searchTask) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, true) }, outputFolder, 25.0);
             engine.Run();
 
             string psmFile = Path.Combine(outputFolder, @"NoFilterTest\AllPSMs.psmtsv");
@@ -332,7 +332,7 @@ namespace Test
             string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\smalldb.fasta");
             Directory.CreateDirectory(outputFolder);
 
-            task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(myDatabase, false) }, new List<string> { myFile }, "test");
+            task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(myDatabase, false) }, new List<string> { myFile }, "test", 25.0);
 
             var peptides = File.ReadAllLines(Path.Combine(outputFolder, @"AllPeptides.psmtsv"));
             var header = peptides[0].Split(new char[] { '\t' }).ToArray();

--- a/Test/TestToml.cs
+++ b/Test/TestToml.cs
@@ -44,9 +44,9 @@ namespace Test
             string myFile = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\PrunedDbSpectra.mzml");
             string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\DbForPrunedDb.fasta");
 
-            var engine = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("Search", searchTask) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, false) }, outputFolder);
+            var engine = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("Search", searchTask) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, false) }, outputFolder, 25.0);
             engine.Run();
-            var engineToml = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("SearchTOML", searchTaskLoaded) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, false) }, outputFolder);
+            var engineToml = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("SearchTOML", searchTaskLoaded) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, false) }, outputFolder, 25.0);
             engineToml.Run();
 
             var results = File.ReadAllLines(Path.Combine(outputFolder, @"Search\AllPSMs.psmtsv"));
@@ -61,9 +61,9 @@ namespace Test
             Toml.WriteFile(gptmdTask, "GptmdTask.toml", MetaMorpheusTask.tomlConfig);
             var gptmdTaskLoaded = Toml.ReadFile<GptmdTask>("GptmdTask.toml", MetaMorpheusTask.tomlConfig);
 
-            var gptmdEngine = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("GPTMD", gptmdTask) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, false) }, outputFolder);
+            var gptmdEngine = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("GPTMD", gptmdTask) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, false) }, outputFolder, 25.0);
             gptmdEngine.Run();
-            var gptmdEngineToml = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("GPTMDTOML", gptmdTaskLoaded) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, false) }, outputFolder);
+            var gptmdEngineToml = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("GPTMDTOML", gptmdTaskLoaded) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, false) }, outputFolder, 25.0);
             gptmdEngineToml.Run();
 
             var gptmdResults = File.ReadAllLines(Path.Combine(outputFolder, @"GPTMD\GPTMD_Candidates.psmtsv"));
@@ -78,9 +78,9 @@ namespace Test
             string myFileXl = Path.Combine(TestContext.CurrentContext.TestDirectory, @"XlTestData\BSA_DSSO_ETchD6010.mgf");
             string myDatabaseXl = Path.Combine(TestContext.CurrentContext.TestDirectory, @"XlTestData\BSA.fasta");
 
-            var xlEngine = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("XLSearch", xLSearchTask) }, new List<string> { myFileXl }, new List<DbForTask> { new DbForTask(myDatabaseXl, false) }, outputFolder);
+            var xlEngine = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("XLSearch", xLSearchTask) }, new List<string> { myFileXl }, new List<DbForTask> { new DbForTask(myDatabaseXl, false) }, outputFolder, 25.0);
             xlEngine.Run();
-            var xlEngineToml = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("XLSearchTOML", xLSearchTaskLoaded) }, new List<string> { myFileXl }, new List<DbForTask> { new DbForTask(myDatabaseXl, false) }, outputFolder);
+            var xlEngineToml = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("XLSearchTOML", xLSearchTaskLoaded) }, new List<string> { myFileXl }, new List<DbForTask> { new DbForTask(myDatabaseXl, false) }, outputFolder, 25.0);
             xlEngineToml.Run();
 
             var xlResults = File.ReadAllLines(Path.Combine(outputFolder, @"XLSearch\XL_Intralinks.tsv"));
@@ -136,7 +136,7 @@ namespace Test
             task.RunTask(outputFolder, 
                 new List<DbForTask> { new DbForTask(Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\okk.xml"), false) },
                 new List<string>{Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\ok.mgf") },
-                outputFolder);
+                outputFolder, 25.0);
 
             //Clear result files
             Directory.Delete(outputFolder, true);

--- a/Test/VariantSearchTests.cs
+++ b/Test/VariantSearchTests.cs
@@ -91,7 +91,7 @@ namespace Test
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, $"TestSearchWithVariants{proteinIdx.ToString()}");
             Directory.CreateDirectory(outputFolder);
 
-            st.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "");
+            st.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "", 25.0);
             var psms = File.ReadAllLines(Path.Combine(outputFolder, "AllPSMs.psmtsv"));
 
             Assert.IsTrue(psms.Any(line => line.Contains(containsVariant ? variantPsmShort : "\t")));
@@ -133,7 +133,7 @@ namespace Test
                 CommonParameters = new CommonParameters(scoreCutoff: 1, digestionParams: new DigestionParams(minPeptideLength: 2), precursorMassTolerance: new PpmTolerance(20)),
             };
 
-            st.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "");
+            st.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "", 25.0);
             var psms = File.ReadAllLines(Path.Combine(outputFolder, "AllPSMs.psmtsv"));
 
             //Assert.IsTrue(psms.Any(line => line.Contains($"\t{variantPsmShort}\t" + (containsVariant ? variantPsmShort : "\t"))));
@@ -164,17 +164,17 @@ namespace Test
 
             string raw = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestVariantPep.mzML");
 
-            EverythingRunnerEngine noVariants = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("NoVariantOutput", task) }, new List<string> { raw }, new List<DbForTask> { noVariantDb }, thisTaskOutputFolder);
-            EverythingRunnerEngine ambigVariant = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("VariantOutput_ambig", task) }, new List<string> { raw }, new List<DbForTask> { ambigVariantDb }, thisTaskOutputFolder);
-            EverythingRunnerEngine frameshifVariants = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("VariantOutput_frameshift", task) }, new List<string> { raw }, new List<DbForTask> { frameshiftVariantDb }, thisTaskOutputFolder);
-            EverythingRunnerEngine missenseVariants = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("VariantOutput_missense", task) }, new List<string> { raw }, new List<DbForTask> { missenseVariantDb }, thisTaskOutputFolder);
-            EverythingRunnerEngine SNVmissenseVariants = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("VariantOutput_SNVmissense", task) }, new List<string> { raw }, new List<DbForTask> { SNVmissenseVariantDb }, thisTaskOutputFolder);
-            EverythingRunnerEngine stopGainedVariants = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("VariantOutput_stopGained", task) }, new List<string> { raw }, new List<DbForTask> { stopGainedVariantDb }, thisTaskOutputFolder);
-            EverythingRunnerEngine conservativeInsertionVariants = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("VariantOutput_conservativeInsertion", task) }, new List<string> { raw }, new List<DbForTask> { conservativeInsertionVariantDb }, thisTaskOutputFolder);
-            EverythingRunnerEngine disruptiveInsertionVariants = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("VariantOutput_disruptiveInsertion", task) }, new List<string> { raw }, new List<DbForTask> { disruptiveInsertionVariantDb }, thisTaskOutputFolder);
-            EverythingRunnerEngine conservativeDeletionVariants = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("VariantOutput_conservativeDeletion", task) }, new List<string> { raw }, new List<DbForTask> { conservativeDeletionVariantDb }, thisTaskOutputFolder);
-            EverythingRunnerEngine disruptiveDeletionVariants = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("VariantOutput_disruptiveDeletion", task) }, new List<string> { raw }, new List<DbForTask> { disruptiveDeletionVariantDb }, thisTaskOutputFolder);
-            EverythingRunnerEngine stopLossVariants = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("VariantOutput_stopLoss", task) }, new List<string> { raw }, new List<DbForTask> { stopLossVariantDb }, thisTaskOutputFolder);
+            EverythingRunnerEngine noVariants = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("NoVariantOutput", task) }, new List<string> { raw }, new List<DbForTask> { noVariantDb }, thisTaskOutputFolder, 25.0);
+            EverythingRunnerEngine ambigVariant = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("VariantOutput_ambig", task) }, new List<string> { raw }, new List<DbForTask> { ambigVariantDb }, thisTaskOutputFolder, 25.0);
+            EverythingRunnerEngine frameshifVariants = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("VariantOutput_frameshift", task) }, new List<string> { raw }, new List<DbForTask> { frameshiftVariantDb }, thisTaskOutputFolder, 25.0);
+            EverythingRunnerEngine missenseVariants = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("VariantOutput_missense", task) }, new List<string> { raw }, new List<DbForTask> { missenseVariantDb }, thisTaskOutputFolder, 25.0);
+            EverythingRunnerEngine SNVmissenseVariants = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("VariantOutput_SNVmissense", task) }, new List<string> { raw }, new List<DbForTask> { SNVmissenseVariantDb }, thisTaskOutputFolder, 25.0);
+            EverythingRunnerEngine stopGainedVariants = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("VariantOutput_stopGained", task) }, new List<string> { raw }, new List<DbForTask> { stopGainedVariantDb }, thisTaskOutputFolder, 25.0);
+            EverythingRunnerEngine conservativeInsertionVariants = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("VariantOutput_conservativeInsertion", task) }, new List<string> { raw }, new List<DbForTask> { conservativeInsertionVariantDb }, thisTaskOutputFolder, 25.0);
+            EverythingRunnerEngine disruptiveInsertionVariants = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("VariantOutput_disruptiveInsertion", task) }, new List<string> { raw }, new List<DbForTask> { disruptiveInsertionVariantDb }, thisTaskOutputFolder, 25.0);
+            EverythingRunnerEngine conservativeDeletionVariants = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("VariantOutput_conservativeDeletion", task) }, new List<string> { raw }, new List<DbForTask> { conservativeDeletionVariantDb }, thisTaskOutputFolder, 25.0);
+            EverythingRunnerEngine disruptiveDeletionVariants = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("VariantOutput_disruptiveDeletion", task) }, new List<string> { raw }, new List<DbForTask> { disruptiveDeletionVariantDb }, thisTaskOutputFolder, 25.0);
+            EverythingRunnerEngine stopLossVariants = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("VariantOutput_stopLoss", task) }, new List<string> { raw }, new List<DbForTask> { stopLossVariantDb }, thisTaskOutputFolder, 25.0);
 
 
             noVariants.Run();

--- a/Test/XLSearchOutputTest.cs
+++ b/Test/XLSearchOutputTest.cs
@@ -20,7 +20,7 @@ namespace Test
 
             XLSearchTask xLSearch = new XLSearchTask();
             xLSearch.XlSearchParameters.CrosslinkAtCleavageSite = true;
-            xLSearch.RunTask(outputFolder, new List<DbForTask> { new DbForTask(myDatabase, false) }, new List<string> { myFile }, "test");
+            xLSearch.RunTask(outputFolder, new List<DbForTask> { new DbForTask(myDatabase, false) }, new List<string> { myFile }, "test", 25.0);
 
             var resultsPath = File.ReadAllLines(Path.Combine(outputFolder, @"XL_Intralinks.tsv"));
             var sections = resultsPath[1].Split('\t');

--- a/Test/XLTest.cs
+++ b/Test/XLTest.cs
@@ -249,7 +249,7 @@ namespace Test
                 }
             }
 
-            new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("Task", task) }, new List<string> { raw }, new List<DbForTask> { db }, Path.Combine(Environment.CurrentDirectory, @"TESTXlTestData")).Run();
+            new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("Task", task) }, new List<string> { raw }, new List<DbForTask> { db }, Path.Combine(Environment.CurrentDirectory, @"TESTXlTestData"), 25.0).Run();
             Directory.Delete(Path.Combine(Environment.CurrentDirectory, @"TESTXlTestData"), true);
         }
 
@@ -860,8 +860,8 @@ namespace Test
             };
             Directory.CreateDirectory(outputFolder);
 
-            xLSearchTask.RunTask(outputFolder, new List<DbForTask> { new DbForTask(myDatabaseXl, false) }, new List<string> { myFileXl }, "test");
-            xLSearchTask2.RunTask(outputFolder, new List<DbForTask> { new DbForTask(myDatabaseXl, false) }, new List<string> { myFileXl }, "test");
+            xLSearchTask.RunTask(outputFolder, new List<DbForTask> { new DbForTask(myDatabaseXl, false) }, new List<string> { myFileXl }, "test", 25.0);
+            xLSearchTask2.RunTask(outputFolder, new List<DbForTask> { new DbForTask(myDatabaseXl, false) }, new List<string> { myFileXl }, "test", 25.0);
             Directory.Delete(outputFolder, true);
             Directory.Delete(Path.Combine(TestContext.CurrentContext.TestDirectory, @"Task Settings"), true);
         }
@@ -877,7 +877,7 @@ namespace Test
 
             Directory.CreateDirectory(outputFolder);
 
-            xLSearchTask.RunTask(outputFolder, new List<DbForTask> { new DbForTask(myDatabaseXl, false) }, new List<string> { myFileXl }, "test");
+            xLSearchTask.RunTask(outputFolder, new List<DbForTask> { new DbForTask(myDatabaseXl, false) }, new List<string> { myFileXl }, "test", 25.0);
             var lines = File.ReadAllLines(Path.Combine(outputFolder, @"Deadends.tsv"));
             Assert.That(lines.Length == 2);
             Assert.That(lines[1].Contains("Dead"));
@@ -904,9 +904,9 @@ namespace Test
             Directory.CreateDirectory(folderPath);
 
             //creates .params files if they do not exist
-            xlSearchTask.RunTask(folderPath, new List<DbForTask> { db }, new List<string> { myFile }, "normal");
+            xlSearchTask.RunTask(folderPath, new List<DbForTask> { db }, new List<string> { myFile }, "normal", 25.0);
             //tests .params files
-            xlSearchTask.RunTask(folderPath, new List<DbForTask> { db }, new List<string> { myFile }, "normal");
+            xlSearchTask.RunTask(folderPath, new List<DbForTask> { db }, new List<string> { myFile }, "normal", 25.0);
 
             var baseDir = Path.GetDirectoryName(db.FilePath);
             var directory = new DirectoryInfo(baseDir);
@@ -919,7 +919,7 @@ namespace Test
                 }
             }
             //tests without .params files
-            xlSearchTask.RunTask(folderPath, new List<DbForTask> { db }, new List<string> { myFile }, "normal");
+            xlSearchTask.RunTask(folderPath, new List<DbForTask> { db }, new List<string> { myFile }, "normal", 25.0);
 
             var lines = File.ReadAllLines(Path.Combine(folderPath, @"XL_Intralinks.tsv"));
             Assert.That(lines.Length == 2);
@@ -1180,7 +1180,7 @@ namespace Test
 
             List<(string, MetaMorpheusTask)> taskList = new List<(string, MetaMorpheusTask)> { ("TestPercolator", xlst) };
 
-            var engine = new EverythingRunnerEngine(taskList, new List<string> { myFileXl }, new List<DbForTask> { db }, outputFolder);
+            var engine = new EverythingRunnerEngine(taskList, new List<string> { myFileXl }, new List<DbForTask> { db }, outputFolder, 25.0);
             engine.Run();
 
             var results = Path.Combine(outputFolder, @"TestPercolator\XL_Intralinks_Percolator.txt");

--- a/Test/XLTestNGlyco.cs
+++ b/Test/XLTestNGlyco.cs
@@ -110,7 +110,7 @@ namespace Test
             Directory.CreateDirectory(Path.Combine(Environment.CurrentDirectory, @"TESTGlycoData"));
             DbForTask db = new DbForTask(Path.Combine(TestContext.CurrentContext.TestDirectory, @"GlycoTestData/Q9C0Y4.fasta"), false);
             string raw = Path.Combine(TestContext.CurrentContext.TestDirectory, @"GlycoTestData/yeast_glycan_25170.mgf");
-            new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("Task", task) }, new List<string> { raw }, new List<DbForTask> { db }, Path.Combine(Environment.CurrentDirectory, @"TESTGlycoData")).Run();
+            new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("Task", task) }, new List<string> { raw }, new List<DbForTask> { db }, Path.Combine(Environment.CurrentDirectory, @"TESTGlycoData"), 25.0).Run();
             Directory.Delete(Path.Combine(Environment.CurrentDirectory, @"TESTGlycoData"), true);
         }
 

--- a/Test/XLTestOGlyco.cs
+++ b/Test/XLTestOGlyco.cs
@@ -383,7 +383,7 @@ namespace Test
             Directory.CreateDirectory(Path.Combine(Environment.CurrentDirectory, @"TESTGlycoData"));
             DbForTask db = new DbForTask(Path.Combine(TestContext.CurrentContext.TestDirectory, @"GlycoTestData/P16150.fasta"), false);
             string spectraFile = Path.Combine(TestContext.CurrentContext.TestDirectory, @"GlycoTestData\2019_09_16_StcEmix_35trig_EThcD25_rep1_9906.mgf");
-            new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("Task", task) }, new List<string> { spectraFile }, new List<DbForTask> { db }, Path.Combine(Environment.CurrentDirectory, @"TESTGlycoData")).Run();
+            new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("Task", task) }, new List<string> { spectraFile }, new List<DbForTask> { db }, Path.Combine(Environment.CurrentDirectory, @"TESTGlycoData"), 25.0).Run();
             Directory.Delete(Path.Combine(Environment.CurrentDirectory, @"TESTGlycoData"), true);
         }
 
@@ -402,7 +402,7 @@ namespace Test
             Directory.CreateDirectory(Path.Combine(Environment.CurrentDirectory, @"TESTGlycoData"));
             DbForTask db = new DbForTask(Path.Combine(TestContext.CurrentContext.TestDirectory, @"GlycoTestData/P02649.fasta"), false);
             string spectraFile = Path.Combine(TestContext.CurrentContext.TestDirectory, @"GlycoTestData\181217_Fusion_(LC2)_NewObj_Serum_deSA_Jacalin_HRM_4h_ETD_HCD_DDA_mz(400_1200)_21707.mgf");
-            new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("Task", task) }, new List<string> { spectraFile }, new List<DbForTask> { db }, Path.Combine(Environment.CurrentDirectory, @"TESTGlycoData")).Run();
+            new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("Task", task) }, new List<string> { spectraFile }, new List<DbForTask> { db }, Path.Combine(Environment.CurrentDirectory, @"TESTGlycoData"), 25.0).Run();
             Directory.Delete(Path.Combine(Environment.CurrentDirectory, @"TESTGlycoData"), true);
         }
 

--- a/Test/gptmdPrunedBdTests.cs
+++ b/Test/gptmdPrunedBdTests.cs
@@ -52,7 +52,7 @@ namespace Test
             string mzmlName = @"TestData\PrunedDbSpectra.mzml";
             string fastaName = @"TestData\DbForPrunedDb.fasta";
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestPrunedGeneration");
-            var engine = new EverythingRunnerEngine(taskList, new List<string> { mzmlName }, new List<DbForTask> { new DbForTask(fastaName, false) }, outputFolder);
+            var engine = new EverythingRunnerEngine(taskList, new List<string> { mzmlName }, new List<DbForTask> { new DbForTask(fastaName, false) }, outputFolder, 25.0);
             engine.Run();
             string final = Path.Combine(MySetUpClass.outputFolder, "task2", "DbForPrunedDbGPTMDproteinPruned.xml");
             List<Protein> proteins = ProteinDbLoader.LoadProteinXML(final, true, DecoyType.Reverse, new List<Modification>(), false, new List<string>(), out var ok);
@@ -165,7 +165,7 @@ namespace Test
             //run!
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestPrunedDatabase");
             var engine = new EverythingRunnerEngine(taskList, new List<string> { mzmlName },
-                new List<DbForTask> { new DbForTask(xmlName, false) }, outputFolder);
+                new List<DbForTask> { new DbForTask(xmlName, false) }, outputFolder, 25.0);
             engine.Run();
 
             string final = Path.Combine(MySetUpClass.outputFolder, "task1", "okkkpruned.xml");
@@ -298,7 +298,7 @@ namespace Test
             //make sure this runs correctly
             //run!
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestUserModSelectionInPrunedDB");
-            var engine = new EverythingRunnerEngine(taskList, new List<string> { mzmlName }, new List<DbForTask> { new DbForTask(xmlName, false) }, outputFolder);
+            var engine = new EverythingRunnerEngine(taskList, new List<string> { mzmlName }, new List<DbForTask> { new DbForTask(xmlName, false) }, outputFolder, 25.0);
             engine.Run();
             string final = Path.Combine(MySetUpClass.outputFolder, "task5", "selectedModspruned.xml");
             var proteins = ProteinDbLoader.LoadProteinXML(final, true, DecoyType.Reverse, new List<Modification>(), false, new List<string>(), out ok);
@@ -399,7 +399,7 @@ namespace Test
                 CommonParameters = new CommonParameters()
             };
 
-            var test = task5.RunTask(Path.Combine(TestContext.CurrentContext.TestDirectory, @"PrunedDbTest"), new List<DbForTask>() { new DbForTask(Path.Combine(TestContext.CurrentContext.TestDirectory, @"PrunedDbTest/fakeDb.xml"),false)}, new List<string>() { mzmlName }, "name");
+            var test = task5.RunTask(Path.Combine(TestContext.CurrentContext.TestDirectory, @"PrunedDbTest"), new List<DbForTask>() { new DbForTask(Path.Combine(TestContext.CurrentContext.TestDirectory, @"PrunedDbTest/fakeDb.xml"),false)}, new List<string>() { mzmlName }, "name", 25.0);
             testPostTaskParameters.SearchTaskResults = test;
            
             PostSearchAnalysisTask testPostTask = new PostSearchAnalysisTask();
@@ -504,7 +504,7 @@ namespace Test
                 CommonParameters = new CommonParameters()
             };
 
-            var test = task5.RunTask(Path.Combine(TestContext.CurrentContext.TestDirectory, @"PrunedDbTest"), new List<DbForTask>() { new DbForTask(Path.Combine(TestContext.CurrentContext.TestDirectory, @"PrunedDbTest/fakeDb.xml"), false) }, new List<string>() { mzmlName }, "name");
+            var test = task5.RunTask(Path.Combine(TestContext.CurrentContext.TestDirectory, @"PrunedDbTest"), new List<DbForTask>() { new DbForTask(Path.Combine(TestContext.CurrentContext.TestDirectory, @"PrunedDbTest/fakeDb.xml"), false) }, new List<string>() { mzmlName }, "name", 25.0);
             testPostTaskParameters.SearchTaskResults = test;
 
             PostSearchAnalysisTask testPostTask = new PostSearchAnalysisTask();


### PR DESCRIPTION
Updates:
- MetaMorpheus takes in RNA seq abundance information in CMD
- abundance information is provided in .tsv file
- user provides CPM threshold in CMD ( or is 25.0 CPM by default)
- incorporation of rescue and resolve algorithm