### PR TITLE
Model lock

### DIFF
--- a/MetaMorpheus/EngineLayer/FdrAnalysis/PEPAnalysisEngine.cs
+++ b/MetaMorpheus/EngineLayer/FdrAnalysis/PEPAnalysisEngine.cs
@@ -17,6 +17,7 @@ using System.Threading.Tasks;
 using Omics.Modifications;
 using Omics;
 using Easy.Common.Extensions;
+using System.Threading;
 
 namespace EngineLayer
 {
@@ -382,7 +383,6 @@ namespace EngineLayer
         }
 
         private readonly object _modelLock = new();
-        private readonly object _peptideCountLock = new();
 
         public int Compute_PSM_PEP(List<SpectralMatchGroup> peptideGroups,
             List<int> peptideGroupIndices,
@@ -460,10 +460,7 @@ namespace EngineLayer
                         }
                     }
 
-                    lock (_peptideCountLock)
-                    {
-                        ambiguousPeptidesResolved += ambigousPeptidesRemovedinThread;
-                    }
+                    Interlocked.Add(ref ambiguousPeptidesResolved, ambigousPeptidesRemovedinThread);
                 });
             return ambiguousPeptidesResolved;
         }

--- a/MetaMorpheus/EngineLayer/FdrAnalysis/PEPAnalysisEngine.cs
+++ b/MetaMorpheus/EngineLayer/FdrAnalysis/PEPAnalysisEngine.cs
@@ -406,6 +406,7 @@ namespace EngineLayer
                     if (GlobalVariables.StopLoops) { return; }
 
                     ITransformer threadSpecificTrainedModel;
+                    
                     if (maxThreads == 1)
                     {
                         threadSpecificTrainedModel = trainedModel;

--- a/MetaMorpheus/EngineLayer/FdrAnalysis/PEPAnalysisEngine.cs
+++ b/MetaMorpheus/EngineLayer/FdrAnalysis/PEPAnalysisEngine.cs
@@ -381,6 +381,8 @@ namespace EngineLayer
             return s.ToString();
         }
 
+        private readonly object _modelLock = new();
+
         public int Compute_PSM_PEP(List<SpectralMatchGroup> peptideGroups,
             List<int> peptideGroupIndices,
             MLContext mLContext, TransformerChain<BinaryPredictionTransformer<Microsoft.ML.Calibrators.CalibratedModelParametersBase<Microsoft.ML.Trainers.FastTree.FastTreeBinaryModelParameters, Microsoft.ML.Calibrators.PlattCalibrator>>> trainedModel, string searchType, string outputFolder)
@@ -410,7 +412,10 @@ namespace EngineLayer
                     }
                     else
                     {
-                        threadSpecificTrainedModel = mLContext.Model.Load(Path.Combine(outputFolder, "model.zip"), out DataViewSchema savedModelSchema);
+                        lock (_modelLock)
+                        {
+                            threadSpecificTrainedModel = mLContext.Model.Load(Path.Combine(outputFolder, "model.zip"), out DataViewSchema savedModelSchema);
+                        }
                     }
 
                     // one prediction engine per thread, because the prediction engine is not thread-safe

--- a/MetaMorpheus/EngineLayer/FdrAnalysis/PEPAnalysisEngine.cs
+++ b/MetaMorpheus/EngineLayer/FdrAnalysis/PEPAnalysisEngine.cs
@@ -382,13 +382,13 @@ namespace EngineLayer
         }
 
         private readonly object _modelLock = new();
+        private readonly object _peptideCountLock = new();
 
         public int Compute_PSM_PEP(List<SpectralMatchGroup> peptideGroups,
             List<int> peptideGroupIndices,
             MLContext mLContext, TransformerChain<BinaryPredictionTransformer<Microsoft.ML.Calibrators.CalibratedModelParametersBase<Microsoft.ML.Trainers.FastTree.FastTreeBinaryModelParameters, Microsoft.ML.Calibrators.PlattCalibrator>>> trainedModel, string searchType, string outputFolder)
         {
             int maxThreads = FileSpecificParametersDictionary.Values.FirstOrDefault().MaxThreadsToUsePerFile;
-            object lockObject = new object();
             int ambiguousPeptidesResolved = 0;
 
             //the trained model is not threadsafe. Therefore, to use the same model for each thread saved the model to disk. Then each thread reads its own copy of the model back from disk.
@@ -460,7 +460,7 @@ namespace EngineLayer
                         }
                     }
 
-                    lock (lockObject)
+                    lock (_peptideCountLock)
                     {
                         ambiguousPeptidesResolved += ambigousPeptidesRemovedinThread;
                     }

--- a/MetaMorpheus/Test/PostSearchAnalysisTaskTests.cs
+++ b/MetaMorpheus/Test/PostSearchAnalysisTaskTests.cs
@@ -71,6 +71,13 @@ namespace Test
         }
 
         [Test]
+        public static void LocalTest()
+        {
+            var modelPath = @"D:\MetaMorpheusVignette\Search_0105GPTMD_NotchSorting\Task1-SearchTask\model.zip";
+            //mLContext.Model.Load(Path.Combine(outputFolder, "model.zip"), out DataViewSchema savedModelSchema);
+        }
+
+        [Test]
         public static void AllResultsAndResultsTxtContainsCorrectValues_PepQValue_BottomUp()
         {
             //First test that AllResults and Results display correct numbers of peptides and psms with pep q-value filter on

--- a/MetaMorpheus/Test/TestData/Task1-SearchTaskconfig.toml
+++ b/MetaMorpheus/Test/TestData/Task1-SearchTaskconfig.toml
@@ -39,7 +39,7 @@ UniProt = 2
 
 [CommonParameters]
 TaskDescriptor = "SearchTask"
-MaxThreadsToUsePerFile = 1
+MaxThreadsToUsePerFile = 2
 ListOfModsFixed = "Common Fixed\tCarbamidomethyl on C\t\tCommon Fixed\tCarbamidomethyl on U"
 ListOfModsVariable = "Common Variable\tOxidation on M"
 DoPrecursorDeconvolution = true


### PR DESCRIPTION
In the PEP analysis engine, multiple threads need to read in the stored model. Currently, no lock is activated during reading, which can result in multiple threads reading the model simultaneously, resulting in a crash.

I'm not sure how to write unit tests for lock objects, so I was hoping we could let this one get through with low patch coverage