### PR TITLE
Invert q-value

### DIFF
--- a/MetaMorpheus/EngineLayer/FdrAnalysis/FdrAnalysisEngine.cs
+++ b/MetaMorpheus/EngineLayer/FdrAnalysis/FdrAnalysisEngine.cs
@@ -189,7 +189,7 @@ namespace EngineLayer.FdrAnalysis
             }
         }
         /// <summary>
-        /// This method gets the PSM count for each psm with q-value < 0.01 and adds that information to the individual psm.
+        /// This method gets the count of PSMs with the same full sequence (with q-value < 0.01) to include in the psmtsv output
         /// </summary>
         public void CountPsm(List<SpectralMatch> proteasePsms)
         {

--- a/MetaMorpheus/EngineLayer/FdrAnalysis/FdrAnalysisEngine.cs
+++ b/MetaMorpheus/EngineLayer/FdrAnalysis/FdrAnalysisEngine.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using EngineLayer;
+using EngineLayer.FdrAnalysis;
 
 namespace EngineLayer.FdrAnalysis
 {
@@ -10,13 +12,13 @@ namespace EngineLayer.FdrAnalysis
         private readonly int MassDiffAcceptorNumNotches;
         private readonly double ScoreCutoff;
         private readonly string AnalysisType;
-        private readonly string OutputFolder; // used for storing PEP training models
+        private readonly string OutputFolder; // used for storing PEP training models  
         private readonly bool DoPEP;
 
         public FdrAnalysisEngine(List<SpectralMatch> psms, int massDiffAcceptorNumNotches, CommonParameters commonParameters,
             List<(string fileName, CommonParameters fileSpecificParameters)> fileSpecificParameters, List<string> nestedIds, string analysisType = "PSM", bool doPEP = true, string outputFolder = null) : base(commonParameters, fileSpecificParameters, nestedIds)
         {
-            AllPsms = psms.OrderByDescending(p=>p).ToList();
+            AllPsms = psms.OrderByDescending(p => p).ToList();
             MassDiffAcceptorNumNotches = massDiffAcceptorNumNotches;
             ScoreCutoff = commonParameters.ScoreCutoff;
             AnalysisType = analysisType;
@@ -52,50 +54,14 @@ namespace EngineLayer.FdrAnalysis
                 QValueTraditional(psms);
                 if (psms.Count > 100)
                 {
+                    if (DoPEP)
+                    {
+                        Compute_PEPValue(myAnalysisResults);
+                    }
                     QValueInverted(psms);
                 }
-
-                // set q-value thresholds such that a lower scoring PSM can't have
-                // a higher confidence than a higher scoring PSM
-                //Populate min qValues
-                double qValueThreshold = 1.0;
-                double[] qValueNotchThreshold = new double[MassDiffAcceptorNumNotches + 1];
-                for (int i = 0; i < qValueNotchThreshold.Length; i++)
-                {
-                    qValueNotchThreshold[i] = 1.0;
-                }
-
-                for (int i = psms.Count - 1; i >= 0; i--)
-                {
-                    SpectralMatch psm = psms[i];
-
-                    // threshold q-values
-                    if (psm.FdrInfo.QValue > qValueThreshold)
-                    {
-                        psm.FdrInfo.QValue = qValueThreshold;
-                    }
-                    else if (psm.FdrInfo.QValue < qValueThreshold)
-                    {
-                        qValueThreshold = psm.FdrInfo.QValue;
-                    }
-
-                    // threshold notch q-values
-                    int notch = psm.Notch ?? MassDiffAcceptorNumNotches;
-                    if (psm.FdrInfo.QValueNotch > qValueNotchThreshold[notch])
-                    {
-                        psm.FdrInfo.QValueNotch = qValueNotchThreshold[notch];
-                    }
-                    else if (psm.FdrInfo.QValueNotch < qValueNotchThreshold[notch])
-                    {
-                        qValueNotchThreshold[notch] = psm.FdrInfo.QValueNotch;
-                    }
-                }
+                CountPsm(psms);
             }
-            if (DoPEP)
-            {
-                Compute_PEPValue(myAnalysisResults);
-            }
-            CountPsm();
         }
 
         private static void QValueInverted(List<SpectralMatch> psms)
@@ -194,7 +160,6 @@ namespace EngineLayer.FdrAnalysis
 
                     Compute_PEPValue_Based_QValue(AllPsms);
                 }
-                CountPsm(); // recounting Psm's after PEP based disambiguation
             }
 
             if (AnalysisType == "Peptide")
@@ -223,35 +188,31 @@ namespace EngineLayer.FdrAnalysis
                 psms[psmsArrayIndicies[i]].FdrInfo.PEP_QValue = Math.Round(qValue, 6);
             }
         }
-
-        public void CountPsm()
+        /// <summary>
+        /// This method gets the PSM count for each psm with q-value < 0.01 and adds that information to the individual psm.
+        /// </summary>
+        public void CountPsm(List<SpectralMatch> proteasePsms)
         {
-            var psmsGroupedByProtease = AllPsms.GroupBy(p => p.DigestionParams.Protease);
+            // exclude ambiguous psms and has a fdr cutoff = 0.01
+            var allUnambiguousPsms = proteasePsms.Where(psm => psm.FullSequence != null).ToList();
 
-            foreach (var proteasePsms in psmsGroupedByProtease)
+            var unambiguousPsmsLessThanOnePercentFdr = allUnambiguousPsms.Where(psm =>
+                    psm.FdrInfo.QValue <= 0.01
+                    && psm.FdrInfo.QValueNotch <= 0.01)
+                .GroupBy(p => p.FullSequence);
+
+            Dictionary<string, int> sequenceToPsmCount = new Dictionary<string, int>();
+
+            foreach (var sequenceGroup in unambiguousPsmsLessThanOnePercentFdr)
             {
-                // exclude ambiguous psms and has a fdr cutoff = 0.01
-                var allUnambiguousProteasePsms = proteasePsms.Where(p => p.FullSequence != null).ToList();
+                sequenceToPsmCount.TryAdd(sequenceGroup.First().FullSequence, sequenceGroup.Count());
+            }
 
-                var fullSequenceGroups = allUnambiguousProteasePsms.Where(p => p.FdrInfo.QValue < 0.01 && p.FdrInfo.QValueNotch < 0.01)
-                    .Select(p => p.FullSequence).GroupBy(s => s);
-
-                Dictionary<string, int> sequenceToPsmCount = new Dictionary<string, int>();
-                foreach (var fullSequence in fullSequenceGroups)
+            foreach (SpectralMatch psm in allUnambiguousPsms)
+            {
+                if (sequenceToPsmCount.TryGetValue(psm.FullSequence, out int count))
                 {
-                    sequenceToPsmCount.Add(fullSequence.Key, fullSequence.Count());
-                }
-
-                foreach (SpectralMatch psm in allUnambiguousProteasePsms)
-                {
-                    if (sequenceToPsmCount.TryGetValue(psm.FullSequence, out int count))
-                    {
-                        psm.PsmCount = count;
-                    }
-                    else
-                    {
-                        psm.PsmCount = 0;
-                    }
+                    psm.PsmCount = count;
                 }
             }
         }

--- a/MetaMorpheus/EngineLayer/PsmTsv/PsmTsvWriter.cs
+++ b/MetaMorpheus/EngineLayer/PsmTsv/PsmTsvWriter.cs
@@ -10,6 +10,7 @@ using System.Text;
 using Omics;
 using Omics.Modifications;
 
+
 namespace EngineLayer
 {
     public static class PsmTsvWriter
@@ -161,6 +162,7 @@ namespace EngineLayer
             }
         }
 
+        //The null-coalescing operator ?? returns the value of its left-hand operand if it isn't null; otherwise, it evaluates the right-hand operand and returns its result.
         internal static void AddBasicMatchData(Dictionary<string, string> s, SpectralMatch psm)
         {
             s[PsmTsvHeader.FileName] = psm == null ? " " : Path.GetFileNameWithoutExtension(psm.FullFilePath);
@@ -177,6 +179,7 @@ namespace EngineLayer
             s[PsmTsvHeader.Notch] = psm == null ? " " : Resolve(psm.BestMatchingBioPolymersWithSetMods.Select(p => p.Notch)).ResolvedString;
         }
 
+        //The null-coalescing operator ?? returns the value of its left-hand operand if it isn't null; otherwise, it evaluates the right-hand operand and returns its result.
         internal static void AddPeptideSequenceData(Dictionary<string, string> s, SpectralMatch sm, IReadOnlyDictionary<string, int> ModsToWritePruned)
         {
             bool pepWithModsIsNull = sm == null || sm.BestMatchingBioPolymersWithSetMods == null || !sm.BestMatchingBioPolymersWithSetMods.Any();
@@ -216,7 +219,7 @@ namespace EngineLayer
                         .Where(d => Includes(b, d))
                         .Select(d => $"{d.OneBasedBeginPosition.ToString()}-{d.OneBasedEndPosition.ToString()}")))).ResolvedString;
             }
-           
+
             s[PsmTsvHeader.Contaminant] = pepWithModsIsNull ? " " : Resolve(pepsWithMods.Select(b => b.Parent.IsContaminant ? "Y" : "N")).ResolvedString;
             s[PsmTsvHeader.Decoy] = pepWithModsIsNull ? " " : Resolve(pepsWithMods.Select(b => b.Parent.IsDecoy ? "Y" : "N")).ResolvedString;
             s[PsmTsvHeader.PeptideDesicription] = pepWithModsIsNull ? " " : Resolve(pepsWithMods.Select(b => b.Description)).ResolvedString;

--- a/MetaMorpheus/EngineLayer/PsmTsv/PsmTsvWriter.cs
+++ b/MetaMorpheus/EngineLayer/PsmTsv/PsmTsvWriter.cs
@@ -162,7 +162,6 @@ namespace EngineLayer
             }
         }
 
-        //The null-coalescing operator ?? returns the value of its left-hand operand if it isn't null; otherwise, it evaluates the right-hand operand and returns its result.
         internal static void AddBasicMatchData(Dictionary<string, string> s, SpectralMatch psm)
         {
             s[PsmTsvHeader.FileName] = psm == null ? " " : Path.GetFileNameWithoutExtension(psm.FullFilePath);
@@ -179,7 +178,6 @@ namespace EngineLayer
             s[PsmTsvHeader.Notch] = psm == null ? " " : Resolve(psm.BestMatchingBioPolymersWithSetMods.Select(p => p.Notch)).ResolvedString;
         }
 
-        //The null-coalescing operator ?? returns the value of its left-hand operand if it isn't null; otherwise, it evaluates the right-hand operand and returns its result.
         internal static void AddPeptideSequenceData(Dictionary<string, string> s, SpectralMatch sm, IReadOnlyDictionary<string, int> ModsToWritePruned)
         {
             bool pepWithModsIsNull = sm == null || sm.BestMatchingBioPolymersWithSetMods == null || !sm.BestMatchingBioPolymersWithSetMods.Any();

--- a/MetaMorpheus/Test/MultiProteaseParsimonyTest.cs
+++ b/MetaMorpheus/Test/MultiProteaseParsimonyTest.cs
@@ -990,7 +990,7 @@ namespace Test
         }
 
         /// <summary>
-        /// This test ensures that FDR for each psm is calculated accoriding to its protease
+        /// This test ensures that FDR for each psm is calculated according to its protease
         /// </summary>
         [Test]
         public static void MultiProteaseParsimony_TestingProteaseSpecificFDRCalculations()
@@ -1032,16 +1032,15 @@ namespace Test
             new FdrAnalysisEngine(psms, 0, new CommonParameters(), fsp, new List<string>()).Run();
             psms = psms.OrderByDescending(p => p.Score).ToList();
 
-            Assert.AreEqual(0.00, Math.Round(psms[0].FdrInfo.QValue, 2));
             Assert.AreEqual(0.00, Math.Round(psms[1].FdrInfo.QValue, 2));
             Assert.AreEqual(0.00, Math.Round(psms[2].FdrInfo.QValue, 2));
             Assert.AreEqual(0.00, Math.Round(psms[3].FdrInfo.QValue, 2));
-            Assert.AreEqual(0.33, Math.Round(psms[4].FdrInfo.QValue, 2));
+            Assert.AreEqual(0.5, Math.Round(psms[4].FdrInfo.QValue, 2));
             Assert.AreEqual(0.33, Math.Round(psms[5].FdrInfo.QValue, 2));
             Assert.AreEqual(0.00, Math.Round(psms[6].FdrInfo.QValue, 2));
             Assert.AreEqual(0.33, Math.Round(psms[7].FdrInfo.QValue, 2));
-            Assert.AreEqual(0.50, Math.Round(psms[8].FdrInfo.QValue, 2));
-            Assert.AreEqual(0.50, Math.Round(psms[9].FdrInfo.QValue, 2));
+            Assert.AreEqual(0.67, Math.Round(psms[8].FdrInfo.QValue, 2));
+            Assert.AreEqual(0.5, Math.Round(psms[9].FdrInfo.QValue, 2));
         }
     }
 }

--- a/MetaMorpheus/Test/PeptideSpectralMatchTest.cs
+++ b/MetaMorpheus/Test/PeptideSpectralMatchTest.cs
@@ -1,0 +1,102 @@
+﻿using EngineLayer;
+using MassSpectrometry;
+using NUnit.Framework;
+using Proteomics.ProteolyticDigestion;
+using Proteomics;
+using System;
+using System.Collections.Generic;
+using Omics.Digestion;
+using Omics.Fragmentation;
+using Omics.Modifications;
+
+namespace Test
+{
+    [TestFixture]
+    internal class PeptideSpectralMatchTest
+    {
+        [Test]
+        public static void GetAminoAcidCoverageTest()
+        {
+            CommonParameters commonParams = new CommonParameters(digestionParams: new DigestionParams(protease: "trypsin", minPeptideLength: 1));
+
+            MsDataScan scanNumberOne = new MsDataScan(new MzSpectrum(new double[] { 10 }, new double[] { 1 }, false), 1, 2, true, Polarity.Positive, double.NaN, null, null, MZAnalyzerType.Orbitrap, double.NaN, null, null, "scan=1", 10, 2, 100, double.NaN, null, DissociationType.AnyActivationType, 0, null);
+
+            Ms2ScanWithSpecificMass ms2ScanOneMzTen = new Ms2ScanWithSpecificMass(scanNumberOne, 10, 2, "File", new CommonParameters());
+
+            string sequence = "";
+            Dictionary<string, Modification> allKnownMods = new();
+            int numFixedMods = 0;
+            DigestionParams digestionParams = new DigestionParams();
+            Protein myProtein = new Protein(sequence, "ACCESSION");
+            int oneBasedStartResidueInProtein = 0;
+            int oneBasedEndResidueInProtein = Math.Max(sequence.Length, 0);
+            int missedCleavages = 0;
+            CleavageSpecificity cleavageSpecificity = CleavageSpecificity.Full;
+            string peptideDescription = null;
+            int? pairedTargetDecoyHash = null;
+
+            PeptideWithSetModifications pwsmNoBaseSequence = new(sequence, allKnownMods, numFixedMods, digestionParams, myProtein,
+                oneBasedStartResidueInProtein, oneBasedEndResidueInProtein, missedCleavages, cleavageSpecificity,
+                peptideDescription, pairedTargetDecoyHash);
+            PeptideSpectralMatch psmNoBaseSequenceNoMFI = new(pwsmNoBaseSequence, 0, 10, 0, ms2ScanOneMzTen, commonParams,
+                new List<MatchedFragmentIon>());
+            psmNoBaseSequenceNoMFI.ResolveAllAmbiguities();
+
+            //PSM has neither sequence nor matched fragment ions
+            var b = psmNoBaseSequenceNoMFI.BaseSequence;
+            Assert.AreEqual("", b);
+            var m = psmNoBaseSequenceNoMFI.MatchedFragmentIons;
+            Assert.AreEqual(0, m.Count);
+            psmNoBaseSequenceNoMFI.GetAminoAcidCoverage();
+
+            sequence = "PEPTIDE";
+            oneBasedEndResidueInProtein = Math.Max(sequence.Length, 0);
+            myProtein = new Protein(sequence, "ACCESSION");
+            PeptideWithSetModifications pwsmBaseSequence = new(sequence, allKnownMods, numFixedMods, digestionParams, myProtein,
+                oneBasedStartResidueInProtein, oneBasedEndResidueInProtein, missedCleavages, cleavageSpecificity,
+                peptideDescription, pairedTargetDecoyHash);
+            PeptideSpectralMatch psmBaseSequenceNoMFI = new(pwsmBaseSequence, 0, 10, 0, ms2ScanOneMzTen, commonParams,
+                new List<MatchedFragmentIon>());
+
+            //PSM has sequence but does not have matched fragment ions
+            psmBaseSequenceNoMFI.ResolveAllAmbiguities();
+            b = psmBaseSequenceNoMFI.BaseSequence;
+            Assert.AreEqual(sequence, b);
+            m = psmBaseSequenceNoMFI.MatchedFragmentIons;
+            Assert.AreEqual(0, m.Count);
+            psmBaseSequenceNoMFI.GetAminoAcidCoverage();
+
+            //PSM has no sequence but does have matched fragment ions
+            Product ntProduct = new Product(ProductType.y, FragmentationTerminus.N, 1, 1, 1, 0);
+            MatchedFragmentIon mfi = new(ntProduct, 1, 1, 1);
+            List<MatchedFragmentIon> mfiList = new List<MatchedFragmentIon>() { mfi };
+            PeptideSpectralMatch psmNoBaseSequenceMFI = new(pwsmNoBaseSequence, 0, 10, 0, ms2ScanOneMzTen, commonParams,
+                mfiList);
+            psmNoBaseSequenceMFI.ResolveAllAmbiguities();
+
+            b = psmNoBaseSequenceMFI.BaseSequence;
+            Assert.AreEqual("", b);
+            m = psmNoBaseSequenceMFI.MatchedFragmentIons;
+            Assert.AreEqual(1, m.Count);
+            psmNoBaseSequenceMFI.GetAminoAcidCoverage();
+
+            //PSM has sequence and matched fragment ions
+            PeptideSpectralMatch psmBaseSequenceMFI = new(pwsmBaseSequence, 0, 10, 0, ms2ScanOneMzTen, commonParams,
+                mfiList);
+            psmBaseSequenceMFI.ResolveAllAmbiguities();
+
+            b = psmBaseSequenceMFI.BaseSequence;
+            Assert.AreEqual("PEPTIDE", b);
+            m = psmBaseSequenceMFI.MatchedFragmentIons;
+            Assert.AreEqual(1, m.Count);
+            psmBaseSequenceMFI.GetAminoAcidCoverage();
+
+            List<PeptideSpectralMatch> psms = new List<PeptideSpectralMatch>() { psmNoBaseSequenceNoMFI, psmBaseSequenceNoMFI, psmNoBaseSequenceMFI, psmBaseSequenceMFI };
+
+            foreach (var psm in psms)
+            {
+                psm.ToString();
+            }
+        }
+    }
+}

--- a/MetaMorpheus/Test/PostSearchAnalysisTaskTests.cs
+++ b/MetaMorpheus/Test/PostSearchAnalysisTaskTests.cs
@@ -34,7 +34,7 @@ namespace Test
             // identified across all files.
             int TaGe_SA_A549_3_snip_2ExpectedPsms = 214;
             int TaGe_SA_A549_3_snip_2ExpectedPeptides = 174;
-            
+
 
             Assert.AreEqual("All target PSMs with q-value = 0.01: 428", allResults[12]);
             Assert.AreEqual("All target peptides with q-value = 0.01 : 174", allResults[13]);
@@ -42,7 +42,7 @@ namespace Test
             Assert.AreEqual("TaGe_SA_A549_3_snip target PSMs with q-value = 0.01: 214", allResults[18]);
             Assert.AreEqual("Target protein groups within 1 % FDR in TaGe_SA_A549_3_snip: 165", allResults[24]);
             Assert.AreEqual("TaGe_SA_A549_3_snip Target peptides with q-value = 0.01 : 174", allResults[26]);
-            
+
             Assert.AreEqual("TaGe_SA_A549_3_snip_2 target PSMs with q-value = 0.01: " + TaGe_SA_A549_3_snip_2ExpectedPsms, allResults[22]);
             Assert.AreEqual("TaGe_SA_A549_3_snip_2 Target peptides with q-value = 0.01 : " + TaGe_SA_A549_3_snip_2ExpectedPeptides, allResults[28]);
             Assert.AreEqual("Target protein groups within 1 % FDR in TaGe_SA_A549_3_snip_2: 165", allResults[25]);
@@ -59,7 +59,7 @@ namespace Test
 
             Assert.AreEqual("TaGe_SA_A549_3_snip_2 target PSMs with q-value = 0.01: " + TaGe_SA_A549_3_snip_2ExpectedPsms, results[17]);
             Assert.AreEqual("TaGe_SA_A549_3_snip_2 Target peptides with q-value = 0.01 : " + TaGe_SA_A549_3_snip_2ExpectedPeptides, results[23]);
-            
+
 
             Directory.Delete(outputFolder, true);
 
@@ -71,9 +71,9 @@ namespace Test
             engineToml.Run();
 
             string[] singleFileResults = File.ReadAllLines(resultsFile);
-            Assert.AreEqual("All target PSMs with q-value = 0.01: " + TaGe_SA_A549_3_snip_2ExpectedPsms, singleFileResults[7]); 
-            Assert.AreEqual("All target peptides with q-value = 0.01 : " + TaGe_SA_A549_3_snip_2ExpectedPeptides, singleFileResults[8]); 
-            Assert.AreEqual("All target protein groups with q-value = 0.01 (1% FDR): 165", singleFileResults[9]); 
+            Assert.AreEqual("All target PSMs with q-value = 0.01: " + TaGe_SA_A549_3_snip_2ExpectedPsms, singleFileResults[7]);
+            Assert.AreEqual("All target peptides with q-value = 0.01 : " + TaGe_SA_A549_3_snip_2ExpectedPeptides, singleFileResults[8]);
+            Assert.AreEqual("All target protein groups with q-value = 0.01 (1% FDR): 165", singleFileResults[9]);
 
             //Second test that AllResults and Results display correct numbers of peptides and psms with PEP q-value filter on
             myTomlPath = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\Task2-SearchTaskconfig.toml");
@@ -83,28 +83,28 @@ namespace Test
 
             allResultsFile = Path.Combine(outputFolder, "allResults.txt");
             allResults = File.ReadAllLines(allResultsFile);
-            Assert.AreEqual("All target PSMs with pep q-value = 0.01: 499", allResults[12]);
-            Assert.AreEqual("All target peptides with pep q-value = 0.01 : 179", allResults[13]);
+            Assert.AreEqual("All target PSMs with pep q-value = 0.01: 501", allResults[12]);
+            Assert.AreEqual("All target peptides with pep q-value = 0.01 : 182", allResults[13]);
             Assert.AreEqual("All target protein groups with q-value = 0.01 (1% FDR): 165", allResults[14]);
-            Assert.AreEqual("TaGe_SA_A549_3_snip target PSMs with pep q-value = 0.01: 230", allResults[18]);
-            Assert.AreEqual("TaGe_SA_A549_3_snip_2 target PSMs with pep q-value = 0.01: 230", allResults[22]);
+            Assert.AreEqual("TaGe_SA_A549_3_snip target PSMs with pep q-value = 0.01: 233", allResults[18]);
+            Assert.AreEqual("TaGe_SA_A549_3_snip_2 target PSMs with pep q-value = 0.01: 233", allResults[22]);
             Assert.AreEqual("Target protein groups within 1 % FDR in TaGe_SA_A549_3_snip: 165", allResults[24]);
             Assert.AreEqual("Target protein groups within 1 % FDR in TaGe_SA_A549_3_snip_2: 165", allResults[25]);
-            Assert.AreEqual("TaGe_SA_A549_3_snip Target peptides with pep q-value = 0.01 : 179", allResults[26]);
-            Assert.AreEqual("TaGe_SA_A549_3_snip_2 Target peptides with pep q-value = 0.01 : 179", allResults[28]);
+            Assert.AreEqual("TaGe_SA_A549_3_snip Target peptides with pep q-value = 0.01 : 182", allResults[26]);
+            Assert.AreEqual("TaGe_SA_A549_3_snip_2 Target peptides with pep q-value = 0.01 : 182", allResults[28]);
 
 
             resultsFile = Path.Combine(outputFolder, @"postSearchAnalysisTaskTestOutput\results.txt");
             results = File.ReadAllLines(resultsFile);
-            Assert.AreEqual("All target PSMs with pep q-value = 0.01: 499", results[7]);
-            Assert.AreEqual("All target peptides with pep q-value = 0.01 : 179", results[8]);
+            Assert.AreEqual("All target PSMs with pep q-value = 0.01: 501", results[7]);
+            Assert.AreEqual("All target peptides with pep q-value = 0.01 : 182", results[8]);
             Assert.AreEqual("All target protein groups with q-value = 0.01 (1% FDR): 165", results[9]);
-            Assert.AreEqual("TaGe_SA_A549_3_snip target PSMs with pep q-value = 0.01: 230", results[13]);
-            Assert.AreEqual("TaGe_SA_A549_3_snip_2 target PSMs with pep q-value = 0.01: 230", results[17]);
+            Assert.AreEqual("TaGe_SA_A549_3_snip target PSMs with pep q-value = 0.01: 233", results[13]);
+            Assert.AreEqual("TaGe_SA_A549_3_snip_2 target PSMs with pep q-value = 0.01: 233", results[17]);
             Assert.AreEqual("Target protein groups within 1 % FDR in TaGe_SA_A549_3_snip: 165", results[19]);
             Assert.AreEqual("Target protein groups within 1 % FDR in TaGe_SA_A549_3_snip_2: 165", results[20]);
-            Assert.AreEqual("TaGe_SA_A549_3_snip Target peptides with pep q-value = 0.01 : 179", results[21]);
-            Assert.AreEqual("TaGe_SA_A549_3_snip_2 Target peptides with pep q-value = 0.01 : 179", results[23]);
+            Assert.AreEqual("TaGe_SA_A549_3_snip Target peptides with pep q-value = 0.01 : 182", results[21]);
+            Assert.AreEqual("TaGe_SA_A549_3_snip_2 Target peptides with pep q-value = 0.01 : 182", results[23]);
 
             Directory.Delete(outputFolder, true);
         }

--- a/MetaMorpheus/Test/SearchTaskTest.cs
+++ b/MetaMorpheus/Test/SearchTaskTest.cs
@@ -386,7 +386,7 @@ namespace Test
 
             // test that the final q-value follows the (target / decoy) formula
             // intermediate q-values no longer always follow this formula, so I'm not testing them here
-            Assert.AreEqual(cumDecoys / (double)cumTargets, finalQValue, 0.0001);
+            Assert.That((double)cumDecoys / (double)cumTargets, Is.EqualTo(finalQValue).Within(.0005));
             Directory.Delete(folderPath, true);
         }
 


### PR DESCRIPTION


We have never used the correct calculation for q-value, which is (decoy count + 1)/(target count). This is because, the highest scoring PSM would have q-value = 0.5. Bill Noble alerted me to an alternate strategy for computing q-value that would eliminate this problem and allow us to use the correct formula. This is accomplished by computing q-value from lowest scoring PSM to highest scoring PSM subject to the following rule. Whenever the current q-value is greater than the previous q-value, we keep the previous q-value. Now, the highest scoring PSM will have a q-value equal to the q-value of the highest scoring decoy PSM. It will never be zero. c est la vie.

overall we expect to see a higher yield of both peptides and PSMs with q-value < 0.01.

An unfortunate by product of this update is that some unit tests with low psm count fail to have sufficent psms with low q-value. In certain instances, this prevents PEP from being calculated. This problem was solved by adding another mzML that could boost the psm count to a sufficiently high level to allow all unit tests to complete successfully while testing what they were intended to test. Please note, some test assertions had to be changed to accommodate the new results.
