### PR TITLE
Allow decimal numbers for product mass tolerance in all tasks

### DIFF
--- a/GUI/TaskWindows/CalibrateTaskWindow.xaml
+++ b/GUI/TaskWindows/CalibrateTaskWindow.xaml
@@ -71,7 +71,7 @@
                                 <StackPanel Grid.Column="1">
                                     <StackPanel Orientation="Horizontal" Margin="5">
                                         <Label x:Name="productMassToleranceLabel" Content="Product Mass Tolerance" />
-                                        <TextBox x:Name="ProductMassToleranceTextBox" HorizontalAlignment="Left" TextWrapping="Wrap" PreviewTextInput="CheckIfNumber" Width="45" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500">
+                                        <local:DoubleTexBoxControl x:Name="ProductMassToleranceTextBox" HorizontalAlignment="Left" TextWrapping="Wrap" Width="45" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500">
                                             <TextBox.ToolTip>
                                                 <TextBlock>
                                                     Accepted tolerance between experimental and theoretical MS2 peaks.
@@ -79,7 +79,7 @@
                                                     For calibration, it is better to be too lenient than too strict
                                                 </TextBlock>
                                             </TextBox.ToolTip>
-                                        </TextBox>
+                                        </local:DoubleTexBoxControl>
                                         <ComboBox x:Name="ProductMassToleranceComboBox" HorizontalAlignment="Left" />
                                     </StackPanel>
                                 </StackPanel>

--- a/GUI/TaskWindows/GPTMDTaskWindow.xaml
+++ b/GUI/TaskWindows/GPTMDTaskWindow.xaml
@@ -135,7 +135,7 @@
                                 <StackPanel Grid.Column="1">
                                     <StackPanel Orientation="Horizontal" Margin="5">
                                         <Label x:Name="productMassToleranceLabel" Content="Product Mass Tolerance" />
-                                        <TextBox x:Name="ProductMassToleranceTextBox" PreviewTextInput="CheckIfNumber" HorizontalAlignment="Left" TextWrapping="Wrap" Width="45" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500">
+                                        <local:DoubleTexBoxControl x:Name="ProductMassToleranceTextBox" HorizontalAlignment="Left" TextWrapping="Wrap" Width="45" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500">
                                             <TextBox.ToolTip>
                                                 <TextBlock>
                                                     Accepted tolerance between experimental and theoretical MS2 peaks.
@@ -143,7 +143,7 @@
                                                     This is a file specific parameter; calibration of spectra files will overwrite this value with the suggested tolerance(s).
                                                 </TextBlock>
                                             </TextBox.ToolTip>
-                                        </TextBox>
+                                        </local:DoubleTexBoxControl>
                                         <ComboBox x:Name="ProductMassToleranceComboBox" HorizontalAlignment="Left" />
                                     </StackPanel>
                                 </StackPanel>

--- a/GUI/TaskWindows/GlycoSearchTaskWindow.xaml
+++ b/GUI/TaskWindows/GlycoSearchTaskWindow.xaml
@@ -239,7 +239,7 @@
                                         </StackPanel>
                                         <StackPanel Orientation="Horizontal" Margin="5">
                                             <Label x:Name="label2_Copy" Content="Product Mass Tolerance" />
-                                            <TextBox x:Name="productMassToleranceTextBox" PreviewTextInput="CheckIfNumber" HorizontalAlignment="Left"  TextWrapping="Wrap" Width="45" />
+                                            <local:DoubleTexBoxControl x:Name="productMassToleranceTextBox" HorizontalAlignment="Left"  TextWrapping="Wrap" Width="45" />
                                             <ComboBox x:Name="productMassToleranceComboBox" HorizontalAlignment="Left" />
                                         </StackPanel>
                                     </StackPanel>

--- a/GUI/TaskWindows/SearchTaskWindow.xaml
+++ b/GUI/TaskWindows/SearchTaskWindow.xaml
@@ -114,7 +114,7 @@
                                 <!-- Product Mass Tolerance -->
                                 <StackPanel Orientation="Horizontal" Margin="5 5 5 0" Grid.Column="1" Grid.Row="1">
                                     <Label Content="Product Mass Tolerance:" Width="150" />
-                                    <TextBox x:Name="ProductMassToleranceTextBox" PreviewTextInput="CheckIfNumber" HorizontalAlignment="Left" TextWrapping="Wrap" Width="45" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500">
+                                    <local:DoubleTexBoxControl x:Name="ProductMassToleranceTextBox" HorizontalAlignment="Left" TextWrapping="Wrap" Width="45" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500">
                                         <TextBox.ToolTip>
                                             <TextBlock>
                                             Accepted tolerance between experimental and theoretical MS2 peaks.
@@ -122,7 +122,7 @@
                                             This is a file specific parameter; calibration of spectra files will overwrite this value with the suggested tolerance(s).
                                             </TextBlock>
                                         </TextBox.ToolTip>
-                                    </TextBox>
+                                    </local:DoubleTexBoxControl>
                                     <ComboBox x:Name="ProductMassToleranceComboBox" HorizontalAlignment="Left" />
                                 </StackPanel>
 

--- a/GUI/TaskWindows/XLSearchTaskWindow.xaml
+++ b/GUI/TaskWindows/XLSearchTaskWindow.xaml
@@ -215,7 +215,7 @@
                                         </StackPanel>
                                         <StackPanel Orientation="Horizontal" Margin="5">
                                             <Label x:Name="label2_Copy" Content="Product Mass Tolerance" />
-                                            <TextBox x:Name="productMassToleranceTextBox" PreviewTextInput="CheckIfNumber" HorizontalAlignment="Left"  TextWrapping="Wrap" Width="45" />
+                                            <local:DoubleTexBoxControl x:Name="productMassToleranceTextBox" HorizontalAlignment="Left"  TextWrapping="Wrap" Width="45" />
                                             <ComboBox x:Name="productMassToleranceComboBox" HorizontalAlignment="Left" />
                                         </StackPanel>
                 

--- a/GUI/Util/DoubleTexBoxControl.cs
+++ b/GUI/Util/DoubleTexBoxControl.cs
@@ -1,0 +1,30 @@
+﻿using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace MetaMorpheusGUI
+{
+    /// <summary>
+    /// This text box requires input text to be decimal only.
+    /// </summary>
+    public class DoubleTexBoxControl : TextBox
+    {
+        protected override void OnPreviewTextInput(TextCompositionEventArgs e)
+        {
+            foreach (var character in e.Text)
+            {
+                if (!char.IsDigit(character) && !(character == '.'))
+                {
+                    e.Handled = true;
+                    return;
+                }
+
+                if (((TextBox)e.Source).Text.Contains('.') && character == '.')
+                {
+                    e.Handled = true;
+                    return;
+                }
+            }
+            e.Handled = false;
+        }
+    }
+}

--- a/GUI/Util/IntegerTextBoxControl.cs
+++ b/GUI/Util/IntegerTextBoxControl.cs
@@ -1,0 +1,24 @@
+﻿using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace MetaMorpheusGUI
+{
+    /// <summary>
+    /// This text box requires input text to be integer only.
+    /// </summary>
+    public class IntegerTexBoxControl : TextBox
+    {
+        protected override void OnPreviewTextInput(TextCompositionEventArgs e)
+        {
+            foreach (var character in e.Text)
+            {
+                if (!char.IsDigit(character))
+                {
+                    e.Handled = true;
+                    return;
+                }
+            }
+            e.Handled = false;
+        }
+    }
+}


### PR DESCRIPTION
user reported being unable to input 0.5 Da for product mass tolerance https://github.com/smith-chem-wisc/MetaMorpheus/issues/2240

Only integer input was allowed. 

This PR enables input of decimal values.

Addition of two utility methods to verify decimal and integer were also added to GUI.Utils