### PR TITLE
Speed up task window launch

### DIFF
--- a/MetaMorpheus/GuiFunctions/MetaDraw/DrawnSequence.cs
+++ b/MetaMorpheus/GuiFunctions/MetaDraw/DrawnSequence.cs
@@ -381,25 +381,26 @@ namespace GuiFunctions
 
         public static SolidColorBrush ParseColorBrushFromOxyColor(OxyColor color)
         {
-            var colorVal = color.ToByteString().Split(',');
-            return new SolidColorBrush(System.Windows.Media.Color.FromArgb(Byte.Parse(colorVal[0]), Byte.Parse(colorVal[1]), Byte.Parse(colorVal[2]), Byte.Parse(colorVal[3])));
+            return new SolidColorBrush(Color.FromArgb(color.A, color.R, color.G, color.B));
         }
 
         public static SolidColorBrush ParseColorBrushFromName(string name)
         {
-            OxyColor color = MetaDrawSettings.PossibleColors.Keys.Where(p => p.GetColorName().Equals(name.Replace(" ", ""))).First();
-            return ParseColorBrushFromOxyColor(color);
+            string cleanedName = name.Replace(" ", "");
+            var foundColor = MetaDrawSettings.PossibleColors.FirstOrDefault(p => p.Value == cleanedName).Key;
+            return ParseColorBrushFromOxyColor(foundColor == default ? MetaDrawSettings.FallbackColor : foundColor);
         }
 
         public static OxyColor ParseOxyColorFromName(string name)
         {
-            return MetaDrawSettings.PossibleColors.Keys.Where(p => p.GetColorName().Equals(name.Replace(" ", ""))).First();
+            string cleanedName = name.Replace(" ", "");
+            var foundColor = MetaDrawSettings.PossibleColors.FirstOrDefault(p => p.Value == cleanedName).Key;
+            return foundColor == default ? MetaDrawSettings.FallbackColor : foundColor;
         }
 
         public static Color ParseColorFromOxyColor(OxyColor color)
         {
-            var colorVal = color.ToByteString().Split(',');
-            return System.Windows.Media.Color.FromArgb(Byte.Parse(colorVal[0]), Byte.Parse(colorVal[1]), Byte.Parse(colorVal[2]), Byte.Parse(colorVal[3]));
+            return Color.FromArgb(color.A, color.R, color.G, color.B);
         }
 
         /// <summary>

--- a/MetaMorpheus/GuiFunctions/MetaDraw/MetaDrawSettings.cs
+++ b/MetaMorpheus/GuiFunctions/MetaDraw/MetaDrawSettings.cs
@@ -37,6 +37,7 @@ namespace GuiFunctions
         public static bool AnnotationBold { get; set; } = false;
         public static bool DisplayInternalIons { get; set; } = true;
         public static bool DisplayInternalIonAnnotations { get; set; }= true;
+        public static OxyColor FallbackColor { get; } = OxyColors.Aqua;
         public static Dictionary<OxyColor, string> PossibleColors { get; set; }
         public static Dictionary<ProductType, OxyColor> ProductTypeToColor { get; set; }
         public static Dictionary<ProductType, OxyColor> BetaProductTypeToColor { get; set; }

--- a/MetaMorpheus/GuiFunctions/ViewModels/CoverageTypeForTreeViewModel.cs
+++ b/MetaMorpheus/GuiFunctions/ViewModels/CoverageTypeForTreeViewModel.cs
@@ -51,7 +51,7 @@ namespace GuiFunctions
         {
             Name = name;
             OxyColor color = MetaDrawSettings.CoverageTypeToColor[name];
-            SelectedColor = AddSpaces(color.GetColorName());
+            SelectedColor = AddSpaces(MetaDrawSettings.PossibleColors[color]);
             ColorBrush = DrawnSequence.ParseColorBrushFromOxyColor(color);
         }
 

--- a/MetaMorpheus/GuiFunctions/ViewModels/IonForTreeViewModel.cs
+++ b/MetaMorpheus/GuiFunctions/ViewModels/IonForTreeViewModel.cs
@@ -66,7 +66,7 @@ namespace GuiFunctions
                 color = MetaDrawSettings.BetaProductTypeToColor[IonType];
             else
                 color = MetaDrawSettings.ProductTypeToColor[IonType];
-            SelectedColor = AddSpaces(color.GetColorName());
+            SelectedColor = AddSpaces(MetaDrawSettings.PossibleColors[color]);
             ColorBrush = DrawnSequence.ParseColorBrushFromOxyColor(color);
         }
 

--- a/MetaMorpheus/GuiFunctions/ViewModels/ModForTreeViewModel.cs
+++ b/MetaMorpheus/GuiFunctions/ViewModels/ModForTreeViewModel.cs
@@ -74,8 +74,8 @@ namespace GuiFunctions
                 // This if statement prevents a crash from loading a search task modifications not found on launch
                 // This can occur due to new custom modifications or a mod in the xml database that was not in our initial list
                 if (!MetaDrawSettings.ModificationTypeToColor.TryGetValue(modName, out OxyColor color))
-                    color = OxyColors.Aqua;
-                SelectedColor = AddSpaces(color.GetColorName());
+                    color = MetaDrawSettings.FallbackColor;
+                SelectedColor = AddSpaces(MetaDrawSettings.PossibleColors[color]);
                 ColorBrush = DrawnSequence.ParseColorBrushFromOxyColor(color);
             }
             

--- a/MetaMorpheus/GuiFunctions/ViewModels/ModForTreeViewModel.cs
+++ b/MetaMorpheus/GuiFunctions/ViewModels/ModForTreeViewModel.cs
@@ -14,6 +14,7 @@ namespace GuiFunctions
         private bool _isChecked;
         private string _selectedColor;
         private SolidColorBrush _colorBrush;
+        private bool _colorDataLoaded;
 
         #endregion
 
@@ -23,10 +24,7 @@ namespace GuiFunctions
 
         public bool Use
         {
-            get
-            {
-                return _isChecked;
-            }
+            get => _isChecked;
             set
             {
                 _isChecked = value;
@@ -40,17 +38,26 @@ namespace GuiFunctions
         public Brush Background { get; }
         public string SelectedColor
         {
-            get { return _selectedColor; }
+            get
+            {
+                EnsureColorDataLoaded();
+                return _selectedColor;
+            }
             set
             {
                 _selectedColor = value;
                 ColorBrush = DrawnSequence.ParseColorBrushFromName(_selectedColor);
+                _colorDataLoaded = true;
                 OnPropertyChanged(nameof(SelectedColor));
             }
         }
         public SolidColorBrush ColorBrush
         {
-            get { return _colorBrush; }
+            get
+            {
+                EnsureColorDataLoaded();
+                return _colorBrush;
+            }
             set
             {
                 _colorBrush = value;
@@ -69,16 +76,6 @@ namespace GuiFunctions
             Use = use;
             ModName = modName;
             DisplayName = modName;
-            if (MetaDrawSettings.ModificationTypeToColor != null)
-            {
-                // This if statement prevents a crash from loading a search task modifications not found on launch
-                // This can occur due to new custom modifications or a mod in the xml database that was not in our initial list
-                if (!MetaDrawSettings.ModificationTypeToColor.TryGetValue(modName, out OxyColor color))
-                    color = MetaDrawSettings.FallbackColor;
-                SelectedColor = AddSpaces(MetaDrawSettings.PossibleColors[color]);
-                ColorBrush = DrawnSequence.ParseColorBrushFromOxyColor(color);
-            }
-            
 
             if (toolTip.ToLower().Contains("terminal"))
             {
@@ -103,6 +100,27 @@ namespace GuiFunctions
         }
 
         #endregion
+
+        /// <summary>
+        /// Ensures the color data is loaded. This is necessary because the color data is not loaded until the first time it is accessed.
+        /// This enables the use of the same control in MetaDraw and Task Windows without loading the color data for task windows. 
+        /// </summary>
+        private void EnsureColorDataLoaded()
+        {
+            if (!_colorDataLoaded)
+            {
+                if (MetaDrawSettings.ModificationTypeToColor != null)
+                {
+                    // This if statement prevents a crash from loading a search task modifications not found on launch
+                    // This can occur due to new custom modifications or a mod in the xml database that was not in our initial list
+                    if (!MetaDrawSettings.ModificationTypeToColor.TryGetValue(ModName, out OxyColor color))
+                        color = MetaDrawSettings.FallbackColor;
+                    _selectedColor = AddSpaces(MetaDrawSettings.PossibleColors[color]);
+                    _colorBrush = DrawnSequence.ParseColorBrushFromOxyColor(color);
+                }
+                _colorDataLoaded = true;
+            }
+        }
 
         public void SelectionChanged(string newColor)
         {

--- a/MetaMorpheus/Test/MetaDraw/MetaDrawSettingsAndViewsTest.cs
+++ b/MetaMorpheus/Test/MetaDraw/MetaDrawSettingsAndViewsTest.cs
@@ -595,9 +595,13 @@ namespace Test.MetaDraw
 
             var colorBrushfromName = DrawnSequence.ParseColorBrushFromName(oxyBlue.GetColorName());
             Assert.That(colorBrushfromName.Color == brushBlue.Color);
+            var colorBrushfromNameBad = DrawnSequence.ParseColorBrushFromName("humbug");
+            Assert.That(colorBrushfromNameBad.Color == Colors.Aqua);
 
             var oxyFromName = DrawnSequence.ParseOxyColorFromName(oxyBlue.GetColorName());
             Assert.That(oxyFromName == oxyBlue);
+            var oxyFromNameBad = DrawnSequence.ParseOxyColorFromName("gobbledygook");
+            Assert.That(oxyFromNameBad == MetaDrawSettings.FallbackColor);
 
             var colorFromOxy = DrawnSequence.ParseColorFromOxyColor(oxyBlue);
             Assert.That(colorFromOxy == colorBlue);


### PR DESCRIPTION
## PR Summary

Task window launch was slowed down because the View model behind each modification checkbox was loading the MetaDraw color for it from a slow reflection method: OxyPlot.GetColorName(). 

This pull request improves loading time by 
1. Deferring instantiation of color related data until it is first called. 
2. Using a cached value in MetaDrawSettings instead of calling the OxyPlot slow reflection method. 


## Detailed Changed

Improvements to color parsing and handling:

* [`MetaMorpheus/GuiFunctions/MetaDraw/DrawnSequence.cs`](diffhunk://#diff-6052a29d4ed153419466b3cbc1d54b74a09485576876a69b01c91e281dab7d1cL384-R403): Simplified the `ParseColorBrushFromOxyColor`, `ParseColorBrushFromName`, and `ParseOxyColorFromName` methods by removing unnecessary string manipulations and adding fallback color handling.
* [`MetaMorpheus/GuiFunctions/MetaDraw/MetaDrawSettings.cs`](diffhunk://#diff-3f93cbf81143cecf8eaad9efc01feb48186810b7a8d0b5d53e54b57b90799046R40): Added a new static property `FallbackColor` to provide a default color when a specified color is not found.

Updates to view models:

* [`MetaMorpheus/GuiFunctions/ViewModels/CoverageTypeForTreeViewModel.cs`](diffhunk://#diff-afb0795faecb0f20f0f0fab6a1353d2377c94d0e89b6d64b81d2b56cf913e168L54-R54): Updated the constructor to use the `PossibleColors` dictionary for color name retrieval.
* [`MetaMorpheus/GuiFunctions/ViewModels/IonForTreeViewModel.cs`](diffhunk://#diff-81c3eaa46d0d4c997a2c3b6784ee048bf3349329efb36fff9cd55e14bef02d9aL69-R69): Modified the constructor to use the `PossibleColors` dictionary for color name retrieval.
* [`MetaMorpheus/GuiFunctions/ViewModels/ModForTreeViewModel.cs`](diffhunk://#diff-db6ebb7c6cc8e8c8e2d2e2509cd13aa691cdda883a4aa94fd1c14957d3bd5343L77-R78): Updated the constructor to use `FallbackColor` and the `PossibleColors` dictionary for color name retrieval.

Enhancements to tests:

* [`MetaMorpheus/Test/MetaDraw/MetaDrawSettingsAndViewsTest.cs`](diffhunk://#diff-d174459732575dfc8b28443140793b8b8044d90c7b4522b00f78535fec283c7dR598-R604): Added tests to validate the fallback color functionality when an unknown color name is provided.