### PR TITLE
Added null checks to enable display of XL results

### DIFF
--- a/MetaMorpheus/GUI/MetaDraw/MetaDraw.xaml.cs
+++ b/MetaMorpheus/GUI/MetaDraw/MetaDraw.xaml.cs
@@ -1,3 +1,4 @@
+using Easy.Common.Extensions;
 using EngineLayer;
 using GuiFunctions;
 using Nett;
@@ -261,7 +262,10 @@ namespace MetaMorpheusGUI
             {
                 
                 int descriptionLineCount = MetaDrawSettings.SpectrumDescription.Count(p => p.Value);
-                descriptionLineCount += (int)Math.Floor((psm.ProteinName.Length - 20) / 26.0);
+                if (psm.ProteinName.IsNotNullOrEmptyOrWhiteSpace())
+                {
+                    descriptionLineCount += (int)Math.Floor((psm.ProteinName.Length - 20) / 26.0);
+                }
                 if (psm.ProteinAccession.Length > 10)
                     descriptionLineCount++;
                 double verticalOffset = descriptionLineCount * 14;

--- a/MetaMorpheus/GuiFunctions/MetaDraw/DrawnSequence.cs
+++ b/MetaMorpheus/GuiFunctions/MetaDraw/DrawnSequence.cs
@@ -66,11 +66,13 @@ namespace GuiFunctions
             }
             double canvasWidth = SequenceDrawingCanvas.Width;
             int spacing = 12;
+            int psmStartResidue = psm.StartAndEndResiduesInProtein != null
+                    ? int.Parse(psm.StartAndEndResiduesInProtein.Split("to")[0].Replace("[", ""))
+                    : 0;
 
             // draw initial amino acid number
             if (stationary && MetaDrawSettings.DrawNumbersUnderStationary)
             {
-                int psmStartResidue = int.Parse(psm.StartAndEndResiduesInProtein.Split("to")[0].Replace("[", ""));
                 var startAA = (MetaDrawSettings.FirstAAonScreenIndex + psmStartResidue).ToString().ToCharArray().Reverse().ToArray();
                 double x = 22;
 
@@ -108,7 +110,6 @@ namespace GuiFunctions
             // draw final amino acid number
             if (stationary && MetaDrawSettings.DrawNumbersUnderStationary)
             {
-                int psmStartResidue = int.Parse(psm.StartAndEndResiduesInProtein.Split("to")[0].Replace("[", ""));
                 var endAA = (MetaDrawSettings.FirstAAonScreenIndex + MetaDrawSettings.NumberOfAAOnScreen + psmStartResidue - 1).ToString();
                 canvasWidth += spacing;
                 double x = canvasWidth;


### PR DESCRIPTION
MetaDraw was crashing when you attempted to view XL results. I added a couple of null checks that resolved the issue (#2289.)

MetaDraw was and continues to crash when attempting to read in the Deadends.tsv output from XLSearchTask. This is due to dead ends being recorded as an unrecognized modification. Should maybe be addressed at some point, but it's outside the scope of this PR.