### PR TITLE
Ambiguous quant option

### DIFF
--- a/MetaMorpheus/CMD/CMD.csproj
+++ b/MetaMorpheus/CMD/CMD.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="2.0.0" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="2.0.0" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.538" />
+    <PackageReference Include="mzLib" Version="1.0.539" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>
 

--- a/MetaMorpheus/EngineLayer/Calibration/CalibrationEngine.cs
+++ b/MetaMorpheus/EngineLayer/Calibration/CalibrationEngine.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Readers;
 
 namespace EngineLayer.Calibration
 {
@@ -102,7 +103,7 @@ namespace EngineLayer.Calibration
                 }
             }
 
-            CalibratedDataFile = new MsDataFile(calibratedScans, MyMsDataFile.SourceFile);
+            CalibratedDataFile = new GenericMsDataFile(calibratedScans, MyMsDataFile.SourceFile);
             return new MetaMorpheusEngineResults(this);
         }
 

--- a/MetaMorpheus/EngineLayer/EngineLayer.csproj
+++ b/MetaMorpheus/EngineLayer/EngineLayer.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="2.0.0" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="2.0.0" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.538" />
+    <PackageReference Include="mzLib" Version="1.0.539" />
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/MetaMorpheus/GUI/GUI.csproj
+++ b/MetaMorpheus/GUI/GUI.csproj
@@ -55,7 +55,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="2.0.0" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="2.0.0" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.538" />
+    <PackageReference Include="mzLib" Version="1.0.539" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0" />

--- a/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml
+++ b/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml
@@ -487,6 +487,23 @@
                                     <ToolTip Content="Use the 'Experimental Design' to normalize intensity values from FlashLFQ" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500" />
                                 </ToolTipService.ToolTip>
                             </CheckBox>
+                            <CheckBox x:Name="CheckBoxQuantifyAmbiguousPeptides" Content="Report intensity values for ambiguous peptide identifications">
+                                <CheckBox.IsEnabled>
+                                    <MultiBinding Converter="{StaticResource boolOrConverter}">
+                                        <Binding  ElementName="CheckBoxLFQ" Path ="IsChecked"/>
+                                        <Binding  ElementName="CheckBoxLFQwSpectralRecovery" Path ="IsChecked"/>
+                                    </MultiBinding>
+                                </CheckBox.IsEnabled>
+                                <CheckBox.Visibility>
+                                    <MultiBinding Converter="{StaticResource boolOr2VisConverter}">
+                                        <Binding  ElementName="CheckBoxLFQ" Path ="IsChecked"/>
+                                        <Binding  ElementName="CheckBoxLFQwSpectralRecovery" Path ="IsChecked"/>
+                                    </MultiBinding>
+                                </CheckBox.Visibility>
+                                <ToolTipService.ToolTip>
+                                    <ToolTip Content="Reports identical intensity values for all ambiguous peptides associated with a given chromatographic peak" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500" />
+                                </ToolTipService.ToolTip>
+                            </CheckBox>
                         </StackPanel>
                     </GroupBox>
 

--- a/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml
+++ b/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml
@@ -487,7 +487,7 @@
                                     <ToolTip Content="Use the 'Experimental Design' to normalize intensity values from FlashLFQ" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500" />
                                 </ToolTipService.ToolTip>
                             </CheckBox>
-                            <CheckBox x:Name="CheckBoxQuantifyAmbiguousPeptides" Content="Report intensity values for ambiguous peptide identifications">
+                            <CheckBox x:Name="CheckBoxQuantifyAmbiguousPeptides" Content="Quantify ambiguous peptides">
                                 <CheckBox.IsEnabled>
                                     <MultiBinding Converter="{StaticResource boolOrConverter}">
                                         <Binding  ElementName="CheckBoxLFQ" Path ="IsChecked"/>

--- a/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml.cs
@@ -177,6 +177,7 @@ namespace MetaMorpheusGUI
             CheckBoxNoOneHitWonders.IsChecked = task.SearchParameters.NoOneHitWonders;
             CheckBoxNoQuant.IsChecked = !task.SearchParameters.DoQuantification;
             CheckBoxLFQ.IsChecked = task.SearchParameters.DoQuantification;
+            CheckBoxQuantifyAmbiguousPeptides.IsChecked = task.SearchParameters.QuantifyAmbiguousPeptides;
             // If Spectral Recovery is enabled
             if (task.SearchParameters.WriteSpectralLibrary & task.SearchParameters.MatchBetweenRuns)
             {
@@ -599,6 +600,7 @@ namespace MetaMorpheusGUI
             TheTask.SearchParameters.DoQuantification = !CheckBoxNoQuant.IsChecked.Value;
             TheTask.SearchParameters.DoSpectralRecovery = CheckBoxLFQwSpectralRecovery.IsChecked.Value;
             TheTask.SearchParameters.Normalize = CheckBoxNormalize.IsChecked.Value;
+            TheTask.SearchParameters.QuantifyAmbiguousPeptides = CheckBoxNormalize.IsChecked.Value;
             TheTask.SearchParameters.MatchBetweenRuns = CheckBoxMatchBetweenRuns.IsChecked.Value;
             TheTask.SearchParameters.ModPeptidesAreDifferent = ModPepsAreUnique.IsChecked.Value;
             TheTask.SearchParameters.QuantifyPpmTol = double.Parse(PeakFindingToleranceTextBox.Text, CultureInfo.InvariantCulture);

--- a/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml.cs
@@ -600,7 +600,7 @@ namespace MetaMorpheusGUI
             TheTask.SearchParameters.DoQuantification = !CheckBoxNoQuant.IsChecked.Value;
             TheTask.SearchParameters.DoSpectralRecovery = CheckBoxLFQwSpectralRecovery.IsChecked.Value;
             TheTask.SearchParameters.Normalize = CheckBoxNormalize.IsChecked.Value;
-            TheTask.SearchParameters.QuantifyAmbiguousPeptides = CheckBoxNormalize.IsChecked.Value;
+            TheTask.SearchParameters.QuantifyAmbiguousPeptides = CheckBoxQuantifyAmbiguousPeptides.IsChecked.Value;
             TheTask.SearchParameters.MatchBetweenRuns = CheckBoxMatchBetweenRuns.IsChecked.Value;
             TheTask.SearchParameters.ModPeptidesAreDifferent = ModPepsAreUnique.IsChecked.Value;
             TheTask.SearchParameters.QuantifyPpmTol = double.Parse(PeakFindingToleranceTextBox.Text, CultureInfo.InvariantCulture);

--- a/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
+++ b/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="itext7" Version="7.1.13" />
-    <PackageReference Include="mzLib" Version="1.0.538" />
+    <PackageReference Include="mzLib" Version="1.0.539" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.0.0" />
     <PackageReference Include="Svg" Version="3.4.3" />
   </ItemGroup>

--- a/MetaMorpheus/MetaMorpheusSetup/Product.wxs
+++ b/MetaMorpheus/MetaMorpheusSetup/Product.wxs
@@ -193,8 +193,8 @@
       <Component Id="src_MzLibUtil.dll" Guid="9475fcb2-63bd-490c-8441-17a1760869ac">
         <File Id="src_MzLibUtil.dll" Name="MzLibUtil.dll" Source="$(var.GUI_TargetDir)MzLibUtil.dll" />
       </Component>
-      <Component Id="src_MzML.dll" Guid="40c12490-638a-41b9-9e0c-05e949236a5a">
-        <File Id="src_MzML.dll" Name="MzML.dll" Source="$(var.GUI_TargetDir)MzML.dll" />
+      <Component Id="src_Readers.dll" Guid ="05E6CB78-4AF7-4BB0-8B08-87AD29539E17">
+        <File Id="src_Readers.dll" Name="Readers.dll" Source="$(var.GUI_TargetDir)Readers.dll" />
       </Component>
       <Component Id="src_NetSerializer.dll" Guid="9eddc340-0dcb-415a-85f4-322f0eaeee4b">
         <File Id="src_NetSerializer.dll" Name="NetSerializer.dll" Source="$(var.GUI_TargetDir)NetSerializer.dll" />
@@ -235,10 +235,7 @@
       <Component Id="src_SharpLearning.RandomForest.dll" Guid="f86fdc0c-6a23-4e4f-803b-0012aaa418e7">
         <File Id="src_SharpLearning.RandomForest.dll" Name="SharpLearning.RandomForest.dll" Source="$(var.GUI_TargetDir)SharpLearning.RandomForest.dll" />
       </Component>
-      <Component Id="src_Mgf.dll" Guid="B4EB5CEA-CFCA-40C7-A915-DB3B9EF53775">
-        <File Id="src_Mgf.dll" Name="Mgf.dll" Source="$(var.GUI_TargetDir)Mgf.dll" />
-      </Component>
-      <Component Id="src_OxyPlot.dll" Guid="1B25D408-13DB-4A9E-A49E-B0A7FC8C05A6">
+	    <Component Id="src_OxyPlot.dll" Guid="1B25D408-13DB-4A9E-A49E-B0A7FC8C05A6">
         <File Id="src_OxyPlot.dll" Name="OxyPlot.dll" Source="$(var.GUI_TargetDir)OxyPlot.dll" />
       </Component>
       <Component Id="src_OxyPlot.Wpf.dll" Guid="2052508D-D83C-45D7-8C9C-9211F97A8949">
@@ -283,10 +280,7 @@
       <Component Id="src_ThermoFisher.CommonCore.RawFileReader.dll" Guid="F5EDAA70-06CD-49E7-932F-016C679B07C7">
         <File Id="src_ThermoFisher.CommonCore.RawFileReader.dll" Name="ThermoFisher.CommonCore.RawFileReader.dll" Source="$(var.GUI_TargetDir)ThermoFisher.CommonCore.RawFileReader.dll" />
       </Component>
-      <Component Id="src_ThermoRawFileReader.dll" Guid="4BE9A662-4CD1-4E5B-8234-0734036A007E">
-        <File Id="src_ThermoRawFileReader.dll" Name="ThermoRawFileReader.dll" Source="$(var.GUI_TargetDir)ThermoRawFileReader.dll" />
-      </Component>
-      <Component Id="src_BayesianEstimation.dll" Guid="100F4A2E-F4FE-4D25-8C5F-66A7092A2622">
+	    <Component Id="src_BayesianEstimation.dll" Guid="100F4A2E-F4FE-4D25-8C5F-66A7092A2622">
         <File Id="src_BayesianEstimation.dll" Name="BayesianEstimation.dll" Source="$(var.GUI_TargetDir)BayesianEstimation.dll" />
       </Component>
       <Component Id="src_Microsoft.ML.Core.dll" Guid="A5B34A93-481B-4B6A-868C-A0DB916CB37C">

--- a/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationTask.cs
+++ b/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationTask.cs
@@ -9,6 +9,7 @@ using MzLibUtil;
 using Nett;
 using Proteomics;
 using Proteomics.Fragmentation;
+using Readers;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -176,7 +177,7 @@ namespace TaskLayer
                 myMsDataFile = engine.CalibratedDataFile;
 
                 // write the calibrated mzML file
-                MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, calibratedFilePath, CalibrationParameters.WriteIndexedMzml);
+                myMsDataFile.ExportAsMzML(calibratedFilePath, CalibrationParameters.WriteIndexedMzml);
                 myFileManager.DoneWithFile(originalUncalibratedFilePath);
 
                 // stats after calibration

--- a/MetaMorpheus/TaskLayer/MyFileManager.cs
+++ b/MetaMorpheus/TaskLayer/MyFileManager.cs
@@ -1,12 +1,10 @@
 ﻿using EngineLayer;
-using IO.Mgf;
-using IO.MzML;
-using IO.ThermoRawFileReader;
 using MassSpectrometry;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using Readers;
 
 namespace TaskLayer
 {
@@ -45,36 +43,9 @@ namespace TaskLayer
             // By now know that need to load this file!!!
             lock (FileLoadingLock) // Lock because reading is sequential
             {
-                if (Path.GetExtension(origDataFile).Equals(".mzML", StringComparison.OrdinalIgnoreCase))
-                {
-                    MyMsDataFiles[origDataFile] = Mzml.LoadAllStaticData(origDataFile, filter, commonParameters.MaxThreadsToUsePerFile);
-                }
-                else if (Path.GetExtension(origDataFile).Equals(".mgf", StringComparison.OrdinalIgnoreCase))
-                {
-                    MyMsDataFiles[origDataFile] = Mgf.LoadAllStaticData(origDataFile, filter);
-                }
-                else
-                {
-                    MyMsDataFiles[origDataFile] = ThermoRawFileReader.LoadAllStaticData(origDataFile, filter, commonParameters.MaxThreadsToUsePerFile);
-                }
-
+                MyMsDataFiles[origDataFile] = MsDataFileReader.GetDataFile(origDataFile)
+                    .LoadAllStaticData(filter, commonParameters.MaxThreadsToUsePerFile);
                 return MyMsDataFiles[origDataFile];
-            }
-        }
-
-        public DynamicDataConnection OpenDynamicDataConnection(string origDataFile)
-        {
-            if (Path.GetExtension(origDataFile).Equals(".mzML", StringComparison.OrdinalIgnoreCase))
-            {
-                return new MzmlDynamicData(origDataFile);
-            }
-            else if (Path.GetExtension(origDataFile).Equals(".mgf", StringComparison.OrdinalIgnoreCase))
-            {
-                return new MgfDynamicData(origDataFile);
-            }
-            else
-            {
-                return new ThermoDynamicData(origDataFile);
             }
         }
 

--- a/MetaMorpheus/TaskLayer/SearchTask/PostSearchAnalysisTask.cs
+++ b/MetaMorpheus/TaskLayer/SearchTask/PostSearchAnalysisTask.cs
@@ -482,6 +482,7 @@ namespace TaskLayer
                 allIdentifications: flashLFQIdentifications,
                 normalize: Parameters.SearchParameters.Normalize,
                 ppmTolerance: Parameters.SearchParameters.QuantifyPpmTol,
+                quantifyAmbiguousPeptides: Parameters.SearchParameters.QuantifyAmbiguousPeptides,
                 matchBetweenRunsPpmTolerance: Parameters.SearchParameters.QuantifyPpmTol,  // If these tolerances are not equivalent, then MBR will falsely classify peptides found in the initial search as MBR peaks
                 matchBetweenRuns: Parameters.SearchParameters.MatchBetweenRuns,
                 silent: true,

--- a/MetaMorpheus/TaskLayer/SearchTask/SearchParameters.cs
+++ b/MetaMorpheus/TaskLayer/SearchTask/SearchParameters.cs
@@ -17,6 +17,7 @@ namespace TaskLayer
             DoQuantification = true;
             DoSpectralRecovery = false;
             QuantifyPpmTol = 5;
+            QuantifyAmbiguousPeptides = false;
             SearchTarget = true;
             DecoyType = DecoyType.Reverse;
             DoHistogramAnalysis = false;
@@ -66,6 +67,7 @@ namespace TaskLayer
         public bool MatchBetweenRuns { get; set; }
         public bool Normalize { get; set; }
         public double QuantifyPpmTol { get; set; }
+        public bool QuantifyAmbiguousPeptides { get; set; }
         public bool DoHistogramAnalysis { get; set; }
         public bool SearchTarget { get; set; }
         public DecoyType DecoyType { get; set; }

--- a/MetaMorpheus/TaskLayer/TaskLayer.csproj
+++ b/MetaMorpheus/TaskLayer/TaskLayer.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="2.0.0" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="2.0.0" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.538" />
+    <PackageReference Include="mzLib" Version="1.0.539" />
     <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>

--- a/MetaMorpheus/Test/AmbiguityTest.cs
+++ b/MetaMorpheus/Test/AmbiguityTest.cs
@@ -12,6 +12,7 @@ using System.IO;
 using System.Linq;
 using TaskLayer;
 using UsefulProteomicsDatabases;
+using Readers;
 
 namespace Test
 {
@@ -81,7 +82,7 @@ namespace Test
             PeptideWithSetModifications pepWithSetMods = targetProtein.Digest(new DigestionParams(), null, null).First();
             TestDataFile msFile = new TestDataFile(pepWithSetMods);
             string mzmlName = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\PEPTIDE.mzML");
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(msFile, mzmlName, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(msFile, mzmlName, false);
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestContaminantAmbiguityOutput");
 
             //run a full modern search using two databases (the same database) but one is called a target and the other is called a contaminant

--- a/MetaMorpheus/Test/BinGenerationTest.cs
+++ b/MetaMorpheus/Test/BinGenerationTest.cs
@@ -57,7 +57,7 @@ namespace Test
 
             List<Protein> proteinList = new List<Protein> { prot1, prot2, prot3, prot4 };
 
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, mzmlFilePath, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, mzmlFilePath, false);
             ProteinDbWriter.WriteXmlDatabase(new Dictionary<string, HashSet<Tuple<int, Modification>>>(), proteinList, proteinDbFilePath);
 
             string output_folder = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestBinGeneration");
@@ -120,8 +120,8 @@ namespace Test
 
             List<Protein> proteinList = new List<Protein> { prot1 };
 
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlFilePath1, false);
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile2, mzmlFilePath2, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlFilePath1, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile2, mzmlFilePath2, false);
             ProteinDbWriter.WriteXmlDatabase(new Dictionary<string, HashSet<Tuple<int, Modification>>>(), proteinList, proteinDbFilePath);
 
             string output_folder = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestProteinSplitAcrossFiles");

--- a/MetaMorpheus/Test/CoIsolationTests.cs
+++ b/MetaMorpheus/Test/CoIsolationTests.cs
@@ -10,6 +10,7 @@ using Proteomics.ProteolyticDigestion;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Readers;
 using TaskLayer;
 
 namespace Test
@@ -56,7 +57,7 @@ namespace Test
             double isolationMZ = selectedIonMz;
             Scans[1] = new MsDataScan(MS2, 2, 2, false, Polarity.Positive, 2.0, new MzRange(100, 1500), "second spectrum", MZAnalyzerType.Unknown, MS2.SumOfAllY, null, null, "scan=2", selectedIonMz, null, null, isolationMZ, 2.5, DissociationType.HCD, 1, null);
 
-            var myMsDataFile = new MsDataFile(Scans, null);
+            var myMsDataFile = new GenericMsDataFile(Scans, null);
             
             var listOfSortedms2Scans = MetaMorpheusTask.GetMs2Scans(myMsDataFile, null, new CommonParameters(deconvolutionIntensityRatio: 50)).OrderBy(b => b.PrecursorMass).ToArray();
             

--- a/MetaMorpheus/Test/GPTMDengineTest.cs
+++ b/MetaMorpheus/Test/GPTMDengineTest.cs
@@ -186,7 +186,7 @@ namespace Test
             Assert.AreEqual("PEK[type:acetyl on K]TID", pepWithSetMods1.FullSequence);//this might be base sequence
             MsDataFile myMsDataFile = new TestDataFile(new List<PeptideWithSetModifications> { pepWithSetMods1 });
             string mzmlName = @"hello.mzML";
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, mzmlName, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, mzmlName, false);
 
             //run!
             var engine = new EverythingRunnerEngine(taskList, new List<string> { mzmlName },

--- a/MetaMorpheus/Test/MatchIonsOfAllCharges.cs
+++ b/MetaMorpheus/Test/MatchIonsOfAllCharges.cs
@@ -3,7 +3,7 @@ using System.IO;
 using System.Linq;
 using EngineLayer;
 using EngineLayer.ClassicSearch;
-using IO.MzML;
+using Readers;
 using MzLibUtil;
 using NUnit.Framework;
 using Proteomics;

--- a/MetaMorpheus/Test/MetaDrawSettingsAndViewsTest.cs
+++ b/MetaMorpheus/Test/MetaDrawSettingsAndViewsTest.cs
@@ -1,7 +1,7 @@
 ﻿using EngineLayer;
 using GuiFunctions;
 using GuiFunctions.ViewModels.Legends;
-using IO.MzML;
+using Readers;
 using NUnit.Framework;
 using OxyPlot;
 using Proteomics.Fragmentation;

--- a/MetaMorpheus/Test/Multiplex_Labeling_TMT_iTRAQ.cs
+++ b/MetaMorpheus/Test/Multiplex_Labeling_TMT_iTRAQ.cs
@@ -1,6 +1,6 @@
 ﻿using Chemistry;
 using EngineLayer;
-using IO.MzML;
+using Readers;
 using MassSpectrometry;
 using NUnit.Framework;
 using Proteomics;

--- a/MetaMorpheus/Test/MyTaskTest.cs
+++ b/MetaMorpheus/Test/MyTaskTest.cs
@@ -94,7 +94,7 @@ namespace Test
             Protein proteinWithChain = new("MAACNNNCAA", "accession3", "organism", new List<Tuple<string, string>>(), new Dictionary<int, List<Modification>>(), new List<ProteolysisProduct> { new ProteolysisProduct(4, 8, "chain") }, "name2", "fullname2");
 
             string mzmlName = @"ok.mzML";
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, mzmlName, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, mzmlName, false);
             string xmlName = "okk.xml";
             ProteinDbWriter.WriteXmlDatabase(new Dictionary<string, HashSet<Tuple<int, Modification>>>(), new List<Protein> { ParentProtein, proteinWithChain }, xmlName);
 
@@ -186,12 +186,12 @@ namespace Test
             MsDataFile myMsDataFile1 = new TestDataFile(new List<PeptideWithSetModifications> { pepWithSetMods1, pepWithSetMods2, digestedList[1] });
 
             string mzmlName1 = @"ok1.mzML";
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName1, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName1, false);
 
             MsDataFile myMsDataFile2 = new TestDataFile(new List<PeptideWithSetModifications> { pepWithSetMods1, pepWithSetMods2, digestedList[1] });
 
             string mzmlName2 = @"ok2.mzML";
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile2, mzmlName2, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile2, mzmlName2, false);
 
             Protein proteinWithChain1 = new("MAACNNNCAA", "accession3", "organism", new List<Tuple<string, string>>(), new Dictionary<int, List<Modification>>(), new List<ProteolysisProduct> { new ProteolysisProduct(4, 8, "chain") }, "name2", "fullname2", false, false, new List<DatabaseReference>(), new List<SequenceVariation>(), null);
             Protein proteinWithChain2 = new("MAACNNNCAA", "accession3", "organism", new List<Tuple<string, string>>(), new Dictionary<int, List<Modification>>(), new List<ProteolysisProduct> { new ProteolysisProduct(4, 8, "chain") }, "name2", "fullname2", false, false, new List<DatabaseReference>(), new List<SequenceVariation>(), null);
@@ -270,7 +270,7 @@ namespace Test
 
             myMsDataFile.ReplaceFirstScanArrays(mz, intensities);
 
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, mzmlName, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, mzmlName, false);
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestMakeSureFdrDoesntSkip");
             Directory.CreateDirectory(outputFolder);
 
@@ -332,7 +332,7 @@ namespace Test
                 PeptideWithSetModifications targetWithUnknownMod = targetDigested[1];
                 MsDataFile myMsDataFile = new TestDataFile(new List<PeptideWithSetModifications> { targetGood, targetWithUnknownMod });
 
-                IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, mzmlName, false);
+                Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, mzmlName, false);
             }
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestMakeSureGptmdTaskMatchesExactMatchesTest");
             Directory.CreateDirectory(outputFolder);
@@ -412,7 +412,7 @@ namespace Test
             //Finally Write MZML file
             MsDataFile myMsDataFile = new TestDataFile(new List<PeptideWithSetModifications> { setList1[0], setList1[1], setList1[2], setList1[3], setList1[0], setList1[1] });
             string mzmlName = @"singleProteinWithRepeatedMods.mzML";
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, mzmlName, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, mzmlName, false);
 
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestMultipleFilesRunner");
             var engine = new EverythingRunnerEngine(taskList, new List<string> { mzmlName }, new List<DbForTask> { new DbForTask(xmlName, false) }, outputFolder);

--- a/MetaMorpheus/Test/OutputTest.cs
+++ b/MetaMorpheus/Test/OutputTest.cs
@@ -1,5 +1,5 @@
 ﻿using EngineLayer;
-using IO.MzML;
+using Readers;
 using MassSpectrometry;
 using MzLibUtil;
 using Nett;

--- a/MetaMorpheus/Test/QuantificationTest.cs
+++ b/MetaMorpheus/Test/QuantificationTest.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using Readers;
 using TaskLayer;
 
 namespace Test
@@ -205,8 +206,8 @@ namespace Test
 
                         // write the .mzML
                         string fullPath = Path.Combine(unitTestFolder, fileToWrite);
-                        IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(
-                            new MsDataFile(scans, new SourceFile(@"scan number only nativeID format", "mzML format", null, "SHA-1", @"C:\fake.mzML", null)),
+                        Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(
+                            new GenericMsDataFile(scans, new SourceFile(@"scan number only nativeID format", "mzML format", null, "SHA-1", @"C:\fake.mzML", null)),
                             fullPath, false);
 
                         SpectraFileInfo spectraFileInfo = new(fullPath, condition, b, r, f);

--- a/MetaMorpheus/Test/SearchEngineTests.cs
+++ b/MetaMorpheus/Test/SearchEngineTests.cs
@@ -4,7 +4,7 @@ using EngineLayer.ClassicSearch;
 using EngineLayer.Indexing;
 using EngineLayer.ModernSearch;
 using EngineLayer.NonSpecificEnzymeSearch;
-using IO.MzML;
+using Readers;
 using MassSpectrometry;
 using MzLibUtil;
 using Nett;
@@ -1810,7 +1810,7 @@ namespace Test
             var spectrum = new MzSpectrum(new double[1], new double[1], false);
             scans[0] = new MsDataScan(spectrum, 1, 1, true, Polarity.Positive, 1.0, new MzRange(0, 1), "", MZAnalyzerType.Orbitrap,
                 1, null, null, "");
-            var fileWithNoMs2Scans = new MsDataFile(scans, null);
+            var fileWithNoMs2Scans = new Readers.GenericMsDataFile(scans, null);
             var ms2Scans = MetaMorpheusTask.GetMs2Scans(fileWithNoMs2Scans, null, new CommonParameters()).OrderBy(b => b.PrecursorMass).ToArray();
             Assert.That(!ms2Scans.Any());
         }
@@ -1838,7 +1838,7 @@ namespace Test
 
             MsDataFile myMsDataFile1 = new TestDataFile(new List<PeptideWithSetModifications> { peptide, peptide2, peptide3, peptide4, peptide5, peptide6, peptide7 });
             string mzmlName = @"test.mzML";
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
 
             string xmlName = "testDb.xml";
             Protein theProtein = new Protein("PEPTIDEK", "accession1");

--- a/MetaMorpheus/Test/SearchWithPeptidesAddedInParsimony.cs
+++ b/MetaMorpheus/Test/SearchWithPeptidesAddedInParsimony.cs
@@ -73,7 +73,7 @@ namespace Test
 
             MsDataFile myMsDataFile = new TestDataFile(new List<PeptideWithSetModifications> { pepMA, pepMG, pepMA111 });
 
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, mzmlName, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, mzmlName, false);
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestSearchWithPeptidesAddedInParsimony");
             Directory.CreateDirectory(outputFolder);
 

--- a/MetaMorpheus/Test/SilacTest.cs
+++ b/MetaMorpheus/Test/SilacTest.cs
@@ -41,7 +41,7 @@ namespace Test
             List<List<double>> massDifferences = new() { new List<double> { heavierArginine.MonoisotopicMass - heavyArginine.MonoisotopicMass } };
             MsDataFile myMsDataFile1 = new TestDataFile(heavyPeptide, massDifferences);
             string mzmlName = @"silac.mzML";
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
 
             string xmlName = "SilacDb.xml";
             Protein theProtein = new("PEPTIDER", "accession1");
@@ -112,7 +112,7 @@ namespace Test
 
             MsDataFile myMsDataFile1 = new TestDataFile(lightPeptide, massDifferences, largePeptideSoDoubleFirstPeakIntensityAndAddAnotherPeak: true);
             string mzmlName = @"silac.mzML";
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
 
             string xmlName = "SilacDb.xml";
             Protein theProtein = new Protein("MPRTEINRSEQENEWITHAKANDANRANDSMSTFF", "accession1");
@@ -159,7 +159,7 @@ namespace Test
 
             myMsDataFile1 = new TestDataFile(heavyPeptide, massDifferences);
             mzmlName = @"silac.mzML";
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
 
             Directory.CreateDirectory(outputFolder);
             task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1");
@@ -190,12 +190,12 @@ namespace Test
 
             MsDataFile myMsDataFile1 = new TestDataFile(lightPeptide, massDifferences1);
             string mzmlName = @"silac.mzML";
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
 
             //create another file to test the handling is done correctly
             MsDataFile myMsDataFile2 = new TestDataFile(lightPeptide, massDifferences2);
             string mzmlName2 = @"silacPart2.mzML";
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile2, mzmlName2, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile2, mzmlName2, false);
 
             string xmlName = "SilacDb.xml";
             Protein theProtein = new Protein("PEPTIDEK", "accession1");
@@ -247,7 +247,7 @@ namespace Test
             List<PeptideWithSetModifications> heavyPeptide = new List<PeptideWithSetModifications> { new PeptideWithSetModifications("PEPTIDEa", new Dictionary<string, Modification>()) }; //has the additional, but not the original
             massDifferences1 = new List<List<double>> { new List<double> { (lightLysine.MonoisotopicMass - heavyLysine.MonoisotopicMass) } }; //have to reset because it gets modified
             myMsDataFile1 = new TestDataFile(heavyPeptide, massDifferences1);
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
 
             //make an ambiguous database
             Protein theProtein2 = new Protein("PEPTLDEKPEPTIDEK", "accession2");
@@ -310,7 +310,7 @@ namespace Test
 
             MsDataFile myMsDataFile1 = new TestDataFile(lightPeptide, massDifferences);
             string mzmlName = @"silac.mzML";
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
 
             string xmlName = "SilacDb.xml";
             Protein theProtein = new Protein("PEPTIDEK", "accession1");
@@ -356,12 +356,12 @@ namespace Test
             string directoryName = "testDirectory";
             Directory.CreateDirectory(directoryName);
             string mzmlName = Path.Combine(directoryName, "silac.mzML");
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
 
             //create another file to test the handling is done correctly
             MsDataFile myMsDataFile2 = new TestDataFile(mixedPeptide, massDifferences);
             string mzmlName2 = @"silacPart2.mzML";
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile2, mzmlName2, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile2, mzmlName2, false);
 
             string xmlName = "SilacDb.xml";
             Protein theProtein = new Protein("PEPEPEPTKIDEKPEPTKIDEKA", "accession1");
@@ -404,7 +404,7 @@ namespace Test
             massDifferences = new List<List<double>> { new List<double> { massShift, massShift * -1 } }; // -6, +6
 
             myMsDataFile1 = new TestDataFile(mixedPeptide, massDifferences);
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
             task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1").ToString();
 
             output = File.ReadAllLines(TestContext.CurrentContext.TestDirectory + @"/TestSilac/AllQuantifiedPeptides.tsv");
@@ -444,7 +444,7 @@ namespace Test
                 new List<double>{7,3} //implies the Ph is AT LEAST 0.7, which conflicts with 0.5 (H/L)
             };
             myMsDataFile1 = new TestDataFile(peptides, massDifferences, intensities);
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
             task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1").ToString();
 
             output = File.ReadAllLines(TestContext.CurrentContext.TestDirectory + @"/TestSilac/AllQuantifiedPeptides.tsv");
@@ -497,7 +497,7 @@ namespace Test
             List<List<double>> massDifferences = new List<List<double>> { new List<double>() };
             MsDataFile myMsDataFile1 = new TestDataFile(mixedPeptide, massDifferences);
             string mzmlName = @"silac.mzML";
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
 
             string xmlName = "SilacDb.xml";
             Protein theProtein = new Protein("PEPTKIDEK", "accession1");
@@ -554,7 +554,7 @@ namespace Test
             PeptideWithSetModifications sixPeptide = new PeptideWithSetModifications("PKEaPaTKIKDa", new Dictionary<string, Modification>());
             MsDataFile myMsDataFile1 = new TestDataFile(new List<PeptideWithSetModifications> { zeroPeptide, onePeptide, sixPeptide, fivePeptide });
             string mzmlName = @"silac.mzML";
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
 
             string xmlName = "SilacDb.xml";
             Protein theProtein = new Protein("PEPTIDERPEPTIDEKPKEKPKTKIKDKEK", "accession1");
@@ -599,7 +599,7 @@ namespace Test
             List<List<double>> precursorIntensities = new List<List<double>> { new List<double> { 5, 1.5, 4, 2, 3, 1.5, 2, 2, 0, 3 } };
             MsDataFile myMsDataFile1 = new TestDataFile(lightPeptide, massDifferences, precursorIntensities);
             string mzmlName = @"silac.mzML";
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
 
             string xmlName = "SilacDb.xml";
             Protein theProtein = new Protein("PEPTIDEK", "accession1");
@@ -615,7 +615,7 @@ namespace Test
             //TEST for blips, where two peaks are found for a single identification
             massDifferences = new List<List<double>> { new List<double> { (heavyLysine.MonoisotopicMass - lightLysine.MonoisotopicMass) } }; //must be reset, since the method below edits it
             myMsDataFile1 = new TestDataFile(lightPeptide, massDifferences, precursorIntensities, 2);
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile1, mzmlName, false);
             task.RunTask(outputFolder, new List<DbForTask> { new DbForTask(xmlName, false) }, new List<string> { mzmlName }, "taskId1").ToString();
             output = File.ReadAllLines(TestContext.CurrentContext.TestDirectory + @"/TestSilac/AllQuantifiedPeptides.tsv");
             Assert.IsTrue(output[1].Contains("\t24500000\t12250000\t")); //intensities will be twice as large as before, but still the same ratio

--- a/MetaMorpheus/Test/Test.csproj
+++ b/MetaMorpheus/Test/Test.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.ML" Version="2.0.0" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="2.0.0" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="2.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.538" />
+    <PackageReference Include="mzLib" Version="1.0.539" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />

--- a/MetaMorpheus/Test/TestDataFile.cs
+++ b/MetaMorpheus/Test/TestDataFile.cs
@@ -6,10 +6,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Readers;
 
 namespace Test
 {
-    internal class TestDataFile : MsDataFile
+    internal class TestDataFile : GenericMsDataFile
     {
         public TestDataFile() : base(2, new SourceFile(null, null, null, null, null))
         {

--- a/MetaMorpheus/Test/TestTopDown.cs
+++ b/MetaMorpheus/Test/TestTopDown.cs
@@ -5,7 +5,7 @@ using EngineLayer;
 using EngineLayer.ClassicSearch;
 using EngineLayer.Indexing;
 using EngineLayer.ModernSearch;
-using IO.MzML;
+using Readers;
 using MzLibUtil;
 using NUnit.Framework;
 using Proteomics;

--- a/MetaMorpheus/Test/VariantSearchTests.cs
+++ b/MetaMorpheus/Test/VariantSearchTests.cs
@@ -87,7 +87,7 @@ namespace Test
             string mzmlName = $"ajgdiv{proteinIdx.ToString()}.mzML";
             MsDataFile myMsDataFile = new TestDataFile(new List<PeptideWithSetModifications> { pep });
 
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, mzmlName, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, mzmlName, false);
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, $"TestSearchWithVariants{proteinIdx.ToString()}");
             Directory.CreateDirectory(outputFolder);
 
@@ -117,7 +117,7 @@ namespace Test
             string mzmlName = $"ajgdiv{filename}{decoyType.ToString()}.mzML";
             MsDataFile myMsDataFile = new TestDataFile(new List<PeptideWithSetModifications> { pep });
 
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, mzmlName, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, mzmlName, false);
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, $"TestSearchWithVariants{filename}{decoyType.ToString()}");
             Directory.CreateDirectory(outputFolder);
 

--- a/MetaMorpheus/Test/XLTest.cs
+++ b/MetaMorpheus/Test/XLTest.cs
@@ -18,6 +18,7 @@ using System.IO;
 using System.IO.Compression;
 using System.Linq;
 using System.Text;
+using Readers;
 using TaskLayer;
 using UsefulProteomicsDatabases;
 
@@ -1527,7 +1528,7 @@ namespace Test
             Assert.AreEqual(arrayIndex, CrosslinkSearchEngine.BinarySearchGetIndex(massArray, targetMass));
         }
 
-        internal class XLTestDataFile : MsDataFile
+        internal class XLTestDataFile : GenericMsDataFile
         {
             //Create DSSO crosslinked fake MS data. Include single, deadend, loop, inter, intra crosslinks ms2 data for match.
             public XLTestDataFile() : base(2, new SourceFile(null, null, null, null, null))
@@ -1595,7 +1596,7 @@ namespace Test
             }
         }
 
-        internal class XLTestDataFileDiffSite : MsDataFile
+        internal class XLTestDataFileDiffSite : GenericMsDataFile
         {
             //Create DSSO crosslinked fake MS data. Include single, deadend, loop, inter, intra crosslinks ms2 data for match.
             public XLTestDataFileDiffSite() : base(2, new SourceFile(null, null, null, null, null))

--- a/MetaMorpheus/Test/gptmdPrunedBdTests.cs
+++ b/MetaMorpheus/Test/gptmdPrunedBdTests.cs
@@ -160,7 +160,7 @@ namespace Test
             Assert.AreEqual("PEP[ConnorModType:ConnorMod on P]TID", pepWithSetMods1.FullSequence);//this might be base sequence
             MsDataFile myMsDataFile = new TestDataFile(new List<PeptideWithSetModifications> { pepWithSetMods1 });
             string mzmlName = @"hello.mzML";
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, mzmlName, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, mzmlName, false);
 
             //run!
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestPrunedDatabase");
@@ -293,7 +293,7 @@ namespace Test
             MsDataFile myMsDataFile = new TestDataFile(new List<PeptideWithSetModifications>
             { pepWithSetMods1, pepWithSetMods2, pepWithSetMods3, pepWithSetMods4, pepWithSetMods5 });
             string mzmlName = @"newMzml.mzML";
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, mzmlName, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, mzmlName, false);
 
             //make sure this runs correctly
             //run!
@@ -382,7 +382,7 @@ namespace Test
             MsDataFile myMsDataFile = new TestDataFile(new List<PeptideWithSetModifications>
             { peptideObserved});
             string mzmlName = @"newMzml.mzML";
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, mzmlName, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, mzmlName, false);
                         
             modList.Add("test", Hash);
             
@@ -487,7 +487,7 @@ namespace Test
             MsDataFile myMsDataFile = new TestDataFile(new List<PeptideWithSetModifications>
             { peptideObserved});
             string mzmlName = @"newMzml.mzML";
-            IO.MzML.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, mzmlName, false);
+            Readers.MzmlMethods.CreateAndWriteMyMzmlWithCalibratedSpectra(myMsDataFile, mzmlName, false);
 
             modList.Add("test", Hash);
 


### PR DESCRIPTION
Adds the option to quantify ambiguous peptides.

Also, updates mzLib to 1.0.539
