### PR TITLE
Updated Nuget packages that were updated in MzLib

### DIFF
--- a/CMD/CMD.csproj
+++ b/CMD/CMD.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.ML.FastTree" Version="1.3.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
     <PackageReference Include="mzLib" Version="1.0.528" />
-    <PackageReference Include="Nett" Version="0.13.0" />
+    <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/EngineLayer/Calibration/DataPointAquisitionResults.cs
+++ b/EngineLayer/Calibration/DataPointAquisitionResults.cs
@@ -1,9 +1,9 @@
 ﻿using Chemistry;
-using MathNet.Numerics.Statistics;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using MathNet.Numerics.Statistics;
 
 namespace EngineLayer.Calibration
 {
@@ -25,11 +25,16 @@ namespace EngineLayer.Calibration
             Ms1List = ms1List;
             Ms2List = ms2List;
 
-            Ms1InfoTh = Ms1List.Select(b => b.ExperimentalMz - b.TheoreticalMz).MeanStandardDeviation();
-            Ms2InfoTh = Ms2List.Select(b => b.ExperimentalMz - b.TheoreticalMz).MeanStandardDeviation();
+            var ms1Range = Ms1List.Select(b => b.ExperimentalMz - b.TheoreticalMz).ToArray();
+            var ms2Range = Ms2List.Select(b => b.ExperimentalMz - b.TheoreticalMz).ToArray();
+            Ms1InfoTh = new Tuple<double, double>(ArrayStatistics.Mean(ms1Range), ArrayStatistics.StandardDeviation(ms1Range));
+            Ms2InfoTh = new Tuple<double, double>(ArrayStatistics.Mean(ms2Range), ArrayStatistics.StandardDeviation(ms2Range));
 
-            Ms1InfoPpm = Ms1List.Select(b => (b.ExperimentalMz - b.TheoreticalMz) / b.TheoreticalMz).MeanStandardDeviation();
-            Ms2InfoPpm = Ms2List.Select(b => (b.ExperimentalMz - b.TheoreticalMz) / b.TheoreticalMz).MeanStandardDeviation();
+
+            var ms1PpmRange = Ms1List.Select(b => (b.ExperimentalMz - b.TheoreticalMz) / b.TheoreticalMz).ToArray();
+            var ms2PpmRange = Ms2List.Select(b => (b.ExperimentalMz - b.TheoreticalMz) / b.TheoreticalMz).ToArray();
+            Ms1InfoPpm = new Tuple<double, double>(ArrayStatistics.Mean(ms1PpmRange), ArrayStatistics.StandardDeviation(ms1PpmRange));
+            Ms2InfoPpm = new Tuple<double, double>(ArrayStatistics.Mean(ms2PpmRange), ArrayStatistics.StandardDeviation(ms2PpmRange));
 
             NumMs1MassChargeCombinationsConsidered = numMs1MassChargeCombinationsConsidered;
             NumMs1MassChargeCombinationsThatAreIgnoredBecauseOfTooManyPeaks = numMs1MassChargeCombinationsThatAreIgnoredBecauseOfTooManyPeaks;
@@ -37,12 +42,12 @@ namespace EngineLayer.Calibration
             NumMs2MassChargeCombinationsThatAreIgnoredBecauseOfTooManyPeaks = numMs2MassChargeCombinationsThatAreIgnoredBecauseOfTooManyPeaks;
 
             var precursorErrors = psms.Select(p => (p.ScanPrecursorMass - p.PeptideMonisotopicMass.Value) / p.PeptideMonisotopicMass.Value * 1e6).ToList();
-            PsmPrecursorIqrPpmError = Statistics.InterquartileRange(precursorErrors);
-            PsmPrecursorMedianPpmError = Statistics.Median(precursorErrors);
+            PsmPrecursorIqrPpmError = precursorErrors.InterquartileRange();
+            PsmPrecursorMedianPpmError = precursorErrors.Median();
 
             var productErrors = psms.Where(p => p.MatchedFragmentIons != null).SelectMany(p => p.MatchedFragmentIons).Select(p => (p.Mz.ToMass(p.Charge) - p.NeutralTheoreticalProduct.NeutralMass) / p.NeutralTheoreticalProduct.NeutralMass * 1e6).ToList();
-            PsmProductIqrPpmError = Statistics.InterquartileRange(productErrors);
-            PsmProductMedianPpmError = Statistics.Median(productErrors);
+            PsmProductIqrPpmError = productErrors.InterquartileRange();
+            PsmProductMedianPpmError = productErrors.Median();
         }
 
         public Tuple<double, double> Ms1InfoTh { get; }

--- a/EngineLayer/EngineLayer.csproj
+++ b/EngineLayer/EngineLayer.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
     <PackageReference Include="mzLib" Version="1.0.528" />
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
-    <PackageReference Include="Nett" Version="0.13.0" />
+    <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -49,7 +49,7 @@
 
   <ItemGroup>
     <PackageReference Include="MarkdownSharp" Version="2.0.5" />
-    <PackageReference Include="MathNet.Numerics" Version="4.15.0" />
+    <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="MathNet.Numerics.MKL.Win" Version="2.5.0" />
     <PackageReference Include="Microsoft.ML" Version="1.3.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="1.3.1" />
@@ -57,7 +57,7 @@
     <PackageReference Include="Microsoft.ML.FastTree" Version="1.3.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
     <PackageReference Include="mzLib" Version="1.0.528" />
-    <PackageReference Include="Nett" Version="0.13.0" />
+    <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.0.0" />

--- a/TaskLayer/TaskLayer.csproj
+++ b/TaskLayer/TaskLayer.csproj
@@ -16,13 +16,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MathNet.Numerics" Version="4.15.0" />
+    <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
     <PackageReference Include="Microsoft.ML" Version="1.3.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="1.3.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
     <PackageReference Include="mzLib" Version="1.0.528" />
     <PackageReference Include="NetSerializer" Version="4.1.1" />
-    <PackageReference Include="Nett" Version="0.13.0" />
+    <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
nett is now version 0.15.0
Mathnet.Numerics is now version 5.0.0

One class, DataPointAcquisitionResults, had issues with the new version of Mathnet.Numerics and was changed to maintain the same behavior. The previous version of the code called the method MeanStandardDeviation whose definition in the Mathnet.Numerics code is below

![image](https://user-images.githubusercontent.com/96196865/201374160-f5a78ee6-c7e6-42aa-a9b3-51a6ee38525f.png)

The code that has been changed, simply implements this in our class. 

![image](https://user-images.githubusercontent.com/96196865/201374349-e5a61ab9-0e3e-43d4-961c-063fb9377716.png)

