### PR TITLE
Added field to adjust FlashLFQ required isotope correlation

### DIFF
--- a/GUI/TaskWindows/CalibrateTaskWindow.xaml.cs
+++ b/GUI/TaskWindows/CalibrateTaskWindow.xaml.cs
@@ -192,7 +192,7 @@ namespace MetaMorpheusGUI
 
             if (!GlobalGuiSettings.CheckTaskSettingsValidity(PrecursorMassToleranceTextBox.Text, ProductMassToleranceTextBox.Text, MissedCleavagesTextBox.Text,
                  MaxModificationIsoformsTextBox.Text, MinPeptideLengthTextBox.Text, MaxPeptideLengthTextBox.Text, MaxThreadsTextBox.Text, MinScoreAllowed.Text,
-                 fieldNotUsed, fieldNotUsed, fieldNotUsed, fieldNotUsed, fieldNotUsed, null, null, fieldNotUsed, MaxModsPerPeptideTextBox.Text, fieldNotUsed, 
+                 fieldNotUsed, fieldNotUsed, fieldNotUsed, fieldNotUsed, fieldNotUsed, fieldNotUsed, null, null, fieldNotUsed, MaxModsPerPeptideTextBox.Text, fieldNotUsed, 
                  null, null))
             {
                 return;

--- a/GUI/TaskWindows/GPTMDTaskWindow.xaml.cs
+++ b/GUI/TaskWindows/GPTMDTaskWindow.xaml.cs
@@ -354,7 +354,7 @@ namespace MetaMorpheusGUI
 
             if (!GlobalGuiSettings.CheckTaskSettingsValidity(PrecursorMassToleranceTextBox.Text, ProductMassToleranceTextBox.Text, MissedCleavagesTextBox.Text,
                  MaxModificationIsoformsTextBox.Text, MinPeptideLengthTextBox.Text, MaxPeptideLengthTextBox.Text, MaxThreadsTextBox.Text, MinScoreAllowed.Text,
-                fieldNotUsed, fieldNotUsed, DeconvolutionMaxAssumedChargeStateTextBox.Text, NumberOfPeaksToKeepPerWindowTextBox.Text, MinimumAllowedIntensityRatioToBasePeakTexBox.Text, 
+                fieldNotUsed, fieldNotUsed, fieldNotUsed, DeconvolutionMaxAssumedChargeStateTextBox.Text, NumberOfPeaksToKeepPerWindowTextBox.Text, MinimumAllowedIntensityRatioToBasePeakTexBox.Text, 
                 null, null, fieldNotUsed, fieldNotUsed, fieldNotUsed, null, null))
             {
                 return;

--- a/GUI/TaskWindows/GlycoSearchTaskWindow.xaml.cs
+++ b/GUI/TaskWindows/GlycoSearchTaskWindow.xaml.cs
@@ -231,7 +231,7 @@ namespace MetaMorpheusGUI
 
             if (!GlobalGuiSettings.CheckTaskSettingsValidity(PrecusorMsTlTextBox.Text, productMassToleranceTextBox.Text, missedCleavagesTextBox.Text,
                 maxModificationIsoformsTextBox.Text, MinPeptideLengthTextBox.Text, MaxPeptideLengthTextBox.Text, maxThreadsTextBox.Text, minScoreAllowed.Text,
-                fieldNotUsed, fieldNotUsed, fieldNotUsed, TopNPeaksTextBox.Text, MinRatioTextBox.Text, null, null, numberOfDatabaseSearchesTextBox.Text, TxtBoxMaxModPerPep.Text, 
+                fieldNotUsed, fieldNotUsed, fieldNotUsed, fieldNotUsed, TopNPeaksTextBox.Text, MinRatioTextBox.Text, null, null, numberOfDatabaseSearchesTextBox.Text, TxtBoxMaxModPerPep.Text, 
                 fieldNotUsed, null, null))
             {
                 return;

--- a/GUI/TaskWindows/SearchTaskWindow.xaml
+++ b/GUI/TaskWindows/SearchTaskWindow.xaml
@@ -434,6 +434,18 @@
                                     <ToolTip Content="Use the 'Experimental Design' to normalize intensity values from FlashLFQ" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500" />
                                 </ToolTipService.ToolTip>
                             </CheckBox>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBox x:Name="IsotopeCorrelationTextBox"  PreviewTextInput="CheckIfNumber" Width="30" Height="20" IsEnabled="{Binding IsChecked, ElementName=CheckBoxMatchBetweenRuns}"  ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500">
+                                    <ToolTipService.ToolTip>
+                                        <TextBlock>
+                                            Minimum correlation betwen actual and theoretical isotpe distribution
+                                            <LineBreak/>
+                                            Default value is 0.7, but single cell quantification may require lowering this value
+                                        </TextBlock>
+                                    </ToolTipService.ToolTip>
+                                </TextBox>
+                                <Label x:Name="isotopeCorrelationTextBox" Content=" isotopic envelope correlation threshold" IsEnabled="{Binding IsChecked, ElementName=CheckBoxLFQ}" />
+                            </StackPanel>
                         </StackPanel>
                     </GroupBox>
 

--- a/GUI/TaskWindows/SearchTaskWindow.xaml.cs
+++ b/GUI/TaskWindows/SearchTaskWindow.xaml.cs
@@ -243,6 +243,7 @@ namespace MetaMorpheusGUI
 
             CheckBoxQuantifyUnlabeledForSilac.IsChecked = task.CommonParameters.DigestionParams.GeneratehUnlabeledProteinsForSilac;
             PeakFindingToleranceTextBox.Text = task.SearchParameters.QuantifyPpmTol.ToString(CultureInfo.InvariantCulture);
+            IsotopeCorrelationTextBox.Text = task.SearchParameters.IsotopeCorrThreshold.ToString(CultureInfo.InvariantCulture);
             CheckBoxMatchBetweenRuns.IsChecked = task.SearchParameters.MatchBetweenRuns;
             CheckBoxNormalize.IsChecked = task.SearchParameters.Normalize;
             ModPepsAreUnique.IsChecked = task.SearchParameters.ModPeptidesAreDifferent;
@@ -413,9 +414,9 @@ namespace MetaMorpheusGUI
 
             if (!GlobalGuiSettings.CheckTaskSettingsValidity(PrecursorMassToleranceTextBox.Text, ProductMassToleranceTextBox.Text, MissedCleavagesTextBox.Text,
                 maxModificationIsoformsTextBox.Text, MinPeptideLengthTextBox.Text, MaxPeptideLengthTextBox.Text, MaxThreadsTextBox.Text, MinScoreAllowed.Text,
-                PeakFindingToleranceTextBox.Text, HistogramBinWidthTextBox.Text, DeconvolutionMaxAssumedChargeStateTextBox.Text, NumberOfPeaksToKeepPerWindowTextBox.Text,
-                MinimumAllowedIntensityRatioToBasePeakTexBox.Text, WindowWidthThomsonsTextBox.Text, NumberOfWindowsTextBox.Text, NumberOfDatabaseSearchesTextBox.Text, 
-                MaxModNumTextBox.Text, MaxFragmentMassTextBox.Text, QValueTextBox.Text, PepQValueTextBox.Text))
+                PeakFindingToleranceTextBox.Text, IsotopeCorrelationTextBox.Text, HistogramBinWidthTextBox.Text, DeconvolutionMaxAssumedChargeStateTextBox.Text,
+                NumberOfPeaksToKeepPerWindowTextBox.Text, MinimumAllowedIntensityRatioToBasePeakTexBox.Text, WindowWidthThomsonsTextBox.Text, NumberOfWindowsTextBox.Text,
+                NumberOfDatabaseSearchesTextBox.Text, MaxModNumTextBox.Text, MaxFragmentMassTextBox.Text, QValueTextBox.Text, PepQValueTextBox.Text))
             {
                 return;
             }
@@ -595,6 +596,7 @@ namespace MetaMorpheusGUI
             TheTask.SearchParameters.MatchBetweenRuns = CheckBoxMatchBetweenRuns.IsChecked.Value;
             TheTask.SearchParameters.ModPeptidesAreDifferent = ModPepsAreUnique.IsChecked.Value;
             TheTask.SearchParameters.QuantifyPpmTol = double.Parse(PeakFindingToleranceTextBox.Text, CultureInfo.InvariantCulture);
+            TheTask.SearchParameters.IsotopeCorrThreshold = double.Parse(IsotopeCorrelationTextBox.Text, CultureInfo.InvariantCulture);
             TheTask.SearchParameters.SearchTarget = CheckBoxTarget.IsChecked.Value;
             TheTask.SearchParameters.WriteMzId = CkbMzId.IsChecked.Value;
             TheTask.SearchParameters.WriteDecoys = WriteDecoyCheckBox.IsChecked.Value;

--- a/GUI/TaskWindows/XLSearchTaskWindow.xaml.cs
+++ b/GUI/TaskWindows/XLSearchTaskWindow.xaml.cs
@@ -239,7 +239,7 @@ namespace MetaMorpheusGUI
 
             if (!GlobalGuiSettings.CheckTaskSettingsValidity(XLPrecusorMsTlTextBox.Text, productMassToleranceTextBox.Text, missedCleavagesTextBox.Text,
                 maxModificationIsoformsTextBox.Text, MinPeptideLengthTextBox.Text, MaxPeptideLengthTextBox.Text, maxThreadsTextBox.Text, minScoreAllowed.Text,
-                fieldNotUsed, fieldNotUsed, fieldNotUsed, TopNPeaksTextBox.Text, MinRatioTextBox.Text, null, null, numberOfDatabaseSearchesTextBox.Text, 
+                fieldNotUsed, fieldNotUsed, fieldNotUsed, fieldNotUsed, TopNPeaksTextBox.Text, MinRatioTextBox.Text, null, null, numberOfDatabaseSearchesTextBox.Text, 
                 fieldNotUsed, fieldNotUsed, null, null))
             {
                 return;

--- a/GUI/Util/GlobalGuiSettings.cs
+++ b/GUI/Util/GlobalGuiSettings.cs
@@ -22,6 +22,7 @@ namespace MetaMorpheusGUI
             string maxThreads,
             string minScore,
             string peakFindingTolerance,
+            string isotopeCorrThreshold,
             string histogramBinWidth,
             string deconMaxAssumedCharge,
             string numberOfPeaksToKeepPerWindow,
@@ -48,6 +49,7 @@ namespace MetaMorpheusGUI
                 (CheckMaxThreads(maxThreads)),
                 (CheckMinScoreAllowed(minScore)),
                 (CheckPeakFindingTolerance(peakFindingTolerance)),
+                (CheckIsotopeCorrThreshold(isotopeCorrThreshold)),
                 (CheckHistogramBinWidth(histogramBinWidth)),
                 (CheckDeconvolutionMaxAssumedChargeState(deconMaxAssumedCharge)),
                 (CheckTopNPeaks(numberOfPeaksToKeepPerWindow)),
@@ -275,7 +277,17 @@ namespace MetaMorpheusGUI
             }
             return true;
         }
-      
+
+        public static bool CheckIsotopeCorrThreshold(string text)
+        {
+            if (!double.TryParse(text, NumberStyles.Any, CultureInfo.InvariantCulture, out double isotopeCorrThreshold) || isotopeCorrThreshold < 0 || isotopeCorrThreshold > 1)
+            {
+                MessageBox.Show("The isotope correlation threshold is invalid. \n You entered " + '"' + text + '"' + "\n Please enter a value between 0 and 1");
+                return false;
+            }
+            return true;
+        }
+
         public static bool CheckHistogramBinWidth(string text)
         {
             if (!double.TryParse(text, NumberStyles.Any, CultureInfo.InvariantCulture, out double binWidth) || binWidth < 0 || binWidth > 1)

--- a/TaskLayer/SearchTask/PostSearchAnalysisTask.cs
+++ b/TaskLayer/SearchTask/PostSearchAnalysisTask.cs
@@ -458,6 +458,7 @@ namespace TaskLayer
             }
 
             // run FlashLFQ
+            // Need to add in parameter Parameters.SearchParameters.IsotopeCorrThreshold once MzLib is updated to take this as an arguments
             var FlashLfqEngine = new FlashLfqEngine(
                 allIdentifications: flashLFQIdentifications,
                 normalize: Parameters.SearchParameters.Normalize,

--- a/TaskLayer/SearchTask/SearchParameters.cs
+++ b/TaskLayer/SearchTask/SearchParameters.cs
@@ -16,6 +16,7 @@ namespace TaskLayer
             ModPeptidesAreDifferent = false;
             DoQuantification = true;
             QuantifyPpmTol = 5;
+            IsotopeCorrThreshold = 0.7;
             SearchTarget = true;
             DecoyType = DecoyType.Reverse;
             DoHistogramAnalysis = false;
@@ -63,6 +64,7 @@ namespace TaskLayer
         public bool ModPeptidesAreDifferent { get; set; }
         public bool NoOneHitWonders { get; set; }
         public bool MatchBetweenRuns { get; set; }
+        public double IsotopeCorrThreshold { get; set; }
         public bool Normalize { get; set; }
         public double QuantifyPpmTol { get; set; }
         public bool DoHistogramAnalysis { get; set; }
@@ -93,5 +95,6 @@ namespace TaskLayer
         public SilacLabel EndTurnoverLabel { get; set; } //used for SILAC turnover experiments
         public TargetContaminantAmbiguity TCAmbiguity { get; set; }
         public bool IncludeModMotifInMzid { get; set; }
+
     }
 }


### PR DESCRIPTION
Adding a new option in the search task window to adjust the required isotope threshold in FlashLFQ. MzLib still needs to be updated to accommodate this parameter.