### PR TITLE
non-specific search dictionary

### DIFF
--- a/MetaMorpheus/EngineLayer/NonSpecificEnzymeSearch/NonSpecificEnzymeSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/NonSpecificEnzymeSearch/NonSpecificEnzymeSearchEngine.cs
@@ -374,12 +374,26 @@ namespace EngineLayer.NonSpecificEnzymeSearch
                             if (mod.Key > indexShift + 1) //check if we cleaved it off, +1 for N-terminus being mod 1 and first residue being 2
                             {
                                 int key = mod.Key - indexShift;
-                                updatedMods.Add(key, mod.Value);
+                                if(updatedMods.ContainsKey(key))
+                                {
+                                    updatedMods[key] = mod.Value;
+                                }
+                                else
+                                {
+                                    updatedMods.Add(key, mod.Value);
+                                }
                             }
                         }
                         if (terminalMod != null)
                         {
-                            updatedMods.Add(startResidue - 1, terminalMod);
+                            if (updatedMods.ContainsKey(startResidue - 1))
+                            {
+                                updatedMods[startResidue - 1] = terminalMod;
+                            }
+                            else
+                            {
+                                updatedMods.Add(startResidue - 1, terminalMod);
+                            }
                         }
                         updatedPwsm = new PeptideWithSetModifications(peptide.Protein, peptide.DigestionParams, startResidue, peptide.OneBasedEndResidue, CleavageSpecificity.Unknown, "", 0, updatedMods, 0);
                     }

--- a/MetaMorpheus/Test/SpectralRecoveryTest.cs
+++ b/MetaMorpheus/Test/SpectralRecoveryTest.cs
@@ -377,7 +377,7 @@ namespace Test
             postSearchTask.Run();
 
             var libraryList = Directory.GetFiles(path, "*.*", SearchOption.AllDirectories);
-            string updateLibraryPath = libraryList.First(p => p.Contains("SpectralLibrary") && !p.Contains(matchingvalue)).ToString();
+            string updateLibraryPath = libraryList.First(p => p.Contains("updateSpectralLibrary") && !p.Contains(matchingvalue)).ToString();
             var updatedLibraryWithoutDecoy = new SpectralLibrary(new List<string> { Path.Combine(path, updateLibraryPath) });
             Assert.That(updatedLibraryWithoutDecoy.TryGetSpectrum("EESGKPGAHVTVK", 2, out spectrum));
 


### PR DESCRIPTION
user dmorgan reported issue during non-specific search of key already existing.

https://github.com/smith-chem-wisc/MetaMorpheus/issues/2400

This PR adds cod the check the dictionary for existence of a key before adding.