### PR TITLE
Added Decon Parameters to Calibration Window

### DIFF
--- a/MetaMorpheus/GUI/TaskWindows/CalibrateTaskWindow.xaml
+++ b/MetaMorpheus/GUI/TaskWindows/CalibrateTaskWindow.xaml
@@ -49,36 +49,6 @@
                     <Expander x:Name="FileLoadExpander" >
                         <StackPanel>
                             <local:HostDeconParamControl x:Name="DeisotopingControl" DataContext="{Binding}"/>
-                            <GroupBox Header="Peak Trimming">
-                                <StackPanel>
-                                    <CheckBox x:Name="TrimMs1" Content="Trim MS1 Peaks" IsChecked="True" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500">
-                                        <ToolTipService.ToolTip>
-                                            <ToolTip Content="Remove low-intensity MS1 peaks using the below settings" />
-                                        </ToolTipService.ToolTip>
-                                    </CheckBox>
-                                    <CheckBox x:Name="TrimMsMs" Content="Trim MS2 Peaks" IsChecked="True" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500">
-                                        <ToolTipService.ToolTip>
-                                            <ToolTip Content="Remove low-intensity MS2 peaks using the below settings" />
-                                        </ToolTipService.ToolTip>
-                                    </CheckBox>
-                                    <StackPanel Orientation="Horizontal" Margin="5">
-                                        <Label Content="Top N peaks per m/z window" />
-                                        <local:IntegerTexBoxControl x:Name="NumberOfPeaksToKeepPerWindowTextBox" Width="45" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500">
-                                            <ToolTipService.ToolTip>
-                                                <ToolTip Content="Use the N most intense peaks from the spectrum and remove all other peaks" />
-                                            </ToolTipService.ToolTip>
-                                        </local:IntegerTexBoxControl>
-                                    </StackPanel>
-                                    <StackPanel Orientation="Horizontal" Margin="5">
-                                        <Label Content="Minimum intensity ratio" />
-                                        <local:DoubleTextBoxControl x:Name="MinimumAllowedIntensityRatioToBasePeakTexBox" Width="45" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500">
-                                            <ToolTipService.ToolTip>
-                                                <ToolTip Content="Peaks must be this intense compared to the base peak" />
-                                            </ToolTipService.ToolTip>
-                                        </local:DoubleTextBoxControl>
-                                    </StackPanel>
-                                </StackPanel>
-                            </GroupBox>
                         </StackPanel>
                     </Expander>
                 </GroupBox>

--- a/MetaMorpheus/GUI/TaskWindows/CalibrateTaskWindow.xaml
+++ b/MetaMorpheus/GUI/TaskWindows/CalibrateTaskWindow.xaml
@@ -45,6 +45,43 @@
                         </TextBox.Style>
                     </TextBox>
                 </StackPanel>
+                <GroupBox Header="File Loading Parameters" DockPanel.Dock="Top">
+                    <Expander x:Name="FileLoadExpander" >
+                        <StackPanel>
+                            <local:HostDeconParamControl x:Name="DeisotopingControl" DataContext="{Binding}"/>
+                            <GroupBox Header="Peak Trimming">
+                                <StackPanel>
+                                    <CheckBox x:Name="TrimMs1" Content="Trim MS1 Peaks" IsChecked="True" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500">
+                                        <ToolTipService.ToolTip>
+                                            <ToolTip Content="Remove low-intensity MS1 peaks using the below settings" />
+                                        </ToolTipService.ToolTip>
+                                    </CheckBox>
+                                    <CheckBox x:Name="TrimMsMs" Content="Trim MS2 Peaks" IsChecked="True" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500">
+                                        <ToolTipService.ToolTip>
+                                            <ToolTip Content="Remove low-intensity MS2 peaks using the below settings" />
+                                        </ToolTipService.ToolTip>
+                                    </CheckBox>
+                                    <StackPanel Orientation="Horizontal" Margin="5">
+                                        <Label Content="Top N peaks per m/z window" />
+                                        <local:IntegerTexBoxControl x:Name="NumberOfPeaksToKeepPerWindowTextBox" Width="45" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500">
+                                            <ToolTipService.ToolTip>
+                                                <ToolTip Content="Use the N most intense peaks from the spectrum and remove all other peaks" />
+                                            </ToolTipService.ToolTip>
+                                        </local:IntegerTexBoxControl>
+                                    </StackPanel>
+                                    <StackPanel Orientation="Horizontal" Margin="5">
+                                        <Label Content="Minimum intensity ratio" />
+                                        <local:DoubleTextBoxControl x:Name="MinimumAllowedIntensityRatioToBasePeakTexBox" Width="45" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500">
+                                            <ToolTipService.ToolTip>
+                                                <ToolTip Content="Peaks must be this intense compared to the base peak" />
+                                            </ToolTipService.ToolTip>
+                                        </local:DoubleTextBoxControl>
+                                    </StackPanel>
+                                </StackPanel>
+                            </GroupBox>
+                        </StackPanel>
+                    </Expander>
+                </GroupBox>
                 <GroupBox Header="Search Parameters" DockPanel.Dock="Top">
                     <Expander x:Name="SearchModeExpander">
                         <StackPanel>

--- a/MetaMorpheus/GUI/TaskWindows/CalibrateTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/CalibrateTaskWindow.xaml.cs
@@ -28,6 +28,7 @@ namespace MetaMorpheusGUI
         private readonly ObservableCollection<ModTypeForLoc> LocalizeModTypeForTreeViewObservableCollection = new ObservableCollection<ModTypeForLoc>();
         private bool AutomaticallyAskAndOrUpdateParametersBasedOnProtease = true;
         private CustomFragmentationWindow CustomFragmentationWindow;
+        private DeconHostViewModel DeconHostViewModel;
 
         public CalibrateTaskWindow(CalibrationTask myCalibrateTask)
         {
@@ -38,6 +39,7 @@ namespace MetaMorpheusGUI
             PopulateChoices();
             UpdateFieldsFromTask(TheTask);
             AutomaticallyAskAndOrUpdateParametersBasedOnProtease = true;
+            DeisotopingControl.DataContext = DeconHostViewModel;
 
             if (myCalibrateTask == null)
             {
@@ -51,6 +53,9 @@ namespace MetaMorpheusGUI
 
         private void UpdateFieldsFromTask(CalibrationTask task)
         {
+            DeconHostViewModel = new DeconHostViewModel(TheTask.CommonParameters.PrecursorDeconvolutionParameters,
+                TheTask.CommonParameters.ProductDeconvolutionParameters,
+                TheTask.CommonParameters.UseProvidedPrecursorInfo, TheTask.CommonParameters.DoPrecursorDeconvolution);
             ProteaseComboBox.SelectedItem = task.CommonParameters.DigestionParams.Protease; //protease needs to come first or recommended settings can overwrite the actual settings
             MissedCleavagesTextBox.Text = task.CommonParameters.DigestionParams.MaxMissedCleavages == int.MaxValue ? "" : task.CommonParameters.DigestionParams.MaxMissedCleavages.ToString(CultureInfo.InvariantCulture);
             MinPeptideLengthTextBox.Text = task.CommonParameters.DigestionParams.MinPeptideLength.ToString(CultureInfo.InvariantCulture);
@@ -255,6 +260,10 @@ namespace MetaMorpheusGUI
             }
 
             bool parseMaxThreadsPerFile = int.Parse(MaxThreadsTextBox.Text, CultureInfo.InvariantCulture) <= Environment.ProcessorCount && int.Parse(MaxThreadsTextBox.Text, CultureInfo.InvariantCulture) > 0;
+            DeconvolutionParameters precursorDeconvolutionParameters = DeconHostViewModel.PrecursorDeconvolutionParameters.Parameters;
+            DeconvolutionParameters productDeconvolutionParameters = DeconHostViewModel.ProductDeconvolutionParameters.Parameters;
+            bool useProvidedPrecursorInfo = DeconHostViewModel.UseProvidedPrecursors;
+            bool doPrecursorDeconvolution = DeconHostViewModel.DoPrecursorDeconvolution;
 
             //the below parameters are optimized for top-down but do not exist in the GUI as of Nov. 13, 2019
             if (((Protease)ProteaseComboBox.SelectedItem).Name.Contains("top-down"))
@@ -272,9 +281,11 @@ namespace MetaMorpheusGUI
                     assumeOrphanPeaksAreZ1Fragments: protease.Name != "top-down",
                     minVariantDepth: minVariantDepth,
                     maxHeterozygousVariants: maxHeterozygousVariants,
-                    useProvidedPrecursorInfo: false, //Updated
-                    deconvolutionMaxAssumedChargeState: 60, //Updated
-                    trimMsMsPeaks: false); //Updated
+                    trimMsMsPeaks: false,
+                    doPrecursorDeconvolution: doPrecursorDeconvolution,
+                    precursorDeconParams: precursorDeconvolutionParameters,
+                    productDeconParams: productDeconvolutionParameters,
+                    useProvidedPrecursorInfo: useProvidedPrecursorInfo); 
                 TheTask.CommonParameters = commonParamsToSave;
             }
             else //bottom-up
@@ -291,7 +302,11 @@ namespace MetaMorpheusGUI
                     precursorMassTolerance: precursorMassTolerance,
                     assumeOrphanPeaksAreZ1Fragments: protease.Name != "top-down",
                     minVariantDepth: minVariantDepth,
-                    maxHeterozygousVariants: maxHeterozygousVariants);
+                    maxHeterozygousVariants: maxHeterozygousVariants,
+                    useProvidedPrecursorInfo: useProvidedPrecursorInfo,
+                    doPrecursorDeconvolution: doPrecursorDeconvolution,
+                    precursorDeconParams: precursorDeconvolutionParameters,
+                    productDeconParams: productDeconvolutionParameters);
                 TheTask.CommonParameters = commonParamsToSave;
             }
 
@@ -381,6 +396,12 @@ namespace MetaMorpheusGUI
                         {
                             //many variables are not present in the calibrate task gui, but we modify them when saving
                             //uncheck all variable mods
+                            DeconHostViewModel.UseProvidedPrecursors = false;
+                            DeconHostViewModel.DoPrecursorDeconvolution = true;
+                            DeconHostViewModel.SetAllPrecursorMaxChargeState(60);
+                            DeconHostViewModel.SetAllProductMaxChargeState(20);
+                            TrimMsMs.IsChecked = false;
+
                             foreach (var mod in VariableModTypeForTreeViewObservableCollection)
                             {
                                 mod.Use = false;

--- a/MetaMorpheus/GUI/TaskWindows/CalibrateTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/CalibrateTaskWindow.xaml.cs
@@ -399,8 +399,7 @@ namespace MetaMorpheusGUI
                             //uncheck all variable mods
                             DeconHostViewModel.UseProvidedPrecursors = false;
                             DeconHostViewModel.DoPrecursorDeconvolution = true;
-                            DeconHostViewModel.SetAllPrecursorMaxChargeState(60);
-                            DeconHostViewModel.SetAllProductMaxChargeState(20);
+                            DeconHostViewModel.PrecursorDeconvolutionParameters.MaxAssumedChargeState = 60;
                             TrimMsMs.IsChecked = false;
 
                             foreach (var mod in VariableModTypeForTreeViewObservableCollection)

--- a/MetaMorpheus/GUI/TaskWindows/CalibrateTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/CalibrateTaskWindow.xaml.cs
@@ -400,7 +400,6 @@ namespace MetaMorpheusGUI
                             DeconHostViewModel.UseProvidedPrecursors = false;
                             DeconHostViewModel.DoPrecursorDeconvolution = true;
                             DeconHostViewModel.PrecursorDeconvolutionParameters.MaxAssumedChargeState = 60;
-                            TrimMsMs.IsChecked = false;
 
                             foreach (var mod in VariableModTypeForTreeViewObservableCollection)
                             {

--- a/MetaMorpheus/GUI/TaskWindows/CalibrateTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/CalibrateTaskWindow.xaml.cs
@@ -53,6 +53,7 @@ namespace MetaMorpheusGUI
 
         private void UpdateFieldsFromTask(CalibrationTask task)
         {
+            MetaMorpheusTask.DetermineAnalyteType(TheTask.CommonParameters);
             DeconHostViewModel = new DeconHostViewModel(TheTask.CommonParameters.PrecursorDeconvolutionParameters,
                 TheTask.CommonParameters.ProductDeconvolutionParameters,
                 TheTask.CommonParameters.UseProvidedPrecursorInfo, TheTask.CommonParameters.DoPrecursorDeconvolution);

--- a/MetaMorpheus/GUI/TaskWindows/GPTMDTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/GPTMDTaskWindow.xaml.cs
@@ -64,6 +64,7 @@ namespace MetaMorpheusGUI
 
         private void UpdateFieldsFromTask(GptmdTask task)
         {
+            MetaMorpheusTask.DetermineAnalyteType(TheTask.CommonParameters);
             DeconHostViewModel = new DeconHostViewModel(TheTask.CommonParameters.PrecursorDeconvolutionParameters,
                 TheTask.CommonParameters.ProductDeconvolutionParameters,
                 TheTask.CommonParameters.UseProvidedPrecursorInfo, TheTask.CommonParameters.DoPrecursorDeconvolution);

--- a/MetaMorpheus/GUI/TaskWindows/GlycoSearchTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/GlycoSearchTaskWindow.xaml.cs
@@ -114,6 +114,7 @@ namespace MetaMorpheusGUI
 
         private void UpdateFieldsFromTask(GlycoSearchTask task)
         {
+            MetaMorpheusTask.DetermineAnalyteType(TheTask.CommonParameters);
             RbtOGlycoSearch.IsChecked = task._glycoSearchParameters.GlycoSearchType == EngineLayer.GlycoSearch.GlycoSearchType.OGlycanSearch;
             RbtNGlycoSearch.IsChecked = task._glycoSearchParameters.GlycoSearchType == EngineLayer.GlycoSearch.GlycoSearchType.NGlycanSearch;
             Rbt_N_O_GlycoSearch.IsChecked = task._glycoSearchParameters.GlycoSearchType == EngineLayer.GlycoSearch.GlycoSearchType.N_O_GlycanSearch;

--- a/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml.cs
@@ -161,6 +161,7 @@ namespace MetaMorpheusGUI
         /// <param name="task"></param>
         private void UpdateFieldsFromTask(SearchTask task)
         {
+            MetaMorpheusTask.DetermineAnalyteType(TheTask.CommonParameters);
             ProteaseComboBox.SelectedItem = task.CommonParameters.DigestionParams.SpecificProtease; //needs to be first, so nonspecific can override if necessary
             ClassicSearchRadioButton.IsChecked = task.SearchParameters.SearchType == SearchType.Classic;
             ModernSearchRadioButton.IsChecked = task.SearchParameters.SearchType == SearchType.Modern;

--- a/MetaMorpheus/GUI/TaskWindows/XLSearchTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/XLSearchTaskWindow.xaml.cs
@@ -121,6 +121,7 @@ namespace MetaMorpheusGUI
 
         private void UpdateFieldsFromTask(XLSearchTask task)
         {
+            MetaMorpheusTask.DetermineAnalyteType(TheTask.CommonParameters);
             cbCrosslinkers.SelectedItem = task.XlSearchParameters.Crosslinker;
             txtXLTopNum.Text = task.XlSearchParameters.CrosslinkSearchTopNum.ToString(CultureInfo.InvariantCulture);
             ckbAddCompIon.IsChecked = task.CommonParameters.AddCompIons;


### PR DESCRIPTION
Added the option to set custom deconvolution parameters in calibration. 

Added MetaMorpheusTask.DetermineAnalyteType(TheTask.CommonParameters) 
at the beginning of the UpdateFieldsFromTask method in task windows. This ensures analyte type is determined and set
before updating fields from the task.