### PR TITLE
GUI Auto Settings Bug Fix

### DIFF
--- a/GUI/TaskWindows/SearchTaskWindow.xaml.cs
+++ b/GUI/TaskWindows/SearchTaskWindow.xaml.cs
@@ -799,6 +799,8 @@ namespace MetaMorpheusGUI
                         if (UpdateGUISettings.UseNonSpecificRecommendedSettings())
                         {
                             MaxPeptideLengthTextBox.Text = "25";
+                            ClassicSearchRadioButton.IsChecked = false;
+                            NonSpecificSearchRadioButton.IsChecked = true;
                         }
                         break;
                     case "top-down":


### PR DESCRIPTION
This is a GUI specific update. Selecting "non-specific" as the protease in the search task triggers a prompt suggesting default settings that we have found to be a useful start point for a non-specific search. This update changes one of the defaults, the mode of search from "classic" to "non-specific". This should give equivalent results but the search should be faster. The search mode can be found in "Advanced Options/Some Search Parameters/Search Mode".

This update solves the issue raised in #1846 
https://github.com/smith-chem-wisc/MetaMorpheus/issues/1846
