### PR TITLE
nativeWin to native in productwxs to fix missing fasttreenative dll bug

### DIFF
--- a/MetaMorpheusSetup/Product.wxs
+++ b/MetaMorpheusSetup/Product.wxs
@@ -64,7 +64,7 @@
         <Directory Id="MetaMorpheusInstallFolder" Name="MetaMorpheus">
           <Directory Id="NativeMathDllFolder_runtimes" Name="runtimes">
             <Directory Id="NativeMathDllFolder_win_x64" Name="win-x64">
-              <Directory Id="NativeMathDllFolder_win_x64_native" Name="nativeWin"/>
+              <Directory Id="NativeMathDllFolder_win_x64_native" Name="native"/>
             </Directory>
             <Directory Id="NativeMathDllFolder_linux_x64" Name="linux-x64">
               <Directory Id="NativeMathDllFolder_linux_x64_native" Name="nativeLinux"/>


### PR DESCRIPTION
Currently AppVeyor successfully builds MetaMorpheus so that it can be installed. However, the installed version crashing during the post search analysis task because it cant find the fasttreenative dll. This problem emerged when we merged the upgrade to .net 6.0. In that PR, we added code to make folders for linux, macOs and windows. So product.wxs changed folder names to nativeLinux, nativeMac and nativeWin. Originally there was only one folder called native.  MM is still looking for the fasttreenative.dll in the folder native, which doesn't exist, so it cant be found. Changing the folder name from nativeWin to native in the product.wxs fixes the problem.

I wish that I know why that dll is being looked for in native, because I think the nativeWin folder name is more informative.