### PR TITLE
[WIP] filter psms for flashlfq only by qvalue and qvalue notch

### DIFF
--- a/TaskLayer/SearchTask/PostSearchAnalysisTask.cs
+++ b/TaskLayer/SearchTask/PostSearchAnalysisTask.cs
@@ -254,21 +254,11 @@ namespace TaskLayer
             }
 
             // get PSMs to pass to FlashLFQ
-            List<PeptideSpectralMatch> unambiguousPsmsBelowOnePercentFdr = new();
-            if (Parameters.AllPsms.Count > 100)//PEP is not computed when there are fewer than 100 psms
-            {
-                unambiguousPsmsBelowOnePercentFdr = Parameters.AllPsms.Where(p =>
-                    p.FdrInfo.PEP_QValue <= 0.01
-                    && !p.IsDecoy
-                    && p.FullSequence != null).ToList(); //if ambiguous, there's no full sequence
-            }
-            else
-            {
-                unambiguousPsmsBelowOnePercentFdr = Parameters.AllPsms.Where(p =>
+            List<PeptideSpectralMatch> unambiguousPsmsBelowOnePercentFdr  = Parameters.AllPsms.Where(p =>
                     p.FdrInfo.QValue <= 0.01
+                    && p.FdrInfo.QValueNotch <= 0.01
                     && !p.IsDecoy
                     && p.FullSequence != null).ToList(); //if ambiguous, there's no full sequence
-            }
 
             // pass protein group info for each PSM
             var psmToProteinGroups = new Dictionary<PeptideSpectralMatch, List<FlashLFQ.ProteinGroup>>();


### PR DESCRIPTION
this code was changed in a prior commit https://github.com/smith-chem-wisc/MetaMorpheus/pull/2161
Files with values for PEP were filtered by PEP. But when assigning them to ProteinGroups, the filter was for qvalue and qvalue notch. Thus there was incosistency that produced UNDEFINED protein groups for some peptides. This messed up protein quantification.