### PR TITLE
PsmTsvReader Bug Fix

### DIFF
--- a/EngineLayer/PsmTsv/PsmFromTsv.cs
+++ b/EngineLayer/PsmTsv/PsmFromTsv.cs
@@ -417,6 +417,9 @@ namespace EngineLayer
                     //if an internal fragment
                     if (ionTypeAndNumber.Contains("["))
                     {
+                        intensity = peakMzs.Count == peakIntensities.Count
+                            ? double.Parse(peakIntensities[index].Split(new char[] { '+', ':', ']' })[3], CultureInfo.InvariantCulture)
+                            : 1.0;
                         string[] internalSplit = split[0].Split('[');
                         string[] productSplit = internalSplit[0].Split("I");
                         string[] positionSplit = internalSplit[1].Replace("]", "").Split('-');

--- a/EngineLayer/PsmTsv/PsmFromTsv.cs
+++ b/EngineLayer/PsmTsv/PsmFromTsv.cs
@@ -417,9 +417,11 @@ namespace EngineLayer
                     //if an internal fragment
                     if (ionTypeAndNumber.Contains("["))
                     {
-                        intensity = peakMzs.Count == peakIntensities.Count
-                            ? double.Parse(peakIntensities[index].Split(new char[] { '+', ':', ']' })[3], CultureInfo.InvariantCulture)
-                            : 1.0;
+                        if (!intensity.Equals(1.0))
+                        {
+                            intensity = double.Parse(peakIntensities[index].Split(new char[] { '+', ':', ']' })[3],
+                                CultureInfo.InvariantCulture);
+                        }
                         string[] internalSplit = split[0].Split('[');
                         string[] productSplit = internalSplit[0].Split("I");
                         string[] positionSplit = internalSplit[1].Replace("]", "").Split('-');

--- a/Test/SearchTaskTest.cs
+++ b/Test/SearchTaskTest.cs
@@ -207,6 +207,12 @@ namespace Test
             Assert.IsTrue(psms.Count == 1);
             //check that it's been disambiguated
             Assert.IsFalse(psms[0].FullSequence.Contains("|"));
+            Assert.AreEqual(psms[0].MatchedIons.First().Intensity, 161210);
+            Assert.AreEqual(psms[0].MatchedIons.First().Mz, 585.25292);
+            Assert.AreEqual(psms[0].MatchedIons.First().Charge, 1);
+            Assert.AreEqual(psms[0].MatchedIons[4].Intensity, 131546);
+            Assert.AreEqual(psms[0].MatchedIons[4].Mz, 782.84816);
+            Assert.AreEqual(psms[0].MatchedIons[4].Charge, 2);
             int numTotalFragments = psms[0].MatchedIons.Count;
 
             //test again but no variable acetyl on K. Make sure that internal fragments are still searched even without ambiguity


### PR DESCRIPTION
Fixed bug in PsmTsvReader where internal ions intensity value was assigned their charge state