### PR TITLE
mzLib 544

### DIFF
--- a/MetaMorpheus/CMD/CMD.csproj
+++ b/MetaMorpheus/CMD/CMD.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.553" />
+    <PackageReference Include="mzLib" Version="1.0.554" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>
 

--- a/MetaMorpheus/EngineLayer/EngineLayer.csproj
+++ b/MetaMorpheus/EngineLayer/EngineLayer.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.553" />
+    <PackageReference Include="mzLib" Version="1.0.554" />
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/MetaMorpheus/GUI/GUI.csproj
+++ b/MetaMorpheus/GUI/GUI.csproj
@@ -55,7 +55,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.553" />
+    <PackageReference Include="mzLib" Version="1.0.554" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0" />

--- a/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
+++ b/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="itext7" Version="8.0.5" />
     <PackageReference Include="itext7.bouncy-castle-adapter" Version="8.0.5" />
-    <PackageReference Include="mzLib" Version="1.0.553" />
+    <PackageReference Include="mzLib" Version="1.0.554" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.0.0" />
     <PackageReference Include="Svg" Version="3.4.7" />
   </ItemGroup>

--- a/MetaMorpheus/TaskLayer/TaskLayer.csproj
+++ b/MetaMorpheus/TaskLayer/TaskLayer.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.553" />
+    <PackageReference Include="mzLib" Version="1.0.554" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>

--- a/MetaMorpheus/Test/IndexEngineTest.cs
+++ b/MetaMorpheus/Test/IndexEngineTest.cs
@@ -21,7 +21,7 @@ namespace Test
         [Test]
         public static void TestIndexEngine()
         {
-            var proteinList = new List<Protein> { new Protein("MNNNKQQQ", null) };
+            var proteinList = new List<Protein> { new Protein("MNNNKQQQ", "FakeAccession") };
             var variableModifications = new List<Modification>();
             var fixedModifications = new List<Modification>();
             var localizeableModifications = new List<Modification>();
@@ -60,6 +60,14 @@ namespace Test
             Assert.That(digestedList.Count, Is.EqualTo(5));
             foreach (PeptideWithSetModifications peptide in digestedList)
             {
+                try
+                {
+                    Assert.That(results.PeptideIndex.Contains(peptide));
+                }
+                catch (Exception e)
+                {
+                    Assert.Fail("Peptide not found in index: " + peptide);
+                }
                 Assert.That(results.PeptideIndex.Contains(peptide));
 
                 var fragments = new List<Product>();

--- a/MetaMorpheus/Test/SearchEngineTests.cs
+++ b/MetaMorpheus/Test/SearchEngineTests.cs
@@ -1341,7 +1341,7 @@ namespace Test
             var fixedModifications = new List<Modification>();
             var localizeableModifications = new List<Modification>();
 
-            var proteinList = new List<Protein> { new Protein("GGGGGMNNNKQQQGGGGG", null) };
+            var proteinList = new List<Protein> { new Protein("GGGGGMNNNKQQQGGGGG", "FakeAccession") };
 
             var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, null, null, null, 1, DecoyType.Reverse,
                 CommonParameters, null, SearchParameters.MaxFragmentSize, false, new List<FileInfo>(), TargetContaminantAmbiguity.RemoveContaminant, new List<string>());
@@ -1546,7 +1546,7 @@ namespace Test
                 ii++;
             }
 
-            var proteinList = new List<Protein> { new Protein("GGGGGMKNNNQQQGGGGKGG", null, null, null, null, new List<ProteolysisProduct> { new ProteolysisProduct(null, null, "test") }) };
+            var proteinList = new List<Protein> { new Protein("GGGGGMKNNNQQQGGGGKGG", "FakeAccession", null, null, null, new List<ProteolysisProduct> { new ProteolysisProduct(null, null, "test") }) };
 
             var productMassTolerance = new AbsoluteTolerance(0.01);
             var searchModes = new SinglePpmAroundZeroSearchMode(5);

--- a/MetaMorpheus/Test/Test.csproj
+++ b/MetaMorpheus/Test/Test.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.553" />
+    <PackageReference Include="mzLib" Version="1.0.554" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />


### PR DESCRIPTION
Update to mzLib 544. 

The new mzLib introduces a bug where peptidewithsetmodifications.Equals() throws an exception if the parent protein has a null value for the Accession property