### PR TITLE
Updated to MzLib 1.0.541 and updated one unit test

### DIFF
--- a/MetaMorpheus/CMD/CMD.csproj
+++ b/MetaMorpheus/CMD/CMD.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="2.0.0" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="2.0.0" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.539" />
+    <PackageReference Include="mzLib" Version="1.0.541" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>
 

--- a/MetaMorpheus/EngineLayer/EngineLayer.csproj
+++ b/MetaMorpheus/EngineLayer/EngineLayer.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="2.0.0" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="2.0.0" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.539" />
+    <PackageReference Include="mzLib" Version="1.0.541" />
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/MetaMorpheus/GUI/GUI.csproj
+++ b/MetaMorpheus/GUI/GUI.csproj
@@ -55,7 +55,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="2.0.0" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="2.0.0" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.539" />
+    <PackageReference Include="mzLib" Version="1.0.541" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0" />

--- a/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
+++ b/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="itext7" Version="7.1.13" />
-    <PackageReference Include="mzLib" Version="1.0.539" />
+    <PackageReference Include="mzLib" Version="1.0.541" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.0.0" />
     <PackageReference Include="Svg" Version="3.4.3" />
   </ItemGroup>

--- a/MetaMorpheus/TaskLayer/TaskLayer.csproj
+++ b/MetaMorpheus/TaskLayer/TaskLayer.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="2.0.0" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="2.0.0" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.539" />
+    <PackageReference Include="mzLib" Version="1.0.541" />
     <PackageReference Include="NetSerializer" Version="4.1.1" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>

--- a/MetaMorpheus/Test/GuiFunctionsTest.cs
+++ b/MetaMorpheus/Test/GuiFunctionsTest.cs
@@ -31,11 +31,13 @@ namespace Test
             Assert.AreEqual(expectedResult, filename);
         }
 
+        // Occasionally the downloaded files will change, and thus the expected result will need to be updated.
+        // To verify, download the database and count the number of entries.
+        // The expected result will be double the number of entries, due to decoys - 9/1/23 NB
         [Test]
-        [Parallelizable(ParallelScope.All)]
         [TestCase("UP000000280", true, true, true, true, "1.fasta.gz", 50)]
         [TestCase("UP000000280", true, true, true, false, "2.fasta", 50)]
-        [TestCase("UP000000280", true, true, false, true, "3.fasta.gz", 40)]
+        [TestCase("UP000000280", true, true, false, true, "3.fasta.gz", 50)]
         [TestCase("UP000000280", true, false, true, true, "4.xml.gz", 50)]
         [TestCase("UP000000280", false, true, true, true, "5.fasta.gz", 2)]
         [TestCase("UP000000280", true, true, false, false, "6.fasta", 50)]
@@ -85,7 +87,6 @@ namespace Test
 
 
             Assert.That(reader.Count == listCount);
-
         }
     }
 }

--- a/MetaMorpheus/Test/Test.csproj
+++ b/MetaMorpheus/Test/Test.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.ML" Version="2.0.0" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="2.0.0" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="2.0.0" />
-    <PackageReference Include="mzLib" Version="1.0.539" />
+    <PackageReference Include="mzLib" Version="1.0.541" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />


### PR DESCRIPTION
Updated to mzlib with reduced complexity scan accessing, this will reduce time to run calibration. 

Updated one unit test to no longer run in parallel as collisions were occurring with file accessing. 
Updated the same unit test to reflect a change in the total number of proteins present in the database as changed by uniprot. 

This version of mzlib will also correctly load fasts.gz files