### PR TITLE
MetaDrawPolishing

### DIFF
--- a/EngineLayer/PsmTsv/PsmFromTsv.cs
+++ b/EngineLayer/PsmTsv/PsmFromTsv.cs
@@ -125,7 +125,9 @@ namespace EngineLayer
             Score = double.Parse(spl[parsedHeader[PsmTsvHeader.Score]].Trim(), CultureInfo.InvariantCulture);
             DecoyContamTarget = spl[parsedHeader[PsmTsvHeader.DecoyContaminantTarget]].Trim();
             QValue = double.Parse(spl[parsedHeader[PsmTsvHeader.QValue]].Trim(), CultureInfo.InvariantCulture);
-            MatchedIons = (spl[parsedHeader[PsmTsvHeader.MatchedIonMzRatios]].StartsWith("{")) ? ReadChildScanMatchedIons(spl[parsedHeader[PsmTsvHeader.MatchedIonMzRatios]].Trim(), spl[parsedHeader[PsmTsvHeader.MatchedIonIntensities]].Trim(), BaseSeq).First().Value : ReadFragmentIonsFromString(spl[parsedHeader[PsmTsvHeader.MatchedIonMzRatios]].Trim(), spl[parsedHeader[PsmTsvHeader.MatchedIonIntensities]].Trim(), BaseSeq);
+            MatchedIons = (spl[parsedHeader[PsmTsvHeader.MatchedIonMzRatios]].StartsWith("{")) ?
+                ReadChildScanMatchedIons(spl[parsedHeader[PsmTsvHeader.MatchedIonMzRatios]].Trim(), spl[parsedHeader[PsmTsvHeader.MatchedIonIntensities]].Trim(), BaseSeq).First().Value : 
+                ReadFragmentIonsFromString(spl[parsedHeader[PsmTsvHeader.MatchedIonMzRatios]].Trim(), spl[parsedHeader[PsmTsvHeader.MatchedIonIntensities]].Trim(), BaseSeq);
             AmbiguityLevel = (parsedHeader[PsmTsvHeader.AmbiguityLevel] < 0) ? null : spl[parsedHeader[PsmTsvHeader.AmbiguityLevel]].Trim();
 
             //For general psms
@@ -446,7 +448,7 @@ namespace EngineLayer
 
                         //get amino acid position
                         aminoAcidPosition = terminus == FragmentationTerminus.C ?
-                            peptideBaseSequence.Length - fragmentNumber :
+                            peptideBaseSequence.Split('|')[0].Length - fragmentNumber :
                             fragmentNumber;
                     }
 

--- a/GUI/App.xaml
+++ b/GUI/App.xaml
@@ -32,5 +32,9 @@
             <Setter Property="Background" Value="{StaticResource BackgroundColor}"/>
             <Setter Property="Margin" Value="0,0,0,0"/>
         </Style>
+
+        <Style x:Key="DataGridCenteredCellStyle" TargetType="TextBlock">
+            <Setter Property="HorizontalAlignment" Value="Center"></Setter>
+        </Style>
     </Application.Resources>
 </Application>

--- a/GUI/MetaDraw/MetaDraw.xaml
+++ b/GUI/MetaDraw/MetaDraw.xaml
@@ -226,7 +226,7 @@
                                             </Grid.ColumnDefinitions>
 
                                             <ItemsControl x:Name="PtmLegendControl" ItemsSource="{Binding}" DataContext="{x:Type guiFunctions:PtmLegendViewModel}" 
-                                                          Grid.Row="1" Grid.Column="1" Height="60" >
+                                                          Grid.Row="1" Grid.Column="1" VerticalAlignment="Bottom" Margin="0 0 0 120" >
                                                 <ItemsControl.Resources>
                                                     <ControlTemplate x:Key="PtmLegendItemTemplate" TargetType="ContentControl">
                                                         <Grid>

--- a/GUI/MetaDraw/MetaDraw.xaml
+++ b/GUI/MetaDraw/MetaDraw.xaml
@@ -88,12 +88,19 @@
 
                                     <DataGrid x:Name="dataGridScanNums" Grid.Row="0" AutoGenerateColumns="False" VerticalAlignment="Stretch" ItemsSource="{Binding}"
                                               ScrollViewer.CanContentScroll="True" IsReadOnly="True" Margin="0,0,0,0" SelectedCellsChanged="dataGridScanNums_SelectedCellsChanged" 
-                                              CanUserDeleteRows="false" CanUserAddRows="false">
+                                              CanUserDeleteRows="false" CanUserAddRows="false" >
                                         <DataGrid.Columns>
-                                            <DataGridTextColumn Header="MS2 Scan" Binding="{Binding Ms2ScanNumber}" Width="70"></DataGridTextColumn>
-                                            <DataGridTextColumn Header="Full Sequence" Binding="{Binding FullSequence}" Width="160"></DataGridTextColumn>
-                                            <DataGridTextColumn Header="Protein Name" Binding="{Binding ProteinName}" Width="100" />
+                                            <DataGridTextColumn Header="MS2 Scan" Binding="{Binding Ms2ScanNumber}" Width="70" 
+                                                                ElementStyle="{StaticResource DataGridCenteredCellStyle}" />
+                                            <DataGridTextColumn Header="Full Sequence" Binding="{Binding FullSequence}" Width="160" />
+                                            <DataGridTextColumn Header="Protein Name" Binding="{Binding ProteinName}" Width="100" 
+                                                                />
                                             <DataGridTextColumn Header="Organism Name" Binding="{Binding OrganismName}" Width="100" />
+                                            <DataGridTextColumn Header="Q-Value" Binding="{Binding QValue}" Width="60"
+                                                                ElementStyle="{StaticResource DataGridCenteredCellStyle}"/>
+                                            <DataGridTextColumn Header="PEP Value" Binding="{Binding PEP}" Width="70" />
+                                            <DataGridTextColumn Header="MetaMorpheus Score" Binding="{Binding Score}" 
+                                                                ElementStyle="{StaticResource DataGridCenteredCellStyle}"/>
                                         </DataGrid.Columns>
                                     </DataGrid>
                                 </Grid>

--- a/GUI/MetaDraw/MetaDraw.xaml
+++ b/GUI/MetaDraw/MetaDraw.xaml
@@ -189,7 +189,7 @@
 
                             <TabControl Grid.Row="1" x:Name="MetaDrawTabControl">
                                 <!--MS2 Scan Annotations-->
-                                <TabItem Header="Parent Scan View" Name="ParentScanView">
+                                <TabItem Header="Child Scan View" Name="ParentScanView">
                                     <Grid Name="PsmAnnotationGrid">
                                         <Grid.RowDefinitions>
                                             <RowDefinition/>
@@ -309,7 +309,7 @@
                                 
                                 <!--Sequence Coverage Annotation-->
                                 <TabItem Header="Sequence Coverage" x:Name="SequenceCoverageAnnotationView">
-                                    <Grid Grid.Row="1" Name="SequenceAnnotationGrid" SizeChanged="AnnotationSizeChanged" Style="{StaticResource InternalGridStyle}">
+                                    <Grid Grid.Row="1" Name="SequenceAnnotationGrid"  Style="{StaticResource InternalGridStyle}">
                                         <Grid.RowDefinitions>
                                             <RowDefinition Height = "35"></RowDefinition>
                                             <RowDefinition Height = "*"></RowDefinition>
@@ -321,7 +321,7 @@
                                         <Label Content="Sequence Coverage Map" Grid.Row="0" />
                                         
                                         <!-- sequence coverage display -->
-                                        <ScrollViewer Grid.Row="1" Name="sequenceCoverageHorizontalScroll" HorizontalAlignment="Center" VerticalAlignment="Center" 
+                                        <ScrollViewer Grid.Row="1" Name="sequenceCoverageHorizontalScroll" HorizontalAlignment="Stretch" VerticalAlignment="Center" 
                                             CanContentScroll="True" VerticalScrollBarVisibility="Disabled" HorizontalScrollBarVisibility="Auto" Width="Auto">
                                             <Grid Name="mapGrid" Background="White">
                                                 <Grid.RowDefinitions>
@@ -331,9 +331,9 @@
                                                 <!-- coverage text-->
                                                 <Canvas x:Name="sequenceText" Grid.Row="0" Background="White"></Canvas>
                                                 <!-- coverage map-->
-                                                <ScrollViewer Grid.Row="1" Name="mapViewer" HorizontalAlignment="Center" VerticalAlignment="Center" Width="Auto" 
+                                                <ScrollViewer Grid.Row="1" Name="mapViewer" HorizontalAlignment="Stretch" VerticalAlignment="Center" Width="Auto" 
                                                     CanContentScroll="True" VerticalScrollBarVisibility="Auto">
-                                                    <Canvas x:Name="map" Background="White"></Canvas>
+                                                    <Canvas x:Name="map" Background="White" HorizontalAlignment="Stretch"></Canvas>
                                                 </ScrollViewer>
                                             </Grid>
                                         </ScrollViewer>

--- a/GUI/MetaDraw/MetaDraw.xaml
+++ b/GUI/MetaDraw/MetaDraw.xaml
@@ -222,10 +222,9 @@
                                         </Grid>
 
                                         <!-- ptm legend -->
-                                        <Grid Grid.Row="0">
+                                        <Grid Grid.Row="0" x:Name="PtmLegendGrid"  >
                                             <Grid.RowDefinitions>
-                                                <RowDefinition Height="*" />
-                                                <RowDefinition Height="*" />
+                                                <RowDefinition Height="*"/>
                                             </Grid.RowDefinitions>
 
                                             <Grid.ColumnDefinitions>
@@ -233,9 +232,9 @@
                                                 <ColumnDefinition Width="165" />
                                                 <ColumnDefinition Width="8" />
                                             </Grid.ColumnDefinitions>
-
-                                            <ItemsControl x:Name="PtmLegendControl" ItemsSource="{Binding}" DataContext="{x:Type guiFunctions:PtmLegendViewModel}" 
-                                                          Grid.Row="1" Grid.Column="1" VerticalAlignment="Bottom" Margin="0 0 0 120" >
+                                            
+                                            <ItemsControl x:Name="PtmLegendControl" ItemsSource="{Binding }" 
+                                                          Grid.Column="1"  VerticalAlignment="Top" >
                                                 <ItemsControl.Resources>
                                                     <ControlTemplate x:Key="PtmLegendItemTemplate" TargetType="ContentControl">
                                                         <Grid>
@@ -245,24 +244,29 @@
                                                 </ItemsControl.Resources>
                                                 <ItemsControl.ItemTemplate>
                                                     <DataTemplate>
-                                                        <ContentControl Name="PtmLegendContentControl" Template="{StaticResource PtmLegendItemTemplate}"
-                                                                BorderBrush="Black" BorderThickness="1">
-                                                            <StackPanel Visibility="{Binding Visibility}">
-                                                                <TextBlock Text="{Binding Header}" HorizontalAlignment="Center" TextAlignment="Center" FontSize="12" FontWeight="DemiBold" />
-                                                                <ItemsControl ItemsSource="{Binding LegendItems}" >
-                                                                    <ItemsControl.ItemTemplate>
-                                                                        <DataTemplate>
-                                                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                                                                                <TextBlock Text="{Binding ModName, FallbackValue='Phosphorylation on Y'}" Margin="5 0 5 0" Width="Auto" TextAlignment="Left"
+                                                        <StackPanel>
+                                                            <!-- sets vertical offset for ptm legend -->
+                                                            <Separator Background="Transparent" Height="{Binding TopOffset}" />
+
+                                                            <ContentControl Name="PtmLegendContentControl" Template="{StaticResource PtmLegendItemTemplate}"
+                                                                            BorderBrush="Black" BorderThickness="1">
+                                                                <StackPanel Visibility="{Binding Visibility}" >
+                                                                    <TextBlock Text="{Binding Header}" HorizontalAlignment="Center" TextAlignment="Center" FontSize="12" FontWeight="DemiBold" />
+                                                                    <ItemsControl ItemsSource="{Binding LegendItems}" >
+                                                                        <ItemsControl.ItemTemplate>
+                                                                            <DataTemplate>
+                                                                                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                                                                    <TextBlock Text="{Binding ModName}" Margin="5 0 5 0" Width="Auto" TextAlignment="Left"
                                                                                             FontSize="12" FontWeight="DemiBold" HorizontalAlignment="Left"/>
-                                                                                <Ellipse Width="12" Height="12" Stroke="{Binding ColorBrush, FallbackValue={StaticResource AccentColor}}" StrokeThickness="1"
+                                                                                    <Ellipse Width="12" Height="12" Stroke="{Binding ColorBrush, FallbackValue={StaticResource AccentColor}}" StrokeThickness="1"
                                                                                             Fill="{Binding ColorBrush}" Margin="10 0 0 0" />
-                                                                            </StackPanel>
-                                                                        </DataTemplate>
-                                                                    </ItemsControl.ItemTemplate>
-                                                                </ItemsControl>
-                                                            </StackPanel>
-                                                        </ContentControl>
+                                                                                </StackPanel>
+                                                                            </DataTemplate>
+                                                                        </ItemsControl.ItemTemplate>
+                                                                    </ItemsControl>
+                                                                </StackPanel>
+                                                            </ContentControl>
+                                                        </StackPanel>
                                                     </DataTemplate>
                                                 </ItemsControl.ItemTemplate>
                                             </ItemsControl>

--- a/GUI/MetaDraw/MetaDraw.xaml
+++ b/GUI/MetaDraw/MetaDraw.xaml
@@ -91,7 +91,9 @@
                                               CanUserDeleteRows="false" CanUserAddRows="false">
                                         <DataGrid.Columns>
                                             <DataGridTextColumn Header="MS2 Scan" Binding="{Binding Ms2ScanNumber}" Width="70"></DataGridTextColumn>
-                                            <DataGridTextColumn Header="Full Sequence" Binding="{Binding FullSequence}" Width="150"></DataGridTextColumn>
+                                            <DataGridTextColumn Header="Full Sequence" Binding="{Binding FullSequence}" Width="160"></DataGridTextColumn>
+                                            <DataGridTextColumn Header="Protein Name" Binding="{Binding ProteinName}" Width="100" />
+                                            <DataGridTextColumn Header="Organism Name" Binding="{Binding OrganismName}" Width="100" />
                                         </DataGrid.Columns>
                                     </DataGrid>
                                 </Grid>

--- a/GUI/MetaDraw/MetaDraw.xaml.cs
+++ b/GUI/MetaDraw/MetaDraw.xaml.cs
@@ -236,9 +236,10 @@ namespace MetaMorpheusGUI
                 PeptideWithSetModifications peptide = new(psm.FullSequence, GlobalVariables.AllModsKnownDictionary);
                 List<Modification> mods = peptide.AllModsOneIsNterminus.Values.ToList();
                 int descriptionLineCount = MetaDrawSettings.SpectrumDescription.Count(p => p.Value);
+                descriptionLineCount += (int)Math.Floor((psm.ProteinName.Length - 20) / 26.0);
+                if (psm.ProteinAccession.Length > 10)
+                    descriptionLineCount++;
                 double verticalOffset = descriptionLineCount * 14;
-                
-                
                 
                 PtmLegend.Add(new PtmLegendViewModel(mods, verticalOffset));
             }

--- a/GUI/MetaDraw/MetaDraw.xaml.cs
+++ b/GUI/MetaDraw/MetaDraw.xaml.cs
@@ -631,7 +631,8 @@ namespace MetaMorpheusGUI
             }
 
             var plotName = selectedItem as string;
-            var fileDirectory = Directory.GetParent(MetaDrawLogic.PsmResultFilePaths.First()).ToString();
+            var fileDirectory = Path.Combine(Path.GetDirectoryName(MetaDrawLogic.PsmResultFilePaths.First()), "MetaDrawExport",
+                    DateTime.Now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
             var fileName = String.Concat(plotName, ".pdf");
 
             // update font sizes to exported PDF's size

--- a/GUI/MetaDraw/MetaDraw.xaml.cs
+++ b/GUI/MetaDraw/MetaDraw.xaml.cs
@@ -165,6 +165,7 @@ namespace MetaMorpheusGUI
         {
             if (dataGridScanNums.SelectedItem == null || sender == null)
             {
+                ClearPresentationArea();
                 return;
             }
             var strings = sender.ToString();
@@ -373,20 +374,7 @@ namespace MetaMorpheusGUI
             // if a psm is selected
             if (MetaDrawLogic.ScrollableSequence != null)
             {
-                DrawnSequence.ClearCanvas(scrollableSequenceCanvas);
-                DrawnSequence.ClearCanvas(stationarySequenceCanvas);
-                DrawnSequence.ClearCanvas(map);
-                DrawnSequence.ClearCanvas(sequenceText);
-                DrawnSequence.ClearCanvas(sequenceAnnotationCanvas);
-                plotView.Visibility = Visibility.Hidden;
-                GrayBox.Opacity = 1;
-                wholeSequenceCoverageHorizontalScroll.Visibility = Visibility.Collapsed;
-                AmbiguousSequenceOptionBox.Items.Clear();
-
-                if (PtmLegend.Count > 0)
-                    PtmLegend.First().Visibility = Visibility.Hidden;
-
-                plotView.Visibility = Visibility.Hidden;
+                ClearPresentationArea();
                 MetaDrawLogic.FilteredListOfPsms.Clear();
             }
         }
@@ -902,6 +890,27 @@ namespace MetaMorpheusGUI
             PtmLegend.First().IncreaseSegmentsPerRow();
             PsmFromTsv psm = (PsmFromTsv)dataGridScanNums.SelectedItem;
             MetaDrawLogic.DisplaySequences(null, null, sequenceAnnotationCanvas, psm);
+        }
+
+        /// <summary>
+        /// Clears and resets the presentation area
+        /// </summary>
+        public void ClearPresentationArea()
+        {
+            DrawnSequence.ClearCanvas(scrollableSequenceCanvas);
+            DrawnSequence.ClearCanvas(stationarySequenceCanvas);
+            DrawnSequence.ClearCanvas(map);
+            DrawnSequence.ClearCanvas(sequenceText);
+            DrawnSequence.ClearCanvas(sequenceAnnotationCanvas);
+            plotView.Visibility = Visibility.Hidden;
+            GrayBox.Opacity = 1;
+            wholeSequenceCoverageHorizontalScroll.Visibility = Visibility.Collapsed;
+            AmbiguousSequenceOptionBox.Items.Clear();
+
+            if (PtmLegend.Count > 0)
+                PtmLegend.First().Visibility = Visibility.Hidden;
+
+            plotView.Visibility = Visibility.Hidden;
         }
     }
 }

--- a/GUI/MetaDraw/MetaDraw.xaml.cs
+++ b/GUI/MetaDraw/MetaDraw.xaml.cs
@@ -806,6 +806,8 @@ namespace MetaMorpheusGUI
         /// </summary>
         private void SetSequenceDrawingPositionSettings(bool reset = false)
         {
+            if (dataGridScanNums.SelectedItem == null)
+                return;
             double width = SequenceAnnotationArea.ActualWidth;
             double offset = wholeSequenceCoverageHorizontalScroll.HorizontalOffset;
             if (reset)

--- a/GUI/MetaDraw/MetaDraw.xaml.cs
+++ b/GUI/MetaDraw/MetaDraw.xaml.cs
@@ -373,8 +373,19 @@ namespace MetaMorpheusGUI
             // if a psm is selected
             if (MetaDrawLogic.ScrollableSequence != null)
             {
-                DrawnSequence.ClearCanvas(MetaDrawLogic.ScrollableSequence.SequenceDrawingCanvas);
-                DrawnSequence.ClearCanvas(MetaDrawLogic.StationarySequence.SequenceDrawingCanvas);
+                DrawnSequence.ClearCanvas(scrollableSequenceCanvas);
+                DrawnSequence.ClearCanvas(stationarySequenceCanvas);
+                DrawnSequence.ClearCanvas(map);
+                DrawnSequence.ClearCanvas(sequenceText);
+                DrawnSequence.ClearCanvas(sequenceAnnotationCanvas);
+                plotView.Visibility = Visibility.Hidden;
+                GrayBox.Opacity = 1;
+                wholeSequenceCoverageHorizontalScroll.Visibility = Visibility.Collapsed;
+                AmbiguousSequenceOptionBox.Items.Clear();
+
+                if (PtmLegend.Count > 0)
+                    PtmLegend.First().Visibility = Visibility.Hidden;
+
                 plotView.Visibility = Visibility.Hidden;
                 MetaDrawLogic.FilteredListOfPsms.Clear();
             }
@@ -604,7 +615,7 @@ namespace MetaMorpheusGUI
         }
 
         /// <summary>
-        /// I believe this one is never used
+        /// Export for Data Visualization tab
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>

--- a/GUI/MetaDraw/MetaDraw.xaml.cs
+++ b/GUI/MetaDraw/MetaDraw.xaml.cs
@@ -181,21 +181,10 @@ namespace MetaMorpheusGUI
             if (psm.FullSequence.Contains('|') && sender.ToString() != "System.Object")
             {
                 // clear all drawings of the previous non-ambiguous psm
-                MetaDrawSettings.DrawMatchedIons = false;
-                DrawnSequence.ClearCanvas(scrollableSequenceCanvas);
-                DrawnSequence.ClearCanvas(stationarySequenceCanvas);
-                DrawnSequence.ClearCanvas(map);
-                DrawnSequence.ClearCanvas(sequenceText);
-                DrawnSequence.ClearCanvas(sequenceAnnotationCanvas);
-                plotView.Visibility = Visibility.Hidden;
-                GrayBox.Opacity = 0;
+                ClearPresentationArea();
+
                 AmbiguousWarningTextBlocks.Visibility = Visibility.Visible;
                 AmbiguousSequenceOptionBox.Visibility = Visibility.Visible;
-                wholeSequenceCoverageHorizontalScroll.Visibility = Visibility.Collapsed;
-                AmbiguousSequenceOptionBox.Items.Clear();
-
-                if (PtmLegend.Count > 0)
-                    PtmLegend.First().Visibility = Visibility.Hidden;
 
                 // create a psm object for each ambiguous option and add it to the dropdown box
                 var fullSeqs = psm.FullSequence.Split('|');
@@ -769,8 +758,11 @@ namespace MetaMorpheusGUI
                 }
             }
             SetSequenceDrawingPositionSettings();
-            if (MetaDrawLogic.StationarySequence != null)
+            if (MetaDrawLogic.StationarySequence != null && !psm.FullSequence.Contains('|'))
+            {
                 DrawnSequence.DrawStationarySequence(psm, MetaDrawLogic.StationarySequence, 10);
+            }
+                
         }
 
         /// <summary>

--- a/GUI/MetaDraw/MetaDraw.xaml.cs
+++ b/GUI/MetaDraw/MetaDraw.xaml.cs
@@ -34,7 +34,7 @@ namespace MetaMorpheusGUI
         private readonly DataTable propertyView;
         private ObservableCollection<string> plotTypes;
         private ObservableCollection<string> PsmStatPlotFiles;
-        private ObservableCollection<PtmLegendViewModel> PtmLegend;
+        public ObservableCollection<PtmLegendViewModel> PtmLegend;
         private ObservableCollection<ModTypeForTreeViewModel> Modifications = new ObservableCollection<ModTypeForTreeViewModel>();
         private static List<string> AcceptedSpectraFormats = new List<string> { ".mzml", ".raw", ".mgf" };
         private static List<string> AcceptedResultsFormats = new List<string> { ".psmtsv", ".tsv" };
@@ -220,14 +220,6 @@ namespace MetaMorpheusGUI
             // display the ion and elements correctly
             MetaDrawSettings.DrawMatchedIons = true;
 
-            // add ptm legend if desired
-            PtmLegend.Clear();
-            if (MetaDrawSettings.ShowLegend)
-            {
-                PeptideWithSetModifications peptide = new(psm.FullSequence, GlobalVariables.AllModsKnownDictionary);
-                List<Modification> mods = peptide.AllModsOneIsNterminus.Values.ToList();
-                PtmLegend.Add(new PtmLegendViewModel(mods));                    
-            }
 
             // define initial limits for sequence annotation
             double maxDisplayedPerRow = (int)Math.Round((SequenceAnnotationArea.ActualWidth - 10) / MetaDrawSettings.AnnotatedSequenceTextSpacing, 0) + 7;
@@ -236,6 +228,20 @@ namespace MetaMorpheusGUI
             // draw the annotated spectrum
             MetaDrawLogic.DisplaySequences(stationarySequenceCanvas, scrollableSequenceCanvas, sequenceAnnotationCanvas, psm);
             MetaDrawLogic.DisplaySpectrumMatch(plotView, psm, itemsControlSampleViewModel, out var errors);
+
+            // add ptm legend if desired
+            PtmLegend.Clear();
+            if (MetaDrawSettings.ShowLegend)
+            {
+                PeptideWithSetModifications peptide = new(psm.FullSequence, GlobalVariables.AllModsKnownDictionary);
+                List<Modification> mods = peptide.AllModsOneIsNterminus.Values.ToList();
+                int descriptionLineCount = MetaDrawSettings.SpectrumDescription.Count(p => p.Value);
+                double verticalOffset = descriptionLineCount * 14;
+                
+                
+                
+                PtmLegend.Add(new PtmLegendViewModel(mods, verticalOffset));
+            }
 
             //draw the sequence coverage if not crosslinked
             if (psm.ChildScanMatchedIons == null)

--- a/GUI/MetaDraw/MetaDraw.xaml.cs
+++ b/GUI/MetaDraw/MetaDraw.xaml.cs
@@ -18,6 +18,8 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
 
 namespace MetaMorpheusGUI
 {
@@ -386,7 +388,6 @@ namespace MetaMorpheusGUI
 
         private void settings_Click(object sender, RoutedEventArgs e)
         {
-            
             // save current selected PSM
             var selectedItem = dataGridScanNums.SelectedItem;
             var settingsWindow = new MetaDrawSettingsWindow(SettingsView);
@@ -509,8 +510,7 @@ namespace MetaMorpheusGUI
             string directoryPath = Path.Combine(Path.GetDirectoryName(MetaDrawLogic.PsmResultFilePaths.First()), "MetaDrawExport",
                     DateTime.Now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
 
-
-            MetaDrawLogic.ExportPlot(plotView, stationarySequenceCanvas, items, itemsControlSampleViewModel, directoryPath, out var errors);
+            MetaDrawLogic.ExportPlot(plotView, stationarySequenceCanvas, items, itemsControlSampleViewModel, directoryPath, out var errors, PtmLegendControl);
             if (errors.Any())
             {
                 MessageBox.Show(errors.First());
@@ -519,7 +519,6 @@ namespace MetaMorpheusGUI
             {
                 MessageBox.Show(MetaDrawSettings.ExportType + "(s) exported to: " + directoryPath);
             }
-
         }
 
         private void SequenceCoverageExportButton_Click(object sender, RoutedEventArgs e)
@@ -533,7 +532,6 @@ namespace MetaMorpheusGUI
             string directoryPath = Path.Combine(Path.GetDirectoryName(MetaDrawLogic.PsmResultFilePaths.First()), "MetaDrawExport",
                     DateTime.Now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
             PsmFromTsv psm = (PsmFromTsv)dataGridScanNums.SelectedItem;
-            int scanNumber = ((PsmFromTsv)dataGridScanNums.SelectedItem).Ms2ScanNumber;
             MetaDrawLogic.ExportSequenceCoverage(sequenceText, map, directoryPath, psm);
             
             if (Directory.Exists(directoryPath))
@@ -724,12 +722,6 @@ namespace MetaMorpheusGUI
                     plot.Model.DefaultXAxis.FontSize = plot.Model.DefaultFontSize;
                 }
             }
-        }
-
-        private void AnnotationSizeChanged(object sender, SizeChangedEventArgs e)
-        {
-            mapViewer.Height = .8 * SequenceAnnotationGrid.ActualHeight;
-            mapViewer.Width = .99 * SequenceAnnotationGrid.ActualWidth;
         }
 
         /// <summary>

--- a/GUI/MetaDraw/MetaDrawSettingsWindow.xaml
+++ b/GUI/MetaDraw/MetaDrawSettingsWindow.xaml
@@ -36,6 +36,8 @@
                     <CheckBox Name="BoldTextCheckBox" Content="Bold text" Margin="5"/>
                     <CheckBox Name="DecoysCheckBox" Content="Show decoys" Margin="5" />
                     <CheckBox Name="ContaminantsCheckBox" Content="Show contaminants" Margin="5" />
+                    <CheckBox Name="ShowInternalIonsCheckBox" Content="Show internal ions" Margin="5" />
+                    <CheckBox Name="ShowInternalIonAnnotationsCheckBox" Content="Display internal ion annotations" Margin="5" />
 
                     <StackPanel Orientation="Horizontal" Margin="5">
                         <Label Content="Filter to q-value:" Width="140"/>
@@ -58,7 +60,7 @@
                     <!-- glycan localization level -->
                     <StackPanel Orientation="Vertical">
                         <Label Content="Glycan Localization Level:" Margin="5" HorizontalAlignment="Center"/>
-                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="20 5 20 0">
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="20 0 20 0">
                             <ComboBox Name="CmbGlycanLocalizationLevelStart" Height="24"  />
                             <ComboBox Name="CmbGlycanLocalizationLevelEnd" Height="24" />
                         </StackPanel>
@@ -68,7 +70,7 @@
                     <StackPanel>
                         <Label Content="Export File Type" Margin="5" HorizontalAlignment="Center" />
                         <ComboBox x:Name="ExportFileFormatComboBox" Height="24" HorizontalAlignment="Center" 
-                                  HorizontalContentAlignment="Center" Margin="20 0 20 0" 
+                                  HorizontalContentAlignment="Center" Margin="20 0 20 5" 
                                   ItemsSource="{Binding}"/>
                     </StackPanel>
                 </StackPanel>

--- a/GUI/MetaDraw/MetaDrawSettingsWindow.xaml
+++ b/GUI/MetaDraw/MetaDrawSettingsWindow.xaml
@@ -38,13 +38,21 @@
                     <CheckBox Name="ContaminantsCheckBox" Content="Show contaminants" Margin="5" />
 
                     <StackPanel Orientation="Horizontal" Margin="5">
-                        <Label Content="Filter to q-value:" Width="120"/>
-                        <TextBox Name ="qValueBox" Width="60" Height="24" Grid.Column="1"/>
+                        <Label Content="Filter to q-value:" Width="140"/>
+                        <TextBox Name ="qValueBox" Width="80" Height="24" Grid.Column="1"
+                                 VerticalContentAlignment="Center" HorizontalContentAlignment="Center"/>
                     </StackPanel>
 
                     <StackPanel Orientation="Horizontal" Margin="5">
-                        <Label Content="Text size:" Width="120"/>
-                        <TextBox Name ="TextSizeBox" Width="60" Height="24" />
+                        <Label Content="Filter to ambiguity level: " Width="140" />
+                        <ComboBox x:Name="AmbiguityFilteringComboBox" Width="80" ItemsSource="{Binding}"
+                                  VerticalContentAlignment="Center" HorizontalContentAlignment="Center"/>
+                    </StackPanel>
+
+                    <StackPanel Orientation="Horizontal" Margin="5">
+                        <Label Content="Text size:" Width="140"/>
+                        <TextBox Name ="TextSizeBox" Width="80" Height="24" 
+                                 VerticalContentAlignment="Center" HorizontalContentAlignment="Center" />
                     </StackPanel>
 
                     <!-- glycan localization level -->

--- a/GUI/MetaDraw/MetaDrawSettingsWindow.xaml
+++ b/GUI/MetaDraw/MetaDrawSettingsWindow.xaml
@@ -131,10 +131,10 @@
                                                         <ItemsControl.ItemTemplate>
                                                             <DataTemplate>
                                                                 <StackPanel Orientation="Horizontal"  >
-                                                                    <TextBlock Text="{Binding IonName, FallbackValue='y - ion'}" Margin="5 0 5 0" Width="80" TextAlignment="Center"/>
+                                                                    <TextBlock Text="{Binding IonName, FallbackValue='y - ion'}" Margin="5 0 5 0" Width="120" TextAlignment="Center"/>
                                                                     <Ellipse Width="12" Height="12" Stroke="{Binding ColorBrush, FallbackValue={StaticResource AccentColor}}" StrokeThickness="1"
                                                                             Fill="{Binding ColorBrush}" Margin="0 5 0 5" />
-                                                                    <ComboBox Width="80" HorizontalAlignment="Right" Margin="5 0 5 0" HorizontalContentAlignment="Center"
+                                                                    <ComboBox Width="100" HorizontalAlignment="Right" Margin="5 0 5 0" HorizontalContentAlignment="Center"
                                                                               SelectedItem="{Binding SelectedColor}" SelectionChanged="ComboBox_SelectionChanged"
                                                                               ItemsSource="{Binding Path=DataContext.PossibleColors, 
                                                                                             RelativeSource={RelativeSource Mode=FindAncestor, 

--- a/GUI/MetaDraw/MetaDrawSettingsWindow.xaml
+++ b/GUI/MetaDraw/MetaDrawSettingsWindow.xaml
@@ -60,7 +60,7 @@
                     <StackPanel>
                         <Label Content="Export File Type" Margin="5" HorizontalAlignment="Center" />
                         <ComboBox x:Name="ExportFileFormatComboBox" Height="24" HorizontalAlignment="Center" 
-                                  HorizontalContentAlignment="Center" Margin="20 5 20 0" 
+                                  HorizontalContentAlignment="Center" Margin="20 0 20 0" 
                                   ItemsSource="{Binding}"/>
                     </StackPanel>
                 </StackPanel>
@@ -221,10 +221,12 @@
                 <Button x:Name="setDefaultbutton" Content ="Save As Default" Click="setDefaultbutton_Click" 
                         FontSize="15" Width="120" Margin="5" >
                     <ToolTipService.ToolTip>
-                        <ToolTip Content="Save these parameters as the default. MetaMorpheus can return to original defaults by deleting the folder 'DefaultParameters'" 
+                        <ToolTip Content="Save these parameters as the default" 
                                  ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500" />
                     </ToolTipService.ToolTip>
                 </Button>
+                <Button x:Name="RestoreDefaultButton" Content="Restore Defaults" Click="RestoreDefaultButton_Click" 
+                        FontSize="15" Width="120" Margin="5" />
             </StackPanel>
         </Grid>
     </Grid>

--- a/GUI/MetaDraw/MetaDrawSettingsWindow.xaml.cs
+++ b/GUI/MetaDraw/MetaDrawSettingsWindow.xaml.cs
@@ -189,5 +189,21 @@ namespace MetaMorpheusGUI
         {
             ((CoverageTypeForTreeViewModel)((ComboBox)sender).DataContext).SelectionChanged((string)((ComboBox)sender).SelectedItem);
         }
+
+        private void RestoreDefaultButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (MessageBox.Show("Reset to default values?", "", MessageBoxButton.YesNo, MessageBoxImage.Warning) == MessageBoxResult.Yes)
+            {
+                if (File.Exists(SettingsViewModel.SettingsPath))
+                    File.Delete(SettingsViewModel.SettingsPath);
+                MetaDrawSettings.ResetSettings();
+                SettingsViewModel settingsViewModel = new SettingsViewModel();
+                SettingsView = settingsViewModel;
+                DataContext = SettingsView;
+                PopulateChoices();
+                DialogResult = true;
+            }
+            
+        }
     }
 }

--- a/GUI/MetaDraw/MetaDrawSettingsWindow.xaml.cs
+++ b/GUI/MetaDraw/MetaDrawSettingsWindow.xaml.cs
@@ -66,6 +66,8 @@ namespace MetaMorpheusGUI
             SequencenNumbersCheckBox.IsChecked = MetaDrawSettings.DrawNumbersUnderStationary;
             ShowLegendCheckBox.IsChecked = MetaDrawSettings.ShowLegend;
             qValueBox.Text = MetaDrawSettings.QValueFilter.ToString();
+            AmbiguityFilteringComboBox.DataContext = MetaDrawSettings.AmbiguityTypes;
+            AmbiguityFilteringComboBox.SelectedItem = MetaDrawSettings.AmbiguityFilter;
             TextSizeBox.Text = MetaDrawSettings.AnnotatedFontSize.ToString();
             CmbGlycanLocalizationLevelStart.SelectedItem = MetaDrawSettings.LocalizationLevelStart.ToString();
             CmbGlycanLocalizationLevelEnd.SelectedItem = MetaDrawSettings.LocalizationLevelEnd.ToString();
@@ -109,6 +111,7 @@ namespace MetaMorpheusGUI
             MetaDrawSettings.LocalizationLevelStart = (LocalizationLevel)System.Enum.Parse(typeof(LocalizationLevel), CmbGlycanLocalizationLevelStart.SelectedItem.ToString());
             MetaDrawSettings.LocalizationLevelEnd = (LocalizationLevel)System.Enum.Parse(typeof(LocalizationLevel), CmbGlycanLocalizationLevelEnd.SelectedItem.ToString());
             MetaDrawSettings.ExportType = ExportFileFormatComboBox.SelectedItem.ToString();
+            MetaDrawSettings.AmbiguityFilter = AmbiguityFilteringComboBox.SelectedItem.ToString();
             SettingsView.Save();
 
             if (!string.IsNullOrWhiteSpace(qValueBox.Text))

--- a/GUI/MetaDraw/MetaDrawSettingsWindow.xaml.cs
+++ b/GUI/MetaDraw/MetaDrawSettingsWindow.xaml.cs
@@ -49,7 +49,9 @@ namespace MetaMorpheusGUI
             BoldTextCheckBox.IsChecked = MetaDrawSettings.AnnotationBold;
             DecoysCheckBox.IsChecked = MetaDrawSettings.ShowDecoys;
             ContaminantsCheckBox.IsChecked = MetaDrawSettings.ShowContaminants;
+            ShowInternalIonAnnotationsCheckBox.IsChecked = MetaDrawSettings.DisplayInternalIonAnnotations;
             PrecursorChargeCheckBox.IsChecked = MetaDrawSettings.SpectrumDescription["Precursor Charge: "];
+            ShowInternalIonsCheckBox.IsChecked = MetaDrawSettings.InternalIonColor != OxyColors.Transparent;
             PrecursorMassCheckBox.IsChecked = MetaDrawSettings.SpectrumDescription["Precursor Mass: "];
             TheoreticalMassCheckBox.IsChecked = MetaDrawSettings.SpectrumDescription["Theoretical Mass: "];
             ScoreCheckBox.IsChecked = MetaDrawSettings.SpectrumDescription["Score: "];
@@ -92,6 +94,7 @@ namespace MetaMorpheusGUI
             MetaDrawSettings.AnnotationBold = BoldTextCheckBox.IsChecked.Value;
             MetaDrawSettings.ShowDecoys = BoldTextCheckBox.IsChecked.Value;
             MetaDrawSettings.ShowContaminants = BoldTextCheckBox.IsChecked.Value;
+            MetaDrawSettings.DisplayInternalIonAnnotations = ShowInternalIonAnnotationsCheckBox.IsChecked.Value;
             MetaDrawSettings.SpectrumDescription["Precursor Charge: "] = PrecursorChargeCheckBox.IsChecked.Value;
             MetaDrawSettings.SpectrumDescription["Precursor Mass: "] = PrecursorMassCheckBox.IsChecked.Value;
             MetaDrawSettings.SpectrumDescription["Theoretical Mass: "] = TheoreticalMassCheckBox.IsChecked.Value;
@@ -112,6 +115,8 @@ namespace MetaMorpheusGUI
             MetaDrawSettings.LocalizationLevelEnd = (LocalizationLevel)System.Enum.Parse(typeof(LocalizationLevel), CmbGlycanLocalizationLevelEnd.SelectedItem.ToString());
             MetaDrawSettings.ExportType = ExportFileFormatComboBox.SelectedItem.ToString();
             MetaDrawSettings.AmbiguityFilter = AmbiguityFilteringComboBox.SelectedItem.ToString();
+            if (!ShowInternalIonsCheckBox.IsChecked.Value)
+                MetaDrawSettings.InternalIonColor = OxyColors.Transparent;
             SettingsView.Save();
 
             if (!string.IsNullOrWhiteSpace(qValueBox.Text))

--- a/GUI/MetaDraw/MetaDrawSettingsWindow.xaml.cs
+++ b/GUI/MetaDraw/MetaDrawSettingsWindow.xaml.cs
@@ -190,6 +190,11 @@ namespace MetaMorpheusGUI
             ((CoverageTypeForTreeViewModel)((ComboBox)sender).DataContext).SelectionChanged((string)((ComboBox)sender).SelectedItem);
         }
 
+        /// <summary>
+        /// Event handler for when the button to restore default settings is clicked
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void RestoreDefaultButton_Click(object sender, RoutedEventArgs e)
         {
             if (MessageBox.Show("Reset to default values?", "", MessageBoxButton.YesNo, MessageBoxImage.Warning) == MessageBoxResult.Yes)
@@ -203,7 +208,6 @@ namespace MetaMorpheusGUI
                 PopulateChoices();
                 DialogResult = true;
             }
-            
         }
     }
 }

--- a/GUI/MetaDraw/MetaDrawSettingsWindow.xaml.cs
+++ b/GUI/MetaDraw/MetaDrawSettingsWindow.xaml.cs
@@ -158,7 +158,6 @@ namespace MetaMorpheusGUI
         {
             Save_Click(sender, e);
             SettingsView.SaveAsDefault();
-            
         }
 
         /// <summary>

--- a/GuiFunctions/GuiFunctions.csproj
+++ b/GuiFunctions/GuiFunctions.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="itext7" Version="7.1.13" />
     <PackageReference Include="mzLib" Version="1.0.528" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.0.0" />
-    <PackageReference Include="Svg" Version="3.4.2" />
+    <PackageReference Include="Svg" Version="3.4.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/GuiFunctions/MetaDraw/DrawnSequence.cs
+++ b/GuiFunctions/MetaDraw/DrawnSequence.cs
@@ -300,11 +300,17 @@ namespace GuiFunctions
                 string fullSequence = baseSequence;
                 foreach (var mod in modDictionary)
                 {
-                    // if modification is within the visible region
-                    if (mod.Key - 1 > i && mod.Key - 1 <= i + residuesPerSegment)
+                    // if first chunk in the row
+                    if (i % segmentsPerRow == 0 && mod.Key - 1 >= i && mod.Key - 1 <= i + residuesPerSegment)
                     {
                         fullSequence = fullSequence.Insert(mod.Key - i - 1, "[" + mod.Value.ModificationType + ":" + mod.Value.IdWithMotif + "]");
                     }
+                    else if (mod.Key - 1 > i && mod.Key - 1 <= i + residuesPerSegment)
+                    {
+                        fullSequence = fullSequence.Insert(mod.Key - i - 1, "[" + mod.Value.ModificationType + ":" + mod.Value.IdWithMotif + "]");
+                    }
+
+                    
                 }
                 PsmFromTsv tempPsm = new(psm, fullSequence, baseSequence: baseSequence);
                 segments.Add(tempPsm);

--- a/GuiFunctions/MetaDraw/MetaDrawLogic.cs
+++ b/GuiFunctions/MetaDraw/MetaDrawLogic.cs
@@ -575,7 +575,7 @@ namespace GuiFunctions
             List<System.Drawing.Bitmap> toCombine = new List<System.Drawing.Bitmap>() { annotationBitmap, ptmLegendBitmap };
             List<Point> points = new List<Point>() { annotationPoint, ptmLegendPoint };
             System.Drawing.Bitmap combinedBitmap = CombineBitmap(toCombine, points, false);
-            System.Drawing.Bitmap finalBitmap = combinedBitmap.Clone(new System.Drawing.Rectangle(0, 0, combinedBitmap.Width - 150, combinedBitmap.Height), combinedBitmap.PixelFormat);
+            System.Drawing.Bitmap finalBitmap = combinedBitmap.Clone(new System.Drawing.Rectangle(0, 0, combinedBitmap.Width - 140, combinedBitmap.Height), combinedBitmap.PixelFormat);
             ExportBitmap(finalBitmap, path);
             combinedBitmap.Dispose();
             finalBitmap.Dispose();
@@ -852,6 +852,22 @@ namespace GuiFunctions
 
                 case "Bmp":
                     bitmap.Save(path, System.Drawing.Imaging.ImageFormat.Bmp);
+                    break;
+
+                case "Svg":
+                    tempImagePath = path.Replace(".Pdf", ".png");
+                    bitmap.Save(tempImagePath, System.Drawing.Imaging.ImageFormat.Png);
+                    imageData = ImageDataFactory.Create(tempImagePath);
+                    File.Delete(tempImagePath);
+                    pdfImage = new(imageData);
+
+                    pdfDocument = new(new PdfWriter(path));
+                    document = new(pdfDocument);
+                    document.Add(pdfImage);
+                     
+                    pdfDocument.Close();
+                    document.Close();
+
                     break;
             }
         }

--- a/GuiFunctions/MetaDraw/MetaDrawLogic.cs
+++ b/GuiFunctions/MetaDraw/MetaDrawLogic.cs
@@ -453,7 +453,9 @@ namespace GuiFunctions
             Canvas.SetZIndex(line, 1); //on top of any other things in canvas
         }
 
-        public void ExportPlot(PlotView plotView, Canvas stationaryCanvas, List<PsmFromTsv> spectrumMatches, ParentChildScanPlotsView parentChildScanPlotsView, string directory, out List<string> errors, ItemsControl ptmLegend = null)
+        public void ExportPlot(PlotView plotView, Canvas stationaryCanvas, List<PsmFromTsv> spectrumMatches,
+            ParentChildScanPlotsView parentChildScanPlotsView, string directory, out List<string> errors,
+            Canvas ptmLegend = null, Vector ptmLegendLocationVector = new())
         {
             errors = new List<string>();
 
@@ -496,7 +498,7 @@ namespace GuiFunctions
                         filePath = System.IO.Path.Combine(directory, plot.Scan.OneBasedScanNumber + "_" + sequence + "_" + i + "." + MetaDrawSettings.ExportType);
                         i++;
                     }
-                    plot.ExportPlot(filePath, StationarySequence.SequenceDrawingCanvas, ptmLegend, plotView.ActualWidth, plotView.ActualHeight);
+                    plot.ExportPlot(filePath, StationarySequence.SequenceDrawingCanvas, ptmLegend, ptmLegendLocationVector, plotView.ActualWidth, plotView.ActualHeight);
                 }
             }
 

--- a/GuiFunctions/MetaDraw/MetaDrawLogic.cs
+++ b/GuiFunctions/MetaDraw/MetaDrawLogic.cs
@@ -672,7 +672,8 @@ namespace GuiFunctions
                 PeptideSpectralMatchesView.Filter = obj =>
                 {
                     PsmFromTsv psm = obj as PsmFromTsv;
-                    return ((psm.Ms2ScanNumber.ToString()).StartsWith(searchString) || psm.FullSequence.ToUpper().Contains(searchString.ToUpper()));
+                    return ((psm.Ms2ScanNumber.ToString()).StartsWith(searchString) || psm.FullSequence.ToUpper().Contains(searchString.ToUpper()) 
+                    || psm.ProteinName.Contains(searchString) || psm.OrganismName.Contains(searchString));
                 };
             }
         }

--- a/GuiFunctions/MetaDraw/MetaDrawLogic.cs
+++ b/GuiFunctions/MetaDraw/MetaDrawLogic.cs
@@ -453,7 +453,7 @@ namespace GuiFunctions
             Canvas.SetZIndex(line, 1); //on top of any other things in canvas
         }
 
-        public void ExportPlot(PlotView plotView, Canvas stationaryCanvas, List<PsmFromTsv> spectrumMatches, ParentChildScanPlotsView parentChildScanPlotsView, string directory, out List<string> errors)
+        public void ExportPlot(PlotView plotView, Canvas stationaryCanvas, List<PsmFromTsv> spectrumMatches, ParentChildScanPlotsView parentChildScanPlotsView, string directory, out List<string> errors, ItemsControl ptmLegend = null)
         {
             errors = new List<string>();
 
@@ -496,7 +496,7 @@ namespace GuiFunctions
                         filePath = System.IO.Path.Combine(directory, plot.Scan.OneBasedScanNumber + "_" + sequence + "_" + i + "." + MetaDrawSettings.ExportType);
                         i++;
                     }
-                    plot.ExportPlot(filePath, StationarySequence.SequenceDrawingCanvas, plotView.ActualWidth, plotView.ActualHeight);
+                    plot.ExportPlot(filePath, StationarySequence.SequenceDrawingCanvas, ptmLegend, plotView.ActualWidth, plotView.ActualHeight);
                 }
             }
 
@@ -531,7 +531,7 @@ namespace GuiFunctions
             System.Drawing.Bitmap textBitmap = ConvertCanvasToBitmap(textCanvas, directory);
             Point textPoint = new(0, 0);
             System.Drawing.Bitmap mapBitmap = ConvertCanvasToBitmap(mapCanvas, directory);
-            Point mapPoint = new(0, textCanvas.ActualHeight - 25);
+            Point mapPoint = new(0, textCanvas.ActualHeight );
 
             List<System.Drawing.Bitmap> toCombine = new List<System.Drawing.Bitmap>() { textBitmap, mapBitmap };
             List<Point> points = new List<Point>() { textPoint, mapPoint };
@@ -582,7 +582,7 @@ namespace GuiFunctions
         }
 
         /// <summary>
-        /// Used to combine two bitmap objects
+        /// Used to combine multiple bitmap objects
         /// </summary>
         /// <param name="images">list of objects to combine</param>
         /// <param name="points">the position to begin drawing each</param>
@@ -821,9 +821,10 @@ namespace GuiFunctions
             switch (MetaDrawSettings.ExportType)
             {
                 case "Pdf":
-                    bitmap.Save(path, System.Drawing.Imaging.ImageFormat.Png);
-                    ImageData imageData = ImageDataFactory.Create(path);
-                    File.Delete(path);
+                    string tempImagePath = path.Replace(".Pdf", ".png");
+                    bitmap.Save(tempImagePath, System.Drawing.Imaging.ImageFormat.Png);
+                    ImageData imageData = ImageDataFactory.Create(tempImagePath);
+                    File.Delete(tempImagePath);
                     iText.Layout.Element.Image pdfImage = new(imageData);
 
                     PdfDocument pdfDocument = new(new PdfWriter(path));

--- a/GuiFunctions/MetaDraw/MetaDrawLogic.cs
+++ b/GuiFunctions/MetaDraw/MetaDrawLogic.cs
@@ -853,22 +853,6 @@ namespace GuiFunctions
                 case "Bmp":
                     bitmap.Save(path, System.Drawing.Imaging.ImageFormat.Bmp);
                     break;
-
-                case "Svg":
-                    tempImagePath = path.Replace(".Pdf", ".png");
-                    bitmap.Save(tempImagePath, System.Drawing.Imaging.ImageFormat.Png);
-                    imageData = ImageDataFactory.Create(tempImagePath);
-                    File.Delete(tempImagePath);
-                    pdfImage = new(imageData);
-
-                    pdfDocument = new(new PdfWriter(path));
-                    document = new(pdfDocument);
-                    document.Add(pdfImage);
-                     
-                    pdfDocument.Close();
-                    document.Close();
-
-                    break;
             }
         }
 

--- a/GuiFunctions/MetaDraw/MetaDrawSettings.cs
+++ b/GuiFunctions/MetaDraw/MetaDrawSettings.cs
@@ -24,6 +24,7 @@ namespace GuiFunctions
         public static bool AnnotateMzValues { get; set; } = false;
         public static bool AnnotateCharges { get; set; } = false;
         public static bool AnnotationBold { get; set; } = false;
+        public static bool DisplayInternalIonAnnotations { get; set; }= true;
         public static Dictionary<OxyColor, string> PossibleColors { get; set; }
         public static Dictionary<ProductType, OxyColor> ProductTypeToColor { get; set; }
         public static Dictionary<ProductType, OxyColor> BetaProductTypeToColor { get; set; }
@@ -177,8 +178,8 @@ namespace GuiFunctions
                         ModificationTypeToColor[mod] = OxyColors.Maroon;
                     }
 
-                // setting individual specific
-                foreach (var mod in ModificationTypeToColor.Where(p => p.Key.Contains("Phosphorylation")))
+                    // setting individual specific
+                    foreach (var mod in ModificationTypeToColor.Where(p => p.Key.Contains("Phosphorylation")))
                     {
                         ModificationTypeToColor[mod.Key] = OxyColors.Red;
                     }
@@ -195,6 +196,9 @@ namespace GuiFunctions
                     CoverageTypeToColor = CoverageTypes.ToDictionary(p => p, p => OxyColors.Blue);
                     CoverageTypeToColor["C-Terminal Color"] = OxyColors.Red;
                     CoverageTypeToColor["Internal Color"] = OxyColors.Purple;
+
+                    UnannotatedPeakColor = OxyColors.LightGray;
+                    InternalIonColor = OxyColors.Purple;
 
                 #endregion
 
@@ -228,6 +232,7 @@ namespace GuiFunctions
                 AnnotationBold = AnnotationBold,
                 ShowDecoys = ShowDecoys,
                 ShowContaminants = ShowContaminants,
+                DisplayInternalIonAnnotations = DisplayInternalIonAnnotations,
                 QValueFilter = QValueFilter,
                 AmbiguityFilter = AmbiguityFilter,
                 DrawStationarySequence = DrawStationarySequence,
@@ -257,6 +262,7 @@ namespace GuiFunctions
             AnnotationBold = settings.AnnotationBold;
             ShowDecoys = settings.ShowDecoys;
             ShowContaminants = settings.ShowContaminants;
+            DisplayInternalIonAnnotations = settings.DisplayInternalIonAnnotations;
             QValueFilter = settings.QValueFilter;
             AmbiguityFilter = settings.AmbiguityFilter;
             DrawStationarySequence = settings.DrawStationarySequence;

--- a/GuiFunctions/MetaDraw/MetaDrawSettings.cs
+++ b/GuiFunctions/MetaDraw/MetaDrawSettings.cs
@@ -230,6 +230,7 @@ namespace GuiFunctions
                 ShowDecoys = ShowDecoys,
                 ShowContaminants = ShowContaminants,
                 QValueFilter = QValueFilter,
+                AmbiguityFilter = AmbiguityFilter,
                 DrawStationarySequence = DrawStationarySequence,
                 DrawNumbersUnderStationary = DrawNumbersUnderStationary,
                 ShowLegend = ShowLegend,
@@ -242,7 +243,7 @@ namespace GuiFunctions
                 CoverageTypeToColorValues = CoverageTypeToColor.Values.Select(p => p.GetColorName()).ToList(),
                 SpectrumDescriptionValues = SpectrumDescription.Values.ToList(),
                 UnannotatedPeakColor = UnannotatedPeakColor,
-                InternalIonColor = InternalIonColor ,
+                InternalIonColor = InternalIonColor,
             };
         }
 
@@ -258,6 +259,7 @@ namespace GuiFunctions
             ShowDecoys = settings.ShowDecoys;
             ShowContaminants = settings.ShowContaminants;
             QValueFilter = settings.QValueFilter;
+            AmbiguityFilter = settings.AmbiguityFilter;
             DrawStationarySequence = settings.DrawStationarySequence;
             DrawNumbersUnderStationary = settings.DrawNumbersUnderStationary;
             ShowLegend = settings.ShowLegend;
@@ -291,6 +293,7 @@ namespace GuiFunctions
             ShowDecoys = false;
             ShowContaminants = true;
             QValueFilter = 0.01;
+            AmbiguityFilter = "No Filter";
             LocalizationLevelStart = LocalizationLevel.Level1;
             LocalizationLevelEnd = LocalizationLevel.Level3;
             DrawMatchedIons  = true;

--- a/GuiFunctions/MetaDraw/MetaDrawSettings.cs
+++ b/GuiFunctions/MetaDraw/MetaDrawSettings.cs
@@ -77,6 +77,7 @@ namespace GuiFunctions
         public static Dictionary<ProductType, double> ProductTypeToYOffset { get; set; }
         public static OxyColor VariantCrossColor { get; set; } = OxyColors.Green;
         public static OxyColor UnannotatedPeakColor { get; set; } = OxyColors.LightGray;
+        public static OxyColor InternalIonColor { get; set; } = OxyColors.Purple;
         public static SolidColorBrush ModificationAnnotationColor { get; set; } = Brushes.Orange;
         public static double CanvasPdfExportDpi { get; set; } = 300;
         public static double StrokeThicknessUnannotated { get; set; } = 0.7;
@@ -134,7 +135,7 @@ namespace GuiFunctions
                 #region Setting Color Defaults
 
                     ModificationTypeToColor = GlobalVariables.AllModsKnown.ToDictionary(p => p.IdWithMotif, p => OxyColors.Orange);
-
+                    
                     // setting whole groups
                     var commonBiological = GlobalVariables.AllModsKnown.Where(p => p.ModificationType == "Common Biological").Select(p => p.IdWithMotif);
                     foreach (var mod in commonBiological)
@@ -228,6 +229,8 @@ namespace GuiFunctions
                 ModificationTypeToColorValues = ModificationTypeToColor.Values.Select(p => p.GetColorName()).ToList(),
                 CoverageTypeToColorValues = CoverageTypeToColor.Values.Select(p => p.GetColorName()).ToList(),
                 SpectrumDescriptionValues = SpectrumDescription.Values.ToList(),
+                UnannotatedPeakColor = UnannotatedPeakColor,
+                InternalIonColor = InternalIonColor ,
             };
         }
 
@@ -255,6 +258,8 @@ namespace GuiFunctions
             ModificationTypeToColor = GlobalVariables.AllModsKnown.Select(p => p.IdWithMotif).ToDictionary(p => p, p => DrawnSequence.ParseOxyColorFromName(settings.ModificationTypeToColorValues[Array.IndexOf(GlobalVariables.AllModsKnown.Select(p => p.IdWithMotif).ToArray(), p)]));
             CoverageTypeToColor = CoverageTypes.ToDictionary(p => p, p => DrawnSequence.ParseOxyColorFromName(settings.CoverageTypeToColorValues[Array.IndexOf(CoverageTypes, p)]));
             SpectrumDescription = SpectrumDescriptors.ToDictionary(p => p, p => settings.SpectrumDescriptionValues[Array.IndexOf(SpectrumDescriptors, p)]);
+            UnannotatedPeakColor = settings.UnannotatedPeakColor;
+            InternalIonColor = settings.InternalIonColor;
         }
 
         /// <summary>
@@ -281,6 +286,8 @@ namespace GuiFunctions
             SequenceAnnotaitonResiduesPerSegment = 10;
             SequenceAnnotationSegmentPerRow = 3;
             ExportType = "Pdf";
+            UnannotatedPeakColor = OxyColors.LightGray;
+            InternalIonColor = OxyColors.Purple;
         }
 
         public static TValue GetValueOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue)

--- a/GuiFunctions/MetaDraw/MetaDrawSettings.cs
+++ b/GuiFunctions/MetaDraw/MetaDrawSettings.cs
@@ -113,7 +113,6 @@ namespace GuiFunctions
                 {
                     return false;
                 }
-                return true;
             }
 
             return false;

--- a/GuiFunctions/MetaDraw/MetaDrawSettings.cs
+++ b/GuiFunctions/MetaDraw/MetaDrawSettings.cs
@@ -37,6 +37,7 @@ namespace GuiFunctions
         public static bool ShowDecoys { get; set; } = false;
         public static bool ShowContaminants { get; set; } = true;
         public static double QValueFilter { get; set; } = 0.01;
+        public static string AmbiguityFilter { get; set; } = "No Filter";
         public static LocalizationLevel LocalizationLevelStart { get; set; } = LocalizationLevel.Level1;
         public static LocalizationLevel LocalizationLevelEnd { get; set; } = LocalizationLevel.Level3;
         public static string ExportType { get; set; } = "Pdf"; 
@@ -71,6 +72,7 @@ namespace GuiFunctions
         "Decoy/Contaminant/Target: ", "Sequence Length: ", "ProForma Level: ", "Spectral Angle: ", "Score: ", "Q-Value: ", "PEP: ", "PEP Q-Value: "};
         public static string[] CoverageTypes { get; set; } = { "N-Terminal Color", "C-Terminal Color", "Internal Color" };
         public static string[] ExportTypes { get; set; } = { "Pdf", "Png", "Jpeg", "Tiff", "Wmf", "Bmp" };
+        public static string[] AmbiguityTypes { get; set; } = { "No Filter", "1", "2A", "2B", "2C", "2D", "3", "4", "5" };
 
         #endregion
 
@@ -102,6 +104,15 @@ namespace GuiFunctions
                  && (psm.DecoyContamTarget == "T" || (psm.DecoyContamTarget == "D" && ShowDecoys) || (psm.DecoyContamTarget == "C" && ShowContaminants))
                  && (psm.GlycanLocalizationLevel == null || psm.GlycanLocalizationLevel >= LocalizationLevelStart && psm.GlycanLocalizationLevel <= LocalizationLevelEnd))
             {
+                // Ambiguity filtering conditionals, should only be hit if Ambiguity Filtering is selected
+                if (AmbiguityFilter == "No Filter" || psm.AmbiguityLevel == AmbiguityFilter)
+                {
+                    return true;
+                }
+                else
+                {
+                    return false;
+                }
                 return true;
             }
 

--- a/GuiFunctions/MetaDraw/MetaDrawSettings.cs
+++ b/GuiFunctions/MetaDraw/MetaDrawSettings.cs
@@ -190,6 +190,7 @@ namespace GuiFunctions
 
                 // lines to be written on the spectrum
                 SpectrumDescription = SpectrumDescriptors.ToDictionary(p => p, p => true);
+                SpectrumDescription["Spectral Angle: "] = false;
             }
             
             // offset for annotation on base sequence

--- a/GuiFunctions/MetaDraw/MetaDrawSettingsSnapshot.cs
+++ b/GuiFunctions/MetaDraw/MetaDrawSettingsSnapshot.cs
@@ -34,6 +34,7 @@ namespace GuiFunctions
         public bool ShowDecoys { get; set; } = false;
         public bool ShowContaminants { get; set; } = true;
         public double QValueFilter { get; set; } = 0.01;
+        public string AmbiguityFilter { get; set; } = "No Filter";
         public LocalizationLevel LocalizationLevelStart { get; set; } = LocalizationLevel.Level1;
         public LocalizationLevel LocalizationLevelEnd { get; set; } = LocalizationLevel.Level3;
         public string ExportType { get; set; }

--- a/GuiFunctions/MetaDraw/MetaDrawSettingsSnapshot.cs
+++ b/GuiFunctions/MetaDraw/MetaDrawSettingsSnapshot.cs
@@ -19,6 +19,7 @@ namespace GuiFunctions
         public bool AnnotateMzValues { get; set; } = false;
         public bool AnnotateCharges { get; set; } = false;
         public bool AnnotationBold { get; set; } = false;
+        public bool DisplayInternalIonAnnotations { get; set; } = true;
         public bool DrawStationarySequence { get; set; } = true;
         public bool DrawNumbersUnderStationary { get; set; } = true;
         public bool ShowLegend { get; set; } = true;

--- a/GuiFunctions/MetaDraw/MetaDrawSettingsSnapshot.cs
+++ b/GuiFunctions/MetaDraw/MetaDrawSettingsSnapshot.cs
@@ -27,6 +27,8 @@ namespace GuiFunctions
         public List<string> BetaProductTypeToColorValues { get; set; }
         public List<string> ModificationTypeToColorValues { get; set; }
         public List<string> CoverageTypeToColorValues { get; set; }
+        public OxyColor UnannotatedPeakColor { get; set; }
+        public OxyColor InternalIonColor { get; set; }
 
         // filter settings
         public bool ShowDecoys { get; set; } = false;

--- a/GuiFunctions/MetaDraw/PeptideSpectrumMatchPlot.cs
+++ b/GuiFunctions/MetaDraw/PeptideSpectrumMatchPlot.cs
@@ -328,37 +328,42 @@ namespace GuiFunctions
                     prefix = "A-";
                 }
             }
-
-            string peakAnnotationText = prefix + matchedIon.NeutralTheoreticalProduct.Annotation;
-
-            if (matchedIon.NeutralTheoreticalProduct.NeutralLoss != 0)
-            {
-                peakAnnotationText += "-" + matchedIon.NeutralTheoreticalProduct.NeutralLoss.ToString("F2");
-            }
-
-            if (MetaDrawSettings.AnnotateCharges)
-            {
-                peakAnnotationText += "+" + matchedIon.Charge;
-            }
-
-            if (MetaDrawSettings.AnnotateMzValues)
-            {
-                peakAnnotationText += " (" + matchedIon.Mz.ToString("F3") + ")";
-            }
-
             var peakAnnotation = new TextAnnotation();
-            peakAnnotation.Font = "Arial";
-            peakAnnotation.FontSize = MetaDrawSettings.AnnotatedFontSize;
-            peakAnnotation.FontWeight = MetaDrawSettings.AnnotationBold ? OxyPlot.FontWeights.Bold : 2.0;
-            peakAnnotation.TextColor = ionColor;
-            peakAnnotation.StrokeThickness = 0;
-            peakAnnotation.Text = peakAnnotationText;
-            peakAnnotation.TextPosition = new DataPoint(mz, intensity);
-            peakAnnotation.TextVerticalAlignment = intensity < 0 ? OxyPlot.VerticalAlignment.Top : OxyPlot.VerticalAlignment.Bottom;
-            peakAnnotation.TextHorizontalAlignment = OxyPlot.HorizontalAlignment.Center;
-            
+            if (MetaDrawSettings.DisplayIonAnnotations)
+            {
+                string peakAnnotationText = prefix + matchedIon.NeutralTheoreticalProduct.Annotation;
 
-            if (!MetaDrawSettings.DisplayIonAnnotations)
+                if (matchedIon.NeutralTheoreticalProduct.NeutralLoss != 0)
+                {
+                    peakAnnotationText += "-" + matchedIon.NeutralTheoreticalProduct.NeutralLoss.ToString("F2");
+                }
+
+                if (MetaDrawSettings.AnnotateCharges)
+                {
+                    peakAnnotationText += "+" + matchedIon.Charge;
+                }
+
+                if (MetaDrawSettings.AnnotateMzValues)
+                {
+                    peakAnnotationText += " (" + matchedIon.Mz.ToString("F3") + ")";
+                }
+
+
+                peakAnnotation.Font = "Arial";
+                peakAnnotation.FontSize = MetaDrawSettings.AnnotatedFontSize;
+                peakAnnotation.FontWeight = MetaDrawSettings.AnnotationBold ? OxyPlot.FontWeights.Bold : 2.0;
+                peakAnnotation.TextColor = ionColor;
+                peakAnnotation.StrokeThickness = 0;
+                peakAnnotation.Text = peakAnnotationText;
+                peakAnnotation.TextPosition = new DataPoint(mz, intensity);
+                peakAnnotation.TextVerticalAlignment = intensity < 0 ? OxyPlot.VerticalAlignment.Top : OxyPlot.VerticalAlignment.Bottom;
+                peakAnnotation.TextHorizontalAlignment = OxyPlot.HorizontalAlignment.Center;
+            }
+            else
+            {
+                peakAnnotation.Text = string.Empty;
+            }
+            if (matchedIon.NeutralTheoreticalProduct.SecondaryProductType != null && !MetaDrawSettings.DisplayInternalIonAnnotations) //if internal fragment
             {
                 peakAnnotation.Text = string.Empty;
             }

--- a/GuiFunctions/MetaDraw/PeptideSpectrumMatchPlot.cs
+++ b/GuiFunctions/MetaDraw/PeptideSpectrumMatchPlot.cs
@@ -451,7 +451,6 @@ namespace GuiFunctions
             this.Model.Annotations.Add(annotation);
         }
 
-
         protected void DrawPeak(double mz, double intensity, double strokeWidth, OxyColor color, TextAnnotation annotation)
         {
             // peak line

--- a/GuiFunctions/MetaDraw/PeptideSpectrumMatchPlot.cs
+++ b/GuiFunctions/MetaDraw/PeptideSpectrumMatchPlot.cs
@@ -255,7 +255,7 @@ namespace GuiFunctions
             }
             else if (matchedIon.NeutralTheoreticalProduct.SecondaryProductType != null) //if internal fragment
             {
-                ionColor = OxyColors.Purple;
+                ionColor = MetaDrawSettings.InternalIonColor;
             }
             else if (isBetaPeptide)
             {

--- a/GuiFunctions/MetaDraw/PeptideSpectrumMatchPlot.cs
+++ b/GuiFunctions/MetaDraw/PeptideSpectrumMatchPlot.cs
@@ -333,7 +333,7 @@ namespace GuiFunctions
             {
                 string peakAnnotationText = prefix + matchedIon.NeutralTheoreticalProduct.Annotation;
 
-                if (matchedIon.NeutralTheoreticalProduct.NeutralLoss != 0)
+                if (matchedIon.NeutralTheoreticalProduct.NeutralLoss != 0 && !peakAnnotationText.Contains("-" + matchedIon.NeutralTheoreticalProduct.NeutralLoss.ToString("F2")))
                 {
                     peakAnnotationText += "-" + matchedIon.NeutralTheoreticalProduct.NeutralLoss.ToString("F2");
                 }
@@ -411,7 +411,7 @@ namespace GuiFunctions
                     text.Append(SpectrumMatch.ProteinName.Substring(0, 20));
                     int length = SpectrumMatch.ProteinName.Length;
                     int remaining = length - 20;
-                    for (int i = 21; i < SpectrumMatch.ProteinName.Length; i += 26)
+                    for (int i = 20; i < SpectrumMatch.ProteinName.Length; i += 26)
                     {
                         if (remaining <= 26)
                             text.Append("\r\n   " + SpectrumMatch.ProteinName.Substring(i, remaining - 1));

--- a/GuiFunctions/MetaDraw/PeptideSpectrumMatchPlot.cs
+++ b/GuiFunctions/MetaDraw/PeptideSpectrumMatchPlot.cs
@@ -426,13 +426,13 @@ namespace GuiFunctions
             if (MetaDrawSettings.SpectrumDescription["PEP: "])
             {
                 text.Append("PEP: ");
-                text.Append(SpectrumMatch.PEP);
+                text.Append(SpectrumMatch.PEP.ToString("F3"));
                 text.Append("\r\n");
             }
             if (MetaDrawSettings.SpectrumDescription["PEP Q-Value: "])
             {
                 text.Append("PEP Q-Value: ");
-                text.Append(SpectrumMatch.PEP_QValue);
+                text.Append(SpectrumMatch.PEP_QValue.ToString("F3"));
                 text.Append("\r\n");
             }
 

--- a/GuiFunctions/MetaDraw/PeptideSpectrumMatchPlot.cs
+++ b/GuiFunctions/MetaDraw/PeptideSpectrumMatchPlot.cs
@@ -62,7 +62,7 @@ namespace GuiFunctions
             RefreshChart();
         }
 
-        public void ExportPlot(string path, Canvas stationarySequence, ItemsControl ptmLegend = null, double width = 700, double height = 370)
+        public void ExportPlot(string path, Canvas stationarySequence, Canvas ptmLegend = null, Vector ptmLegendLocationVector = new(), double width = 700, double height = 370)
         {
             width = width > 0 ? width : 700;
             height = height > 0 ? height : 300;
@@ -110,21 +110,10 @@ namespace GuiFunctions
             Point ptmLegendPoint;
             if (ptmLegend != null && MetaDrawSettings.ShowLegend)
             {
-                // converting ItemsControl to a Canvas
-                ItemsControl ptmLegendCopy = new();
-                ptmLegendCopy.ItemsSource = ptmLegend.ItemsSource;
-                ptmLegendCopy.ItemTemplate = ptmLegend.ItemTemplate;
-                Canvas tempPtmLegendCanvas = new();
-                tempPtmLegendCanvas.Children.Add(ptmLegendCopy);
-                Size ptmLegendSize = new Size((int)ptmLegend.ActualWidth, (int)ptmLegend.ActualHeight);
-                tempPtmLegendCanvas.Measure(ptmLegendSize);
-                tempPtmLegendCanvas.Arrange(new Rect(ptmLegendSize));
-                tempPtmLegendCanvas.UpdateLayout();
-
                 // Saving Canvas as a usable Png
                 RenderTargetBitmap ptmLegendRenderBitmap = new((int)(dpiScale * ptmLegend.ActualWidth), (int)(dpiScale * ptmLegend.ActualHeight),
                          MetaDrawSettings.CanvasPdfExportDpi, MetaDrawSettings.CanvasPdfExportDpi, PixelFormats.Pbgra32);
-                ptmLegendRenderBitmap.Render(tempPtmLegendCanvas);
+                ptmLegendRenderBitmap.Render(ptmLegend);
                 PngBitmapEncoder legendEncoder = new PngBitmapEncoder();
                 legendEncoder.Frames.Add(BitmapFrame.Create(ptmLegendRenderBitmap));
                 using (FileStream file = File.Create(tempPtmLegendPngPath))
@@ -136,7 +125,6 @@ namespace GuiFunctions
                 System.Drawing.Bitmap tempPtmLegendBitmap = new(tempPtmLegendPngPath);
                 ptmLegendBitmap = new System.Drawing.Bitmap(tempPtmLegendBitmap, new System.Drawing.Size((int)ptmLegend.ActualWidth, (int)ptmLegend.ActualHeight));
                 bitmaps.Add(ptmLegendBitmap);
-                Vector ptmLegendLocationVector = (Vector)ptmLegend.GetType().GetProperty("VisualOffset", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(ptmLegend);
                 ptmLegendPoint = new Point(ptmLegendLocationVector.X, ptmLegendLocationVector.Y);
                 points.Add(ptmLegendPoint);
                 tempPtmLegendBitmap.Dispose();

--- a/GuiFunctions/ViewModels/IonForTreeViewModel.cs
+++ b/GuiFunctions/ViewModels/IonForTreeViewModel.cs
@@ -54,7 +54,7 @@ namespace GuiFunctions
 
         #endregion
 
-        #region Constructor
+        #region Constructors
 
         public IonForTreeViewModel(ProductType type, bool beta)
         {
@@ -68,6 +68,27 @@ namespace GuiFunctions
                 color = MetaDrawSettings.ProductTypeToColor[IonType];
             SelectedColor = AddSpaces(color.GetColorName());
             ColorBrush = DrawnSequence.ParseColorBrushFromOxyColor(color);
+        }
+
+        // should only be used for unannotated peak or internal ion color as it is not an actual product type
+        public IonForTreeViewModel(string type, bool beta)
+        {
+            if (type.Equals("Unannotated Peak"))
+            {
+                IonName = type;
+                IsBeta = beta;
+                OxyColor color = MetaDrawSettings.UnannotatedPeakColor;
+                SelectedColor = AddSpaces(color.GetColorName());
+                ColorBrush = DrawnSequence.ParseColorBrushFromOxyColor(color);
+            }
+            else if (type.Equals("Internal Ion"))
+            {
+                IonName = type;
+                IsBeta = beta;
+                OxyColor color = MetaDrawSettings.InternalIonColor;
+                SelectedColor = AddSpaces(color.GetColorName());
+                ColorBrush = DrawnSequence.ParseColorBrushFromOxyColor(color);
+            }
         }
 
         #endregion

--- a/GuiFunctions/ViewModels/IonTypeForTreeViewModel.cs
+++ b/GuiFunctions/ViewModels/IonTypeForTreeViewModel.cs
@@ -34,6 +34,12 @@ namespace GuiFunctions
             {
                 Ions.Add(new IonForTreeViewModel(ion, beta));
             }
+
+            if (groupName.Equals("Common Ions"))
+            {
+                Ions.Add(new IonForTreeViewModel("Unannotated Peak", beta));
+                Ions.Add(new IonForTreeViewModel("Internal Ion", beta));
+            }
         }
 
         #endregion

--- a/GuiFunctions/ViewModels/PtmLegendViewModel.cs
+++ b/GuiFunctions/ViewModels/PtmLegendViewModel.cs
@@ -14,18 +14,26 @@ namespace GuiFunctions
     /// </summary>
     public class PtmLegendViewModel : BaseViewModel
     {
-        private Visibility _visibility;
+        private Visibility visibility;
+        private double topOffset;
         public string Header { get; set; } = "Legend";
         public int HeaderSize { get; set; } = 12;
-        public ObservableCollection<PtmLegendItemViewModel> LegendItems { get; }
+        public ObservableCollection<PtmLegendItemViewModel> LegendItems { get; set; }
+
         public Visibility Visibility
         {
-            get { return _visibility; }
+            get { return visibility; }
             set
             {
-                _visibility = value;
+                visibility = value;
                 OnPropertyChanged(nameof(Visibility));
             }
+        }
+
+        public double TopOffset
+        {
+            get => topOffset;
+            set { topOffset = value; OnPropertyChanged(nameof(TopOffset)); }
         }
 
         /// <summary>
@@ -58,7 +66,7 @@ namespace GuiFunctions
 
         #region Constructor
 
-        public PtmLegendViewModel(List<Modification> mods)
+        public PtmLegendViewModel(List<Modification> mods, double offset = 0)
         {
             LegendItems = new ObservableCollection<PtmLegendItemViewModel>();
             foreach (var mod in mods.Distinct())
@@ -67,9 +75,10 @@ namespace GuiFunctions
                 LegendItems.Add(modItem);
             }
 
+            topOffset = offset;
             Visibility = mods.Count > 0 ? Visibility.Visible : Visibility.Hidden;
         }
-
+        
         #endregion
 
         #region Commands

--- a/GuiFunctions/ViewModels/PtmLegendViewModel.cs
+++ b/GuiFunctions/ViewModels/PtmLegendViewModel.cs
@@ -75,7 +75,7 @@ namespace GuiFunctions
                 LegendItems.Add(modItem);
             }
 
-            topOffset = offset;
+            TopOffset = offset;
             Visibility = mods.Count > 0 ? Visibility.Visible : Visibility.Hidden;
         }
         

--- a/GuiFunctions/ViewModels/SettingsViewModel.cs
+++ b/GuiFunctions/ViewModels/SettingsViewModel.cs
@@ -127,7 +127,11 @@ namespace GuiFunctions
                 {
                     if (ion.HasChanged)
                     {
-                        if (ion.IsBeta)
+                        if (ion.IonName.Equals("Unannotated Peak"))
+                            MetaDrawSettings.UnannotatedPeakColor = DrawnSequence.ParseOxyColorFromName(ion.SelectedColor.Replace(" ", ""));
+                        else if (ion.IonName.Equals("Internal Ion"))
+                            MetaDrawSettings.InternalIonColor = DrawnSequence.ParseOxyColorFromName(ion.SelectedColor.Replace(" ", ""));
+                        else if (ion.IsBeta)
                             MetaDrawSettings.BetaProductTypeToColor[ion.IonType] = DrawnSequence.ParseOxyColorFromName(ion.SelectedColor.Replace(" ", ""));
                         else
                             MetaDrawSettings.ProductTypeToColor[ion.IonType] = DrawnSequence.ParseOxyColorFromName(ion.SelectedColor.Replace(" ", ""));

--- a/Test/MetaDrawSettingsAndViewsTest.cs
+++ b/Test/MetaDrawSettingsAndViewsTest.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Media;
 
 namespace Test
@@ -257,7 +258,8 @@ namespace Test
         {
             var modGroup = GlobalVariables.AllModsKnown.GroupBy(b => b.ModificationType).First();
             var twoMods = modGroup.Take(2).ToList();
-            PtmLegendViewModel PtmLegendView = new PtmLegendViewModel(twoMods);
+            PtmLegendViewModel PtmLegendView = new PtmLegendViewModel(twoMods, 100);
+            PtmLegendView.Visibility = Visibility.Collapsed;
             Assert.That(PtmLegendView.Header == "Legend");
             Assert.That(PtmLegendView.HeaderSize == 12);
             Assert.That(PtmLegendView.LegendItems.Count == 2);

--- a/Test/MetaDrawSettingsAndViewsTest.cs
+++ b/Test/MetaDrawSettingsAndViewsTest.cs
@@ -212,7 +212,7 @@ namespace Test
             var ions = (ProductType[])Enum.GetValues(typeof(ProductType));
             IonTypeForTreeViewModel ionForTreeViews = new("Common Ions", ions, false);
             Assert.That(ionForTreeViews.GroupName == "Common Ions");
-            Assert.That(ionForTreeViews.Ions.Count == ions.Length);
+            Assert.That(ionForTreeViews.Ions.Count == ions.Length + 2); // magic number +2 is for the internal ion color and background peak color
             Assert.That(!ionForTreeViews.Ions.Any(p => p.IsBeta));
             ionForTreeViews = new("Common Ions", ions, true);
             Assert.That(ionForTreeViews.Ions.Any(p => p.IsBeta));

--- a/Test/MetaDrawSettingsAndViewsTest.cs
+++ b/Test/MetaDrawSettingsAndViewsTest.cs
@@ -159,10 +159,26 @@ namespace Test
             Assert.That(view.CoverageColors.First().SelectedColor == "Blue");
             Assert.That(view.CoverageColors.First().ColorBrush.Color == DrawnSequence.ParseColorBrushFromName("Blue").Color);
 
+            var internalIonIonTypeForTreeView = view.IonGroups.First().Ions.First(p => p.IonName == "Internal Ion");
+            Assert.That(!internalIonIonTypeForTreeView.HasChanged);
+            internalIonIonTypeForTreeView.SelectionChanged("Blue");
+            Assert.That(internalIonIonTypeForTreeView.HasChanged);
+            Assert.That(internalIonIonTypeForTreeView.SelectedColor == "Blue");
+            Assert.That(internalIonIonTypeForTreeView.ColorBrush.Color == DrawnSequence.ParseColorBrushFromName("Blue").Color);
+
+            internalIonIonTypeForTreeView = view.IonGroups.First().Ions.First(p => p.IonName == "Unannotated Peak");
+            Assert.That(!internalIonIonTypeForTreeView.HasChanged);
+            internalIonIonTypeForTreeView.SelectionChanged("Blue");
+            Assert.That(internalIonIonTypeForTreeView.HasChanged);
+            Assert.That(internalIonIonTypeForTreeView.SelectedColor == "Blue");
+            Assert.That(internalIonIonTypeForTreeView.ColorBrush.Color == DrawnSequence.ParseColorBrushFromName("Blue").Color);
+
             view.Save();
             Assert.That(MetaDrawSettings.ProductTypeToColor[view.IonGroups.First().Ions.First().IonType] == OxyColors.Blue);
             Assert.That(MetaDrawSettings.ModificationTypeToColor[view.Modifications.First().Children.First().ModName] == OxyColors.Blue);
             Assert.That(MetaDrawSettings.CoverageTypeToColor[view.CoverageColors.First().Name] == OxyColors.Blue);
+            Assert.That(MetaDrawSettings.InternalIonColor == OxyColors.Blue);
+            Assert.That(MetaDrawSettings.UnannotatedPeakColor == OxyColors.Blue);
         }
 
         [Test]

--- a/Test/MetaDrawTest.cs
+++ b/Test/MetaDrawTest.cs
@@ -11,7 +11,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
+using System.Windows;
 using System.Windows.Controls;
 using TaskLayer;
 
@@ -695,6 +697,17 @@ namespace Test
             metadrawLogic.ExportPlot(plotView, metadrawLogic.StationarySequence.SequenceDrawingCanvas, psmsToExport, parentChildView, outputFolder, out errors);
 
             // test that pdf exists
+            Assert.That(File.Exists(Path.Combine(outputFolder, @"27_STTAVQTPTSGEPLVST[O-Glycosylat.pdf"))); // parent scan
+            Assert.That(File.Exists(Path.Combine(outputFolder, @"30_STTAVQTPTSGEPLVST[O-Glycosylat.pdf"))); // child scan
+            Directory.Delete(outputFolder, true);
+
+            Canvas ptmLegend = new();
+            Size legendSize = new(100, 100);
+            ptmLegend.Measure(legendSize);
+            ptmLegend.Arrange(new Rect(legendSize));
+            ptmLegend.UpdateLayout();   
+            Vector ptmLegendVector = new(10, 10);
+            metadrawLogic.ExportPlot(plotView, metadrawLogic.StationarySequence.SequenceDrawingCanvas, psmsToExport, parentChildView, outputFolder, out errors, ptmLegend, ptmLegendVector);
             Assert.That(File.Exists(Path.Combine(outputFolder, @"27_STTAVQTPTSGEPLVST[O-Glycosylat.pdf"))); // parent scan
             Assert.That(File.Exists(Path.Combine(outputFolder, @"30_STTAVQTPTSGEPLVST[O-Glycosylat.pdf"))); // child scan
 

--- a/Test/MetaDrawTest.cs
+++ b/Test/MetaDrawTest.cs
@@ -698,6 +698,14 @@ namespace Test
             Assert.That(File.Exists(Path.Combine(outputFolder, @"27_STTAVQTPTSGEPLVST[O-Glycosylat.pdf"))); // parent scan
             Assert.That(File.Exists(Path.Combine(outputFolder, @"30_STTAVQTPTSGEPLVST[O-Glycosylat.pdf"))); // child scan
 
+            // test that a directory is created if it does not exist
+            Directory.Delete(outputFolder, true);
+            metadrawLogic.ExportPlot(plotView, metadrawLogic.StationarySequence.SequenceDrawingCanvas, psmsToExport, parentChildView, outputFolder, out errors);
+            Assert.That(File.Exists(Path.Combine(outputFolder, @"27_STTAVQTPTSGEPLVST[O-Glycosylat.pdf"))); // parent scan
+            Assert.That(File.Exists(Path.Combine(outputFolder, @"30_STTAVQTPTSGEPLVST[O-Glycosylat.pdf"))); // child scan
+
+
+
             // clean up resources
             metadrawLogic.CleanUpResources();
             Assert.That(!metadrawLogic.FilteredListOfPsms.Any());

--- a/Test/MetaDrawTest.cs
+++ b/Test/MetaDrawTest.cs
@@ -346,6 +346,18 @@ namespace Test
             var plotAxes = plotView.Model.Axes;
             Assert.That(plotAxes.Count == 2);
 
+            // test with different drawing settings
+            MetaDrawSettings.AnnotateCharges = true;
+            MetaDrawSettings.AnnotateMzValues = true;
+            metadrawLogic.DisplaySequences(stationaryCanvas, scrollableCanvas, sequenceAnnotationCanvas, psm);
+            metadrawLogic.DisplaySpectrumMatch(plotView, psm, parentChildView, out errors);
+            Assert.That(errors == null || !errors.Any());
+
+            MetaDrawSettings.DisplayIonAnnotations = false;
+            metadrawLogic.DisplaySequences(stationaryCanvas, scrollableCanvas, sequenceAnnotationCanvas, psm);
+            metadrawLogic.DisplaySpectrumMatch(plotView, psm, parentChildView, out errors);
+            Assert.That(errors == null || !errors.Any());
+
             // test that scrollable sequence annotation was drawn
             int numAnnotatedResidues = psm.BaseSeq.Length;
             int numAnnotatedIons = psm.MatchedIons.Count;

--- a/Test/MetaDrawTest.cs
+++ b/Test/MetaDrawTest.cs
@@ -185,7 +185,7 @@ namespace Test
             int numAnnotatedResidues = psm.BaseSeq.Length;
             int numAnnotatedIons = psm.MatchedIons.Count;
             int numAnnotatedMods = psm.FullSequence.Count(p => p == '[');
-
+            var peptide = new PeptideWithSetModifications(psm.FullSequence, GlobalVariables.AllModsKnownDictionary);
 
             // Iterates through the psm, simulating scrolling, until the sequence is scrolled as far as allowed
             for (; MetaDrawSettings.FirstAAonScreenIndex < psm.BaseSeq.Length - MetaDrawSettings.NumberOfAAOnScreen; MetaDrawSettings.FirstAAonScreenIndex++)
@@ -200,23 +200,14 @@ namespace Test
                 // Checks to see if the stationary sequence updated with the new positioning
                 string modifiedBaseSeq = psm.BaseSeq.Substring(MetaDrawSettings.FirstAAonScreenIndex, MetaDrawSettings.NumberOfAAOnScreen);
                 string fullSequence = modifiedBaseSeq;
-                Dictionary<int, List<string>> modDictionary = PsmFromTsv.ParseModifications(psm.FullSequence);
-                foreach (var mod in modDictionary.OrderByDescending(p => p.Key))
+                var modDictionary = peptide.AllModsOneIsNterminus.Where(p => p.Key - 1 >= MetaDrawSettings.FirstAAonScreenIndex
+                    && p.Key - 1 < (MetaDrawSettings.FirstAAonScreenIndex + MetaDrawSettings.NumberOfAAOnScreen)).OrderByDescending(p => p.Key);
+                foreach (var mod in modDictionary)
                 {
                     // if modification is within the visible region
-                    if (mod.Key >= MetaDrawSettings.FirstAAonScreenIndex && mod.Key < (MetaDrawSettings.FirstAAonScreenIndex + MetaDrawSettings.NumberOfAAOnScreen))
-                    {
-                        // account for multiple modifications on the same amino acid
-                        for (int i = mod.Value.Count - 1; i > -1; i--)
-                        {
-                            fullSequence = fullSequence.Insert(mod.Key - MetaDrawSettings.FirstAAonScreenIndex, "[" + mod.Value[i] + "]");
-                            if (i >= 1)
-                            {
-                                fullSequence = fullSequence.Insert(mod.Key, "|");
-                            }
-                        }
-                    }
+                    fullSequence = fullSequence.Insert(mod.Key - 1 - MetaDrawSettings.FirstAAonScreenIndex, "[" + mod.Value.ModificationType + ":" + mod.Value.IdWithMotif + "]");
                 }
+
                 List<MatchedFragmentIon> matchedIons = psm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.AminoAcidPosition > MetaDrawSettings.FirstAAonScreenIndex &&
                                                        p.NeutralTheoreticalProduct.AminoAcidPosition < (MetaDrawSettings.FirstAAonScreenIndex + MetaDrawSettings.NumberOfAAOnScreen)).ToList();
                 int psmStartResidue = int.Parse(psm.StartAndEndResiduesInProtein.Split("to")[0].Replace("[", ""));
@@ -266,6 +257,13 @@ namespace Test
             Assert.That(metadrawLogic.FilteredListOfPsms.Any(p => p.DecoyContamTarget == "D"));
             Assert.That(metadrawLogic.FilteredListOfPsms.Any(p => p.QValue > 0.01));
 
+            MetaDrawSettings.AmbiguityFilter = "2A";
+            metadrawLogic.FilterPsms();
+            Assert.That(metadrawLogic.FilteredListOfPsms.All(p => p.AmbiguityLevel == "2A"));
+
+            MetaDrawSettings.AmbiguityFilter = "No Filter";
+            metadrawLogic.FilterPsms();
+
             // test text search filter (filter by full sequence)
             string filterString = @"QIVHDSGR";
             metadrawLogic.FilterPsmsByString(filterString);
@@ -291,6 +289,33 @@ namespace Test
                 c++;
             }
             Assert.That(c > 0);
+
+            // test text search filter (filter by organism name)
+            filterString = "Sacc";
+            metadrawLogic.FilterPsmsByString(filterString);
+
+            c = 0;
+            foreach (var filteredPsm in metadrawLogic.PeptideSpectralMatchesView)
+            {
+                var psmObj = (PsmFromTsv)filteredPsm;
+                Assert.That(psmObj.OrganismName.Contains(filterString));
+                c++;
+            }
+            Assert.That(c > 0);
+
+            // test text search filter (filter by protein name)
+            filterString = "tRNA";
+            metadrawLogic.FilterPsmsByString(filterString);
+
+            c = 0;
+            foreach (var filteredPsm in metadrawLogic.PeptideSpectralMatchesView)
+            {
+                var psmObj = (PsmFromTsv)filteredPsm;
+                Assert.That(psmObj.ProteinName.Contains(filterString));
+                c++;
+            }
+            Assert.That(c > 0);
+
 
             // draw PSM
             var plotView = new OxyPlot.Wpf.PlotView();


### PR DESCRIPTION
Additional Features:
Color options for background peaks and internal ions
MetaDraw specific reset defaults button
Spectrum description elements PEP and PEP-Q only show three decimals
Sort list of psms by protein name, species of origin, q-value, pep, and MetaMorpheus Score
Filter psms by ambiguity level

Changes:
Data visualization charts now export to same folder as the rest of the images
Spectrum description 'spectral angle' field now off by default

Bug Fixes:
Resizing after psm or spectra files were reset caused a crash
Sequence annotation and stationary sequence ptm annotation positioning corrected
Export child scan as pdf now includes ptm color legend
Export sequence coverage no longer cuts off the sequence text
Sequence coverage now stays the correct size when the window is resolved
Psmtsv would use the ambiguous base sequence to set the positions of the matched ions instead of only one of the possible sequence