### PR TITLE
Added SpectralAveraging.dll to project.wxs

### DIFF
--- a/MetaMorpheus/GUI/MainWindow.xaml
+++ b/MetaMorpheus/GUI/MainWindow.xaml
@@ -524,7 +524,7 @@
                         <Button Name="AddCalibTaskButton" Grid.Column="0" Content="+ADD CALIBRATION" HorizontalAlignment="Right" Click="AddCalibrateTaskButton_Click" 
                             Style="{StaticResource ImportantButtonStyle}" Margin="0,0,1,0" Width="140"/>
                         <Button Name="AddAveragingTaskButton" Grid.Column="1" Content="+AVERAGE SPECTRA" HorizontalAlignment="Right" Click="AddAveragingTaskButton_OnClick" 
-                                Style="{StaticResource ImportantButtonStyle}" Margin="0, 0, 1, 0" Width="140" FontSize="11" Visibility="Collapsed"/>
+                                Style="{StaticResource ImportantButtonStyle}" Margin="0, 0, 1, 0" Width="140" FontSize="11" Visibility="Visible"/>
                         <Button Name="AddGptmdTaskButton" Grid.Column="2" Content="+ADD PTM DISCOVERY" HorizontalAlignment="Right" Click="AddGPTMDTaskButton_Click" 
                             Style="{StaticResource ImportantButtonStyle}" Margin="0,0,1,0" Width="140"/>
                         <Button Name="AddSearchTaskButton" Grid.Column="3" Content="+ADD SEARCH" HorizontalAlignment="Right" Click="AddSearchTaskButton_Click" 

--- a/MetaMorpheus/MetaMorpheusSetup/Product.wxs
+++ b/MetaMorpheus/MetaMorpheusSetup/Product.wxs
@@ -181,6 +181,9 @@
       <Component Id="src_MassSpectrometry.dll" Guid="d6241678-3d48-4c7a-becf-9c1160fbe06b">
         <File Id="src_MassSpectrometry.dll" Name="MassSpectrometry.dll" Source="$(var.GUI_TargetDir)MassSpectrometry.dll" />
       </Component>
+      <Component Id="src_SpectralAveraging.dll" Guid="{1B9EB148-6FC3-4DA1-82D0-935EDE76E8D7}">
+        <File Id="src_SpectralAveraging.dll" Name="SpectralAveraging.dll" Source="$(var.GUI_TargetDir)SpectralAveraging.dll" />
+      </Component>
       <Component Id="src_MathNet.Numerics.dll" Guid="dea92905-719e-48e1-8a64-e845dca06dac">
         <File Id="src_MathNet.Numerics.dll" Name="MathNet.Numerics.dll" Source="$(var.GUI_TargetDir)MathNet.Numerics.dll" />
       </Component>


### PR DESCRIPTION
SpectralAveraging.dll was not being packaged properly with the Wix Installer. This PR adds the lines to the wix install script to package the new dll within mzlib correctly. 

Future work should dig into why this is not happening automatically. 