### PR TITLE
adjusted file specific parameters window

### DIFF
--- a/GUI/Views/FileSpecificParametersWindow.xaml
+++ b/GUI/Views/FileSpecificParametersWindow.xaml
@@ -6,126 +6,112 @@
         xmlns:local="clr-namespace:MetaMorpheusGUI"
         mc:Ignorable="d"
         KeyDown="KeyPressed"
-        Title="File-Specific Parameters" Height="400" Width="500" WindowStartupLocation="CenterScreen">
-    <StackPanel>
-        <Label Content="Enabled?">
-            <ToolTipService.ToolTip>
-                <ToolTip Content="Checking these boxes will override task parameters with parameters specified here (e.g., for a multiprotease dataset)" />
-            </ToolTipService.ToolTip>
-        </Label>
-        <!-- File-specific Precursor Tolerance -->
-        <StackPanel Orientation="Horizontal" Margin="10,0,0,8">
-            <CheckBox x:Name="fileSpecificPrecursorMassTolEnabled" Margin="10,0,0,0" VerticalAlignment="Center" IsChecked="False">
-                <ToolTipService.ToolTip>
-                    <ToolTip Content="Override task precursor tolerance for the selected spectra files with the tolerance specified here" />
-                </ToolTipService.ToolTip>
-            </CheckBox>
-            <Label Content="Precursor Mass Tolerance" Width="150" Margin="20,0,0,0" IsEnabled="{Binding IsChecked, ElementName=fileSpecificPrecursorMassTolEnabled}" />
-            <TextBox x:Name="precursorMassToleranceTextBox" PreviewTextInput="CheckIfNumber" Height="26" Width="45" HorizontalAlignment="Left" TextWrapping="Wrap" IsEnabled="{Binding IsChecked, ElementName=fileSpecificPrecursorMassTolEnabled}" />
-            <ComboBox x:Name="precursorMassToleranceComboBox" Height="26" HorizontalAlignment="Left" IsEnabled="{Binding IsChecked, ElementName=fileSpecificPrecursorMassTolEnabled}"  />
-        </StackPanel>
-        <!-- File-specific Product Tolerance -->
-        <StackPanel Orientation="Horizontal" Margin="10,0,0,8">
-            <CheckBox x:Name="fileSpecificProductMassTolEnabled" Margin="10,0,0,0" VerticalAlignment="Center" IsChecked="False">
-                <ToolTipService.ToolTip>
-                    <ToolTip Content="Override task product tolerance for the selected spectra files with the tolerance specified here" />
-                </ToolTipService.ToolTip>
-            </CheckBox>
-            <Label Content="Product Mass Tolerance" Width="150"  Margin="20,0,0,0" IsEnabled="{Binding IsChecked, ElementName=fileSpecificProductMassTolEnabled}"  />
-            <TextBox x:Name="productMassToleranceTextBox" PreviewTextInput="CheckIfNumber" HorizontalAlignment="Left" TextWrapping="Wrap" Width="45" IsEnabled="{Binding IsChecked, ElementName=fileSpecificProductMassTolEnabled}" />
-            <ComboBox x:Name="productMassToleranceComboBox" HorizontalAlignment="Left" IsEnabled="{Binding IsChecked, ElementName=fileSpecificProductMassTolEnabled}"  />
-        </StackPanel>
-        <!-- File-specific Protease -->
-        <StackPanel Orientation="Horizontal" Margin="10,0,0,8">
-            <CheckBox x:Name="fileSpecificProteaseEnabled" Margin="10,0,0,0" VerticalAlignment="Center" IsChecked="False">
-                <ToolTipService.ToolTip>
-                    <ToolTip Content="Override task protease for the selected spectra files with the protease specified here" />
-                </ToolTipService.ToolTip>
-            </CheckBox>
-            <Label x:Name="fileSpecificProteaseLabel" Margin="20,0,0,0"  Content="Protease" IsEnabled="{Binding IsChecked, ElementName=fileSpecificProteaseEnabled}" />
-            <ComboBox x:Name="fileSpecificProtease" IsEnabled="{Binding IsChecked, ElementName=fileSpecificProteaseEnabled}"/>
-        </StackPanel>
-        <!-- File-specific Min Peptide Length -->
-        <StackPanel Orientation="Horizontal" Margin="10,0,0,8">
-            <CheckBox x:Name="fileSpecificMinPeptideLengthEnabled" Margin="10,0,0,0" VerticalAlignment="Center" IsChecked="False">
-                <ToolTipService.ToolTip>
-                    <ToolTip Content="Override task min peptide length for the selected spectra files with the min peptide length specified here" />
-                </ToolTipService.ToolTip>
-            </CheckBox>
-            <Label x:Name="lblMinPeptideLength" Margin="20,0,0,0" Width="100" Content="Min Peptide Len" IsEnabled="{Binding IsChecked, ElementName=fileSpecificMinPeptideLengthEnabled}" />
-            <TextBox x:Name="MinPeptideLengthTextBox" PreviewTextInput="CheckIfNumber" Width="45" IsEnabled="{Binding IsChecked, ElementName=fileSpecificMinPeptideLengthEnabled}" />
-        </StackPanel>
-        <!-- File-specific Max Peptide Length -->
-        <StackPanel Orientation="Horizontal" Margin="10,0,0,8">
-            <CheckBox x:Name="fileSpecificMaxPeptideLengthEnabled" Margin="10,0,0,0" VerticalAlignment="Center" IsChecked="False">
-                <ToolTipService.ToolTip>
-                    <ToolTip Content="Override task max peptide length for the selected spectra files with the max peptide length specified here" />
-                </ToolTipService.ToolTip>
-            </CheckBox>
-            <Label x:Name="lblMaxPeptideLength" Margin="20,0,0,0" Width="100"  Content="Max Peptide Len" IsEnabled="{Binding IsChecked, ElementName=fileSpecificMaxPeptideLengthEnabled}" />
-            <TextBox x:Name="MaxPeptideLengthTextBox" PreviewTextInput="CheckIfNumber" Width="45" IsEnabled="{Binding IsChecked, ElementName=fileSpecificMaxPeptideLengthEnabled}" />
-        </StackPanel>
-        <!-- File-specific Max Missed Cleavages -->
-        <StackPanel Orientation="Horizontal" Margin="10,0,0,8">
-            <CheckBox x:Name="fileSpecificMissedCleavagesEnabled" Margin="10,0,0,0" VerticalAlignment="Center" IsChecked="False">
-                <ToolTipService.ToolTip>
-                    <ToolTip Content="Override task max missed cleavages for the selected spectra files with the max missed cleavages specified here" />
-                </ToolTipService.ToolTip>
-            </CheckBox>
-            <Label x:Name="maxMissedCleavagesLabel" Margin="20,0,0,0" Width="130" Content="Max Missed Cleavages" IsEnabled="{Binding IsChecked, ElementName=fileSpecificMissedCleavagesEnabled}"  />
-            <TextBox x:Name="missedCleavagesTextBox" PreviewTextInput="CheckIfNumber" Width="45" IsEnabled="{Binding IsChecked, ElementName=fileSpecificMissedCleavagesEnabled}" />
-        </StackPanel>
-        <!-- File-specific Max Mods per Peptide -->
-        <StackPanel Orientation="Horizontal" Margin="10,0,0,8">
-            <CheckBox x:Name="fileSpecificMaxModNumEnabled" Margin="10,0,0,0" VerticalAlignment="Center" IsChecked="False">
-                <ToolTipService.ToolTip>
-                    <ToolTip Content="Override task max mods per peptide for the selected spectra files with the max mods per peptide specified here" />
-                </ToolTipService.ToolTip>
-            </CheckBox>
-            <Label x:Name="lbMaxModNum" Margin="20,0,0,0" Width="130" Content="Max mods per peptide" IsEnabled="{Binding IsChecked, ElementName=fileSpecificMaxModNumEnabled}" />
-            <TextBox x:Name="MaxModNumTextBox" PreviewTextInput="CheckIfNumber" Width="45" IsEnabled="{Binding IsChecked, ElementName=fileSpecificMaxModNumEnabled}" />
-        </StackPanel>
-        <!-- File-specific Dissociation Type -->
-        <StackPanel Orientation="Horizontal" Margin="10,0,0,8">
-            <CheckBox x:Name="fileSpecificDissociationTypesEnabled" Margin="10,0,0,0" VerticalAlignment="Center" IsChecked="False">
-                <ToolTipService.ToolTip>
-                    <ToolTip Content="Override task default dissociation type for the dissociation type specified here" />
-                </ToolTipService.ToolTip>
-            </CheckBox>
-            <Label x:Name="fileSpecificDissociationTypeLabel" Margin="20,0,0,0"  Content="Dissociation Type" IsEnabled="{Binding IsChecked, ElementName=fileSpecificDissociationTypesEnabled}" />
-            <ComboBox x:Name="fileSpecificDissociationType" IsEnabled="{Binding IsChecked, ElementName=fileSpecificDissociationTypesEnabled}"/>
-        </StackPanel>
-        <!-- File-specific Separation Type -->
-        <StackPanel Orientation="Horizontal" Margin="10,0,0,8">
-            <CheckBox x:Name="fileSpecificSeparationTypesEnabled" Margin="10,0,0,0" VerticalAlignment="Center" IsChecked="False">
-                <ToolTipService.ToolTip>
-                    <ToolTip Content="Override task default separation type for the separation type specified here - HPLC or CZE " />
-                </ToolTipService.ToolTip>
-            </CheckBox>
-            <Label x:Name="fileSpecificSeparationTypeLabel" Margin="20,0,0,0"  Content="Separation Type" IsEnabled="{Binding IsChecked, ElementName=fileSpecificSeparationTypesEnabled}" />
-            <ComboBox x:Name="fileSpecificSeparationType" IsEnabled="{Binding IsChecked, ElementName=fileSpecificSeparationTypesEnabled}"/>
-        </StackPanel>
-        <!-- File-specific Ion Types -->
-        <!--<StackPanel Grid.Column="1" Margin="10,0,0,8">
-            <StackPanel Orientation="Horizontal" Margin="0">
-                <CheckBox x:Name="fileSpecificIonTypesEnabled" Margin="10,0,0,0" VerticalAlignment="Center" IsChecked="False">
-                    <ToolTipService.ToolTip>
-                        <ToolTip Content="Override task ion types for the selected spectra files with the ion types specified here" />
-                    </ToolTipService.ToolTip>
-                </CheckBox>
-                <Label x:Name="ionsToSearchLabel" Margin="21,0,0,0" Content="Ions to search" IsEnabled="{Binding IsChecked, ElementName=fileSpecificIonTypesEnabled}" />
-                <CheckBox x:Name="bCheckBox" VerticalAlignment="Center" Width="70" Content="b ions" IsEnabled="{Binding IsChecked, ElementName=fileSpecificIonTypesEnabled}" />
-                <CheckBox x:Name="yCheckBox" VerticalAlignment="Center" Width="70" Content="y ions" IsEnabled="{Binding IsChecked, ElementName=fileSpecificIonTypesEnabled}" />
+        Title="File-Specific Parameters" Height="Auto" MaxHeight="500" d:Height="410" Width="500" WindowStartupLocation="CenterScreen">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <ScrollViewer Grid.Row="1">
+            <StackPanel>
+                <!-- File-specific Precursor Tolerance -->
+                <StackPanel Orientation="Horizontal" Margin="10,0,0,8">
+                    <CheckBox x:Name="fileSpecificPrecursorMassTolEnabled" Margin="10,0,0,0" VerticalAlignment="Center" IsChecked="False">
+                        <ToolTipService.ToolTip>
+                            <ToolTip Content="Override task precursor tolerance for the selected spectra files with the tolerance specified here" />
+                        </ToolTipService.ToolTip>
+                    </CheckBox>
+                    <Label Content="Precursor Mass Tolerance" Width="150" Margin="20,0,0,0" IsEnabled="{Binding IsChecked, ElementName=fileSpecificPrecursorMassTolEnabled}" />
+                    <TextBox x:Name="precursorMassToleranceTextBox" PreviewTextInput="CheckIfNumber" Height="26" Width="45" HorizontalAlignment="Left" TextWrapping="Wrap" IsEnabled="{Binding IsChecked, ElementName=fileSpecificPrecursorMassTolEnabled}" />
+                    <ComboBox x:Name="precursorMassToleranceComboBox" Height="26" HorizontalAlignment="Left" IsEnabled="{Binding IsChecked, ElementName=fileSpecificPrecursorMassTolEnabled}"  />
+                </StackPanel>
+                <!-- File-specific Product Tolerance -->
+                <StackPanel Orientation="Horizontal" Margin="10,0,0,8">
+                    <CheckBox x:Name="fileSpecificProductMassTolEnabled" Margin="10,0,0,0" VerticalAlignment="Center" IsChecked="False">
+                        <ToolTipService.ToolTip>
+                            <ToolTip Content="Override task product tolerance for the selected spectra files with the tolerance specified here" />
+                        </ToolTipService.ToolTip>
+                    </CheckBox>
+                    <Label Content="Product Mass Tolerance" Width="150"  Margin="20,0,0,0" IsEnabled="{Binding IsChecked, ElementName=fileSpecificProductMassTolEnabled}"  />
+                    <TextBox x:Name="productMassToleranceTextBox" PreviewTextInput="CheckIfNumber" HorizontalAlignment="Left" TextWrapping="Wrap" Width="45" IsEnabled="{Binding IsChecked, ElementName=fileSpecificProductMassTolEnabled}" />
+                    <ComboBox x:Name="productMassToleranceComboBox" HorizontalAlignment="Left" IsEnabled="{Binding IsChecked, ElementName=fileSpecificProductMassTolEnabled}"  />
+                </StackPanel>
+                <!-- File-specific Protease -->
+                <StackPanel Orientation="Horizontal" Margin="10,0,0,8">
+                    <CheckBox x:Name="fileSpecificProteaseEnabled" Margin="10,0,0,0" VerticalAlignment="Center" IsChecked="False">
+                        <ToolTipService.ToolTip>
+                            <ToolTip Content="Override task protease for the selected spectra files with the protease specified here" />
+                        </ToolTipService.ToolTip>
+                    </CheckBox>
+                    <Label x:Name="fileSpecificProteaseLabel" Margin="20,0,0,0"  Content="Protease" IsEnabled="{Binding IsChecked, ElementName=fileSpecificProteaseEnabled}" />
+                    <ComboBox x:Name="fileSpecificProtease" IsEnabled="{Binding IsChecked, ElementName=fileSpecificProteaseEnabled}"/>
+                </StackPanel>
+                <!-- File-specific Min Peptide Length -->
+                <StackPanel Orientation="Horizontal" Margin="10,0,0,8">
+                    <CheckBox x:Name="fileSpecificMinPeptideLengthEnabled" Margin="10,0,0,0" VerticalAlignment="Center" IsChecked="False">
+                        <ToolTipService.ToolTip>
+                            <ToolTip Content="Override task min peptide length for the selected spectra files with the min peptide length specified here" />
+                        </ToolTipService.ToolTip>
+                    </CheckBox>
+                    <Label x:Name="lblMinPeptideLength" Margin="20,0,0,0" Width="100" Content="Min Peptide Len" IsEnabled="{Binding IsChecked, ElementName=fileSpecificMinPeptideLengthEnabled}" />
+                    <TextBox x:Name="MinPeptideLengthTextBox" PreviewTextInput="CheckIfNumber" Width="45" IsEnabled="{Binding IsChecked, ElementName=fileSpecificMinPeptideLengthEnabled}" />
+                </StackPanel>
+                <!-- File-specific Max Peptide Length -->
+                <StackPanel Orientation="Horizontal" Margin="10,0,0,8">
+                    <CheckBox x:Name="fileSpecificMaxPeptideLengthEnabled" Margin="10,0,0,0" VerticalAlignment="Center" IsChecked="False">
+                        <ToolTipService.ToolTip>
+                            <ToolTip Content="Override task max peptide length for the selected spectra files with the max peptide length specified here" />
+                        </ToolTipService.ToolTip>
+                    </CheckBox>
+                    <Label x:Name="lblMaxPeptideLength" Margin="20,0,0,0" Width="100"  Content="Max Peptide Len" IsEnabled="{Binding IsChecked, ElementName=fileSpecificMaxPeptideLengthEnabled}" />
+                    <TextBox x:Name="MaxPeptideLengthTextBox" PreviewTextInput="CheckIfNumber" Width="45" IsEnabled="{Binding IsChecked, ElementName=fileSpecificMaxPeptideLengthEnabled}" />
+                </StackPanel>
+                <!-- File-specific Max Missed Cleavages -->
+                <StackPanel Orientation="Horizontal" Margin="10,0,0,8">
+                    <CheckBox x:Name="fileSpecificMissedCleavagesEnabled" Margin="10,0,0,0" VerticalAlignment="Center" IsChecked="False">
+                        <ToolTipService.ToolTip>
+                            <ToolTip Content="Override task max missed cleavages for the selected spectra files with the max missed cleavages specified here" />
+                        </ToolTipService.ToolTip>
+                    </CheckBox>
+                    <Label x:Name="maxMissedCleavagesLabel" Margin="20,0,0,0" Width="130" Content="Max Missed Cleavages" IsEnabled="{Binding IsChecked, ElementName=fileSpecificMissedCleavagesEnabled}"  />
+                    <TextBox x:Name="missedCleavagesTextBox" PreviewTextInput="CheckIfNumber" Width="45" IsEnabled="{Binding IsChecked, ElementName=fileSpecificMissedCleavagesEnabled}" />
+                </StackPanel>
+                <!-- File-specific Max Mods per Peptide -->
+                <StackPanel Orientation="Horizontal" Margin="10,0,0,8">
+                    <CheckBox x:Name="fileSpecificMaxModNumEnabled" Margin="10,0,0,0" VerticalAlignment="Center" IsChecked="False">
+                        <ToolTipService.ToolTip>
+                            <ToolTip Content="Override task max mods per peptide for the selected spectra files with the max mods per peptide specified here" />
+                        </ToolTipService.ToolTip>
+                    </CheckBox>
+                    <Label x:Name="lbMaxModNum" Margin="20,0,0,0" Width="130" Content="Max mods per peptide" IsEnabled="{Binding IsChecked, ElementName=fileSpecificMaxModNumEnabled}" />
+                    <TextBox x:Name="MaxModNumTextBox" PreviewTextInput="CheckIfNumber" Width="45" IsEnabled="{Binding IsChecked, ElementName=fileSpecificMaxModNumEnabled}" />
+                </StackPanel>
+                <!-- File-specific Dissociation Type -->
+                <StackPanel Orientation="Horizontal" Margin="10,0,0,8">
+                    <CheckBox x:Name="fileSpecificDissociationTypesEnabled" Margin="10,0,0,0" VerticalAlignment="Center" IsChecked="False">
+                        <ToolTipService.ToolTip>
+                            <ToolTip Content="Override task default dissociation type for the dissociation type specified here" />
+                        </ToolTipService.ToolTip>
+                    </CheckBox>
+                    <Label x:Name="fileSpecificDissociationTypeLabel" Margin="20,0,0,0"  Content="Dissociation Type" IsEnabled="{Binding IsChecked, ElementName=fileSpecificDissociationTypesEnabled}" />
+                    <ComboBox x:Name="fileSpecificDissociationType" IsEnabled="{Binding IsChecked, ElementName=fileSpecificDissociationTypesEnabled}"/>
+                </StackPanel>
+                <!-- File-specific Separation Type -->
+                <StackPanel Orientation="Horizontal" Margin="10,0,0,8">
+                    <CheckBox x:Name="fileSpecificSeparationTypesEnabled" Margin="10,0,0,0" VerticalAlignment="Center" IsChecked="False">
+                        <ToolTipService.ToolTip>
+                            <ToolTip Content="Override task default separation type for the separation type specified here - HPLC or CZE " />
+                        </ToolTipService.ToolTip>
+                    </CheckBox>
+                    <Label x:Name="fileSpecificSeparationTypeLabel" Margin="20,0,0,0"  Content="Separation Type" IsEnabled="{Binding IsChecked, ElementName=fileSpecificSeparationTypesEnabled}" />
+                    <ComboBox x:Name="fileSpecificSeparationType" IsEnabled="{Binding IsChecked, ElementName=fileSpecificSeparationTypesEnabled}"/>
+                </StackPanel>
             </StackPanel>
-            <StackPanel Orientation="Horizontal" Margin="130,0,0,0">
-                <CheckBox x:Name="cCheckBox" VerticalAlignment="Center" Width="70" Content="c ions" IsEnabled="{Binding IsChecked, ElementName=fileSpecificIonTypesEnabled}" />
-                <CheckBox x:Name="zdotCheckBox" VerticalAlignment="Center" Width="70" Content="zdot ions" IsEnabled="{Binding IsChecked, ElementName=fileSpecificIonTypesEnabled}" />
-            </StackPanel>
-        </StackPanel>-->
-        <!-- Save/cancel buttons -->
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,5,0,5">
-            <Button x:Name="Save"  Height="40" Width="300" Content="Save File-Specific Settings" Click="Save_Click" FontSize="25" Grid.Row="3" />
-            <Button x:Name="Cancel" Height="40" Width="100" Content="Cancel" Click="Cancel_Click" FontSize="15" Grid.Row="3" />
+        </ScrollViewer>
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,5,0,5" VerticalAlignment="Bottom" Grid.Row="2">
+            <Button x:Name="Save"  Height="40" Width="300" Content="Save File-Specific Settings" Click="Save_Click" FontSize="25"/>
+            <Button x:Name="Cancel" Height="40" Width="100" Content="Cancel" Click="Cancel_Click" FontSize="25"/>
         </StackPanel>
-    </StackPanel>
+    </Grid>
 </Window>


### PR DESCRIPTION
Adding the option for file specific dissociation type to file specific settings window caused the window to be undersized on some monitors. This PR adjusts the default window size and adds the ability to scroll the buttons if the user makes the window vertical size smaller than the height needed to accommodate all the buttons. Also, set button is pinned to the bottom and is always visible regardless of overall window height. Thanks Nic.