### PR TITLE
Added global.json

### DIFF
--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -16,6 +16,10 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <PackageReference Include="coverlet.msbuild" Version="3.2.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.ML" Version="1.3.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="1.3.1" />
     <PackageReference Include="mzLib" Version="1.0.528" />

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "6.0.402",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
Appveyor recently started including .NET 7 with the Visual Studio 2022 image. This broke coverlet. Added a global.json to set the correct version of .NET