### PR TITLE
[WIP] add parallelization to the determination of spectral angles

### DIFF
--- a/CMD/CMD.csproj
+++ b/CMD/CMD.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.ML" Version="1.3.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="1.3.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.500" />
+    <PackageReference Include="mzLib" Version="1.0.505" />
     <PackageReference Include="Nett" Version="0.13.0" />
   </ItemGroup>
 

--- a/EngineLayer/EngineLayer.csproj
+++ b/EngineLayer/EngineLayer.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.ML" Version="1.3.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="1.3.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.500" />
+    <PackageReference Include="mzLib" Version="1.0.505" />
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="Nett" Version="0.13.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/EngineLayer/SpectralLibrarySearch/LibrarySpectrum.cs
+++ b/EngineLayer/SpectralLibrarySearch/LibrarySpectrum.cs
@@ -1,4 +1,6 @@
-﻿using Proteomics.Fragmentation;
+﻿using Chemistry;
+using Proteomics.Fragmentation;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -17,6 +19,11 @@ namespace EngineLayer
         public int ChargeState { get; set; }
         public List<MatchedFragmentIon> MatchedFragmentIons { get; set; }
         public bool IsDecoy { get; set; }
+
+        public double[] XArray => _XArray;
+        private double[] _XArray;
+        public double[] YArray => _YArray;
+        private double[] _YArray;
         public string Name
         {
             get { return Sequence + "/" + ChargeState; }
@@ -30,6 +37,7 @@ namespace EngineLayer
             ChargeState = chargeState;
             IsDecoy = isDecoy;
             RetentionTime = rt;
+            PopulateSpectrumArrays(peaks, chargeState);
         }
 
         public override string ToString()
@@ -61,6 +69,13 @@ namespace EngineLayer
             }
 
             return spectrum.ToString();
+        }
+
+        private void PopulateSpectrumArrays(List<MatchedFragmentIon> peaks, int charge)
+        {
+            _XArray = peaks.Select(p => p.NeutralTheoreticalProduct.NeutralMass.ToMz(charge)).ToArray();
+            _YArray = peaks.Select(p => p.Intensity).ToArray();
+            Array.Sort(_XArray,_YArray);
         }
     }
 }

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -55,7 +55,7 @@
     <PackageReference Include="Microsoft.ML.DataView" Version="1.3.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="1.3.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.500" />
+    <PackageReference Include="mzLib" Version="1.0.505" />
     <PackageReference Include="Nett" Version="0.13.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0" />

--- a/GuiFunctions/GuiFunctions.csproj
+++ b/GuiFunctions/GuiFunctions.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="itext7" Version="7.1.13" />
-    <PackageReference Include="mzLib" Version="1.0.500" />
+    <PackageReference Include="mzLib" Version="1.0.505" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.0.0" />
   </ItemGroup>
 

--- a/TaskLayer/TaskLayer.csproj
+++ b/TaskLayer/TaskLayer.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.ML" Version="1.3.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="1.3.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.500" />
+    <PackageReference Include="mzLib" Version="1.0.505" />
     <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="Nett" Version="0.13.0" />
   </ItemGroup>

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.ML" Version="1.3.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="1.3.1" />
-    <PackageReference Include="mzLib" Version="1.0.500" />
+    <PackageReference Include="mzLib" Version="1.0.505" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />


### PR DESCRIPTION
spectral library search is performed after search is complete. currently all spectral angles are computed one at a time. This PR will parallelize that process by the number of threads. Step one is to provide access to new spectral angle calculations that were added to mzlib in update 505