### PR TITLE
Upgrading wixtools from a release candidate version to 5.0.0

### DIFF
--- a/MetaMorpheus/Bootstrapper/Bootstrapper.wixproj
+++ b/MetaMorpheus/Bootstrapper/Bootstrapper.wixproj
@@ -1,4 +1,4 @@
-<Project Sdk="WixToolset.Sdk/4.0.0-rc.2">
+<Project Sdk="WixToolset.Sdk/5.0.0">
   <PropertyGroup>
     <OutputName>MetaMorpheusInstaller</OutputName>
     <OutputType>Bundle</OutputType>
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="WixToolset.Util.wixext" Version="5.0.0" />
-    <PackageReference Include="WixToolset.Bal.wixext" Version="4.0.0-rc.2" />
+    <PackageReference Include="WixToolset.Bal.wixext" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MetaMorpheusSetup\MetaMorpheusSetup.wixproj">

--- a/MetaMorpheus/Bootstrapper/Bootstrapper.wixproj
+++ b/MetaMorpheus/Bootstrapper/Bootstrapper.wixproj
@@ -5,7 +5,7 @@
     <Platforms>x64;ARM64</Platforms>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="WixToolset.Util.wixext" Version="4.0.0-rc.2" />
+    <PackageReference Include="WixToolset.Util.wixext" Version="5.0.0" />
     <PackageReference Include="WixToolset.Bal.wixext" Version="4.0.0-rc.2" />
   </ItemGroup>
   <ItemGroup>

--- a/MetaMorpheus/MetaMorpheusSetup/MetaMorpheusSetup.wixproj
+++ b/MetaMorpheus/MetaMorpheusSetup/MetaMorpheusSetup.wixproj
@@ -1,5 +1,5 @@
 ﻿<Project>
-  <Import Project="Sdk.props" Sdk="WixToolset.Sdk" Version="4.0.0-rc.2" />
+  <Import Project="Sdk.props" Sdk="WixToolset.Sdk" Version="5.0.0" />
   <PropertyGroup>
     <Platform Condition=" '$(Platform)' == '' ">x64</Platform>
     <OutputName>MetaMorpheusInstaller</OutputName>
@@ -54,7 +54,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="WixToolset.Util.wixext" Version="5.0.0" />
-    <PackageReference Include="WixToolset.UI.wixext" Version="4.0.0-rc.2" />
+    <PackageReference Include="WixToolset.UI.wixext" Version="5.0.0" />
   </ItemGroup>
   <Import Project="Sdk.targets" Sdk="WixToolset.Sdk" Version="4.0.0-rc.2" />
   <PropertyGroup>

--- a/MetaMorpheus/MetaMorpheusSetup/MetaMorpheusSetup.wixproj
+++ b/MetaMorpheus/MetaMorpheusSetup/MetaMorpheusSetup.wixproj
@@ -53,7 +53,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="WixToolset.Util.wixext" Version="4.0.0-rc.2" />
+    <PackageReference Include="WixToolset.Util.wixext" Version="5.0.0" />
     <PackageReference Include="WixToolset.UI.wixext" Version="4.0.0-rc.2" />
   </ItemGroup>
   <Import Project="Sdk.targets" Sdk="WixToolset.Sdk" Version="4.0.0-rc.2" />


### PR DESCRIPTION
A warning popped up on Visual Studio saying that the version MetaMorpheus is using for WixTools might contain severe vulnerabilities. I upgraded to version 5.0.0