### PR TITLE
Changed the main window to own the subsequent windows

### DIFF
--- a/MetaMorpheus/GUI/MainWindow.xaml.cs
+++ b/MetaMorpheus/GUI/MainWindow.xaml.cs
@@ -1751,6 +1751,7 @@ namespace MetaMorpheusGUI
             }
 
             // save the task to the task collection
+            dialog.Owner = this;
             if (dialog.ShowDialog() == true)
             {
                 switch (taskType)


### PR DESCRIPTION
This should make the task windows (and MetaDraw) pop up in front of the main window