### PR TITLE
Meta draw default settings bug fix and default mod colors

### DIFF
--- a/GuiFunctions/MetaDraw/MetaDrawLogic.cs
+++ b/GuiFunctions/MetaDraw/MetaDrawLogic.cs
@@ -808,7 +808,6 @@ namespace GuiFunctions
             unformattedBitmap.Dispose();
             File.Delete(tempBitmapPath);
             return bitmap;
-            bitmap.Dispose();
         }
 
         /// <summary>

--- a/GuiFunctions/MetaDraw/MetaDrawSettings.cs
+++ b/GuiFunctions/MetaDraw/MetaDrawSettings.cs
@@ -131,20 +131,61 @@ namespace GuiFunctions
                 BetaProductTypeToColor[ProductType.D] = OxyColors.AliceBlue;
                 BetaProductTypeToColor[ProductType.M] = OxyColors.LightCoral;
 
-                // default color of each ptm
-                ModificationTypeToColor = GlobalVariables.AllModsKnown.ToDictionary(p => p.IdWithMotif, p => OxyColors.Orange);
-                ModificationTypeToColor["Acetylation on K"] = OxyColors.Aqua;
-                ModificationTypeToColor["Acetylation on X"] = OxyColors.Aqua;
-                ModificationTypeToColor["Acetylation on S"] = OxyColors.Purple;
-                ModificationTypeToColor["Acetylation on T"] = OxyColors.Purple;
-                ModificationTypeToColor["Acetylation on Y"] = OxyColors.Purple;
-                ModificationTypeToColor["Carbamidomethyl on C"] = OxyColors.Green;
-                ModificationTypeToColor["Carbamidomethyl on U"] = OxyColors.Green;
-                ModificationTypeToColor["Oxidation on M"] = OxyColors.HotPink;
+                #region Setting Color Defaults
 
-                CoverageTypeToColor = CoverageTypes.ToDictionary(p => p, p => OxyColors.Blue);
-                CoverageTypeToColor["C-Terminal Color"] = OxyColors.Red;
-                CoverageTypeToColor["Internal Color"] = OxyColors.Purple;
+                    ModificationTypeToColor = GlobalVariables.AllModsKnown.ToDictionary(p => p.IdWithMotif, p => OxyColors.Orange);
+
+                    // setting whole groups
+                    var commonBiological = GlobalVariables.AllModsKnown.Where(p => p.ModificationType == "Common Biological").Select(p => p.IdWithMotif);
+                    foreach (var mod in commonBiological)
+                    {
+                        ModificationTypeToColor[mod] = OxyColors.Plum;
+                    }
+
+                    var lessCommon = GlobalVariables.AllModsKnown.Where(p => p.ModificationType == "Less Common").Select(p => p.IdWithMotif);
+                    foreach (var mod in lessCommon)
+                    {
+                        ModificationTypeToColor[mod] = OxyColors.PowderBlue;
+                    }
+
+                    var commonArtificat = GlobalVariables.AllModsKnown.Where(p => p.ModificationType == "Common Artifact").Select(p => p.IdWithMotif);
+                    foreach (var mod in commonArtificat)
+                    {
+                        ModificationTypeToColor[mod] = OxyColors.Teal;
+                    }
+
+                    var metal = GlobalVariables.AllModsKnown.Where(p => p.ModificationType == "Metal").Select(p => p.IdWithMotif);
+                    foreach (var mod in metal)
+                    {
+                        ModificationTypeToColor[mod] = OxyColors.Maroon;
+                    }
+
+                    var glyco = GlobalVariables.AllModsKnown.Where(p => p.ModificationType.Contains("glycosylation")).Select(p => p.IdWithMotif);
+                    foreach (var mod in glyco)
+                    {
+                        ModificationTypeToColor[mod] = OxyColors.Maroon;
+                    }
+
+                // setting individual specific
+                foreach (var mod in ModificationTypeToColor.Where(p => p.Key.Contains("Phosphorylation")))
+                    {
+                        ModificationTypeToColor[mod.Key] = OxyColors.Red;
+                    }
+
+                    foreach (var mod in ModificationTypeToColor.Where(p => p.Key.Contains("Acetylation")))
+                    {
+                        ModificationTypeToColor[mod.Key] = OxyColors.Purple; ;
+                    }
+
+                    ModificationTypeToColor["Carbamidomethyl on C"] = OxyColors.Green;
+                    ModificationTypeToColor["Carbamidomethyl on U"] = OxyColors.Green;
+                    ModificationTypeToColor["Oxidation on M"] = OxyColors.HotPink;
+
+                    CoverageTypeToColor = CoverageTypes.ToDictionary(p => p, p => OxyColors.Blue);
+                    CoverageTypeToColor["C-Terminal Color"] = OxyColors.Red;
+                    CoverageTypeToColor["Internal Color"] = OxyColors.Purple;
+
+                #endregion
 
                 // lines to be written on the spectrum
                 SpectrumDescription = SpectrumDescriptors.ToDictionary(p => p, p => true);

--- a/GuiFunctions/ViewModels/ModForTreeViewModel.cs
+++ b/GuiFunctions/ViewModels/ModForTreeViewModel.cs
@@ -69,9 +69,13 @@ namespace GuiFunctions
             Use = use;
             ModName = modName;
             DisplayName = modName;
-            OxyColor color = MetaDrawSettings.ModificationTypeToColor[modName];
-            SelectedColor = AddSpaces(color.GetColorName());
-            ColorBrush = DrawnSequence.ParseColorBrushFromOxyColor(color);
+            if (MetaDrawSettings.ModificationTypeToColor != null)
+            {
+                OxyColor color = MetaDrawSettings.ModificationTypeToColor[modName];
+                SelectedColor = AddSpaces(color.GetColorName());
+                ColorBrush = DrawnSequence.ParseColorBrushFromOxyColor(color);
+            }
+            
 
             if (toolTip.ToLower().Contains("terminal"))
             {

--- a/GuiFunctions/ViewModels/SettingsViewModel.cs
+++ b/GuiFunctions/ViewModels/SettingsViewModel.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
+using Nett;
 using System.Windows.Input;
 
 namespace GuiFunctions
@@ -161,6 +162,12 @@ namespace GuiFunctions
         {
             Save();
             MetaDrawSettingsSnapshot settings = MetaDrawSettings.MakeSnapShot();
+            string directoryPath = Path.GetDirectoryName(SettingsPath);
+            if (!Directory.Exists(directoryPath))
+            {
+                Directory.CreateDirectory(directoryPath);
+            }
+
             XmlReaderWriter.WriteToXmlFile<MetaDrawSettingsSnapshot>(SettingsPath, settings);
         }
 

--- a/Test/MetaDrawSettingsAndViewsTest.cs
+++ b/Test/MetaDrawSettingsAndViewsTest.cs
@@ -86,7 +86,7 @@ namespace Test
             SettingsViewModel model = new SettingsViewModel(false);
 
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestMetaDrawWithSpectraLibrary");
-            Directory.CreateDirectory(outputFolder);
+            Assert.That(!Directory.Exists(outputFolder));
 
             SettingsViewModel.SettingsPath = Path.Combine(outputFolder, @"MetaDrawSettingsDefault.xml");
             Assert.That(model.HasDefaultSaved == false);


### PR DESCRIPTION
Fixed a bug where meta draw would crash if there was not a default param directory. Added default colors to some mods per Austin's suggestion in my previous pull request

These defaults in windows are added to \user\user\appdata\local\metamorpheus\defaultparameters

can be reset by deleting those files