### PR TITLE
mock style unit test

### DIFF
--- a/MetaMorpheus/TaskLayer/DbForTask.cs
+++ b/MetaMorpheus/TaskLayer/DbForTask.cs
@@ -2,6 +2,13 @@
 
 namespace TaskLayer
 {
+    public interface IdbForTask
+    {
+        string FilePath { get; }
+        bool IsContaminant { get; }
+        string FileName { get; }
+        bool IsSpectralLibrary { get; }
+    }
     public class DbForTask
     {
         public DbForTask(string filePath, bool isContaminant)
@@ -11,10 +18,16 @@ namespace TaskLayer
             FileName = System.IO.Path.GetFileName(filePath);
             IsSpectralLibrary = GlobalVariables.GetFileExtension(filePath).ToLowerInvariant() == ".msp";
         }
+        public DbForTask(IdbForTask dbForTask)
+        {
+            this.dbForTask = dbForTask;
+        }
 
         public bool IsSpectralLibrary { get; }
         public string FilePath { get; }
         public bool IsContaminant { get; }
         public string FileName { get; }
+
+        private readonly IdbForTask dbForTask;
     }
 }

--- a/MetaMorpheus/Test/DbForTaskTests.cs
+++ b/MetaMorpheus/Test/DbForTaskTests.cs
@@ -1,0 +1,23 @@
+﻿using NUnit.Framework;
+using TaskLayer;
+using Moq;
+
+namespace Test
+{
+    [TestFixture]
+    internal class DbForTaskTests
+    {
+
+        [Test]
+        public void MockDbForTask_IsSpectralLibrary_ReturnsTrue()
+        {
+            var dbMock = new Mock<IdbForTask>();
+            dbMock.Setup(x => x.FilePath).Returns("path");
+            dbMock.Setup(x => x.IsContaminant).Returns(false);
+            dbMock.Setup(x => x.FileName).Returns("name");
+            dbMock.Setup(x => x.IsSpectralLibrary).Returns(true);
+
+            Assert.That(dbMock.Object.IsSpectralLibrary, Is.True);
+        }
+    }
+}

--- a/MetaMorpheus/Test/Test.csproj
+++ b/MetaMorpheus/Test/Test.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="mzLib" Version="1.0.552" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />


### PR DESCRIPTION
I have for many years been intrigued by the possibility of using Mock for unit tests. Mock, to my understanding, let's you test individual aspects of complex classes without populating all of the fields. Testing a PSM is hard because it has several fields that needed to be created. This unit test doesn't really test anything. But, it does use Mock and it provides one example to follow. The idea is to add an interface to your class and then add a constructor the takes the interface as input and returns the object. With the interface, you can fiddle with the inner parts of the object for use in testing. 

Obviously this is way more powerful than what is demonstrated here. But this power is presently beyond my ken. 