### PR TITLE
Made updates pertaining to PIP-ECHO

### DIFF
--- a/MetaMorpheus/EngineLayer/SpectralMatch.cs
+++ b/MetaMorpheus/EngineLayer/SpectralMatch.cs
@@ -85,7 +85,7 @@ namespace EngineLayer
         public FdrInfo PeptideFdrInfo { get;  set; }
         public FdrInfo GetFdrInfo(bool peptideLevel)
         {
-            return peptideLevel ? PeptideFdrInfo : PsmFdrInfo;
+            return peptideLevel & PeptideFdrInfo != null ? PeptideFdrInfo : PsmFdrInfo;
         }
 
         public PsmData PsmData_forPEPandPercolator { get; set; }

--- a/MetaMorpheus/EngineLayer/SpectralMatch.cs
+++ b/MetaMorpheus/EngineLayer/SpectralMatch.cs
@@ -85,7 +85,7 @@ namespace EngineLayer
         public FdrInfo PeptideFdrInfo { get;  set; }
         public FdrInfo GetFdrInfo(bool peptideLevel)
         {
-            return peptideLevel & PeptideFdrInfo != null ? PeptideFdrInfo : PsmFdrInfo;
+            return peptideLevel ? PeptideFdrInfo : PsmFdrInfo;
         }
 
         public PsmData PsmData_forPEPandPercolator { get; set; }

--- a/MetaMorpheus/GUI/TaskWindows/CalibrateTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/CalibrateTaskWindow.xaml.cs
@@ -198,7 +198,7 @@ namespace MetaMorpheusGUI
 
             if (!GlobalGuiSettings.CheckTaskSettingsValidity(PrecursorMassToleranceTextBox.Text, ProductMassToleranceTextBox.Text, MissedCleavagesTextBox.Text,
                  MaxModificationIsoformsTextBox.Text, MinPeptideLengthTextBox.Text, MaxPeptideLengthTextBox.Text, MaxThreadsTextBox.Text, MinScoreAllowed.Text,
-                 fieldNotUsed, fieldNotUsed, fieldNotUsed, fieldNotUsed, fieldNotUsed, null, null, fieldNotUsed, MaxModsPerPeptideTextBox.Text, fieldNotUsed, 
+                 fieldNotUsed, fieldNotUsed, fieldNotUsed, fieldNotUsed, fieldNotUsed, fieldNotUsed, null, null, fieldNotUsed, MaxModsPerPeptideTextBox.Text, fieldNotUsed, 
                  null, null, null))
             {
                 return;

--- a/MetaMorpheus/GUI/TaskWindows/GPTMDTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/GPTMDTaskWindow.xaml.cs
@@ -359,7 +359,7 @@ namespace MetaMorpheusGUI
 
             if (!GlobalGuiSettings.CheckTaskSettingsValidity(PrecursorMassToleranceTextBox.Text, ProductMassToleranceTextBox.Text, MissedCleavagesTextBox.Text,
                  MaxModificationIsoformsTextBox.Text, MinPeptideLengthTextBox.Text, MaxPeptideLengthTextBox.Text, MaxThreadsTextBox.Text, MinScoreAllowed.Text,
-                fieldNotUsed, fieldNotUsed, DeconHostViewModel.PrecursorDeconvolutionParameters.MaxAssumedChargeState.ToString(), NumberOfPeaksToKeepPerWindowTextBox.Text, MinimumAllowedIntensityRatioToBasePeakTexBox.Text, 
+                fieldNotUsed, fieldNotUsed, fieldNotUsed, DeconHostViewModel.PrecursorDeconvolutionParameters.MaxAssumedChargeState.ToString(), NumberOfPeaksToKeepPerWindowTextBox.Text, MinimumAllowedIntensityRatioToBasePeakTexBox.Text, 
                 null, null, fieldNotUsed, fieldNotUsed, fieldNotUsed, null, null, null))
             {
                 return;

--- a/MetaMorpheus/GUI/TaskWindows/GlycoSearchTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/GlycoSearchTaskWindow.xaml.cs
@@ -247,7 +247,7 @@ namespace MetaMorpheusGUI
 
             if (!GlobalGuiSettings.CheckTaskSettingsValidity(PrecusorMsTlTextBox.Text, productMassToleranceTextBox.Text, missedCleavagesTextBox.Text,
                 maxModificationIsoformsTextBox.Text, MinPeptideLengthTextBox.Text, MaxPeptideLengthTextBox.Text, maxThreadsTextBox.Text, minScoreAllowed.Text,
-                fieldNotUsed, fieldNotUsed, DeconHostViewModel.PrecursorDeconvolutionParameters.MaxAssumedChargeState.ToString(), TopNPeaksTextBox.Text, MinRatioTextBox.Text, null, null, numberOfDatabaseSearchesTextBox.Text, TxtBoxMaxModPerPep.Text, 
+                fieldNotUsed, fieldNotUsed, fieldNotUsed, DeconHostViewModel.PrecursorDeconvolutionParameters.MaxAssumedChargeState.ToString(), TopNPeaksTextBox.Text, MinRatioTextBox.Text, null, null, numberOfDatabaseSearchesTextBox.Text, TxtBoxMaxModPerPep.Text, 
                 fieldNotUsed, null, null, null))
             {
                 return;

--- a/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml
+++ b/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml
@@ -564,7 +564,7 @@
                                         <ToolTip Content="Q-Value Threshold for MBR&#x0a;Determines which MBR matches will be reported in the AllQuantifiedPeptides and AllQuantifiedProteinGroups outputs" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500" />
                                     </ToolTipService.ToolTip>
                                 </local:DoubleTextBoxControl>
-                                <Label x:Name="MbrFdrThreshold" Content=" MBR FDR Threshold" />
+                                <Label x:Name="MbrFdrThreshold" Content=" MBR Q-Value Threshold" />
                             </StackPanel>
 
                             <!-- Multiplex Options -->

--- a/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml
+++ b/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml
@@ -428,10 +428,10 @@
                                     <ToolTip Content="Intensity of reporter ions are reported as additional columns in AllPeptides.psmtsv and AllPSMs.psmtsv" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500"/>
                                 </ToolTipService.ToolTip>
                             </RadioButton>
-                            <RadioButton x:Name="CheckBoxLFQwSpectralRecovery" Content="LFQ + Spectral Recovery: Spectral recovery finds misidentified MS/MS spectra common in single-cell proteomics data" 
+                            <RadioButton x:Name="CheckBoxLFQwSpectralRecovery" Content="LFQ + Spectral Recovery: Spectral recovery finds missed MS/MS spectra common in single-cell proteomics data" 
                                          GroupName="QuantType" Click="SpectralRecoveryUpdate">
                                 <ToolTipService.ToolTip>
-                                    <ToolTip Content="Match between runs analysis via spectral library search" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500" />
+                                    <ToolTip Content="Re-analyzes MS/MS spectra based on the results of MBR to find spectra that may have been missed during the inital search" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500" />
                                 </ToolTipService.ToolTip>
                             </RadioButton>
 
@@ -508,7 +508,7 @@
                                     </MultiBinding>
                                 </CheckBox.Visibility>
                                 <ToolTipService.ToolTip>
-                                    <ToolTip Content="(LFQ) Use MS2 identifications from one run to quantify those same peptides in other runs where they were not identified&#x0a;Selecting &quot;Write Spectral Library&quot; in the Output Options below will enable additional MBR analysis" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500" />
+                                    <ToolTip Content="(LFQ) Use MS2 identifications from one run to quantify those same peptides in other runs where they were not identified" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500" />
                                 </ToolTipService.ToolTip>
                             </CheckBox>
                             <CheckBox x:Name="CheckBoxNormalize" Content="Normalize quantification results">
@@ -561,7 +561,7 @@
                                 
                                 <local:DoubleTextBoxControl x:Name="MbrFdrThresholdTextBox" Width="45" Height="20">
                                     <ToolTipService.ToolTip>
-                                        <ToolTip Content="FDR Threshold for MBR Results" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500" />
+                                        <ToolTip Content="Q-Value Threshold for MBR&#x0a;Determines which MBR matches will be reported in the AllQuantifiedPeptides and AllQuantifiedProteinGroups outputs" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500" />
                                     </ToolTipService.ToolTip>
                                 </local:DoubleTextBoxControl>
                                 <Label x:Name="MbrFdrThreshold" Content=" MBR FDR Threshold" />

--- a/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml
+++ b/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml
@@ -546,37 +546,25 @@
                                 </ToolTipService.ToolTip>
                             </CheckBox>
                             <StackPanel Orientation="Horizontal">
+                                <StackPanel.IsEnabled>
+                                    <MultiBinding Converter="{StaticResource boolOrConverter}">
+                                        <Binding  ElementName="CheckBoxLFQ" Path ="IsChecked"/>
+                                        <Binding  ElementName="CheckBoxLFQwSpectralRecovery" Path ="IsChecked"/>
+                                    </MultiBinding>
+                                </StackPanel.IsEnabled>
+                                <StackPanel.Visibility>
+                                    <MultiBinding Converter="{StaticResource boolOr2VisConverter}">
+                                        <Binding  ElementName="CheckBoxLFQ" Path ="IsChecked"/>
+                                        <Binding  ElementName="CheckBoxLFQwSpectralRecovery" Path ="IsChecked"/>
+                                    </MultiBinding>
+                                </StackPanel.Visibility>
+                                
                                 <local:DoubleTextBoxControl x:Name="MbrFdrThresholdTextBox" Width="45" Height="20">
-                                    <TextBox.IsEnabled>
-                                        <MultiBinding Converter="{StaticResource boolOrConverter}">
-                                            <Binding  ElementName="CheckBoxLFQ" Path ="IsChecked"/>
-                                            <Binding  ElementName="CheckBoxLFQwSpectralRecovery" Path ="IsChecked"/>
-                                        </MultiBinding>
-                                    </TextBox.IsEnabled>
-                                    <TextBox.Visibility>
-                                        <MultiBinding Converter="{StaticResource boolOr2VisConverter}">
-                                            <Binding  ElementName="CheckBoxLFQ" Path ="IsChecked"/>
-                                            <Binding  ElementName="CheckBoxLFQwSpectralRecovery" Path ="IsChecked"/>
-                                        </MultiBinding>
-                                    </TextBox.Visibility>
                                     <ToolTipService.ToolTip>
                                         <ToolTip Content="FDR Threshold for MBR Results" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500" />
                                     </ToolTipService.ToolTip>
                                 </local:DoubleTextBoxControl>
-                                <Label x:Name="MbrFdrThreshold" Content=" MBR FDR Threshold">
-                                    <Label.IsEnabled>
-                                        <MultiBinding Converter="{StaticResource boolOrConverter}">
-                                            <Binding  ElementName="CheckBoxLFQ" Path ="IsChecked"/>
-                                            <Binding  ElementName="CheckBoxLFQwSpectralRecovery" Path ="IsChecked"/>
-                                        </MultiBinding>
-                                    </Label.IsEnabled>
-                                    <Label.Visibility>
-                                        <MultiBinding Converter="{StaticResource boolOr2VisConverter}">
-                                            <Binding  ElementName="CheckBoxLFQ" Path ="IsChecked"/>
-                                            <Binding  ElementName="CheckBoxLFQwSpectralRecovery" Path ="IsChecked"/>
-                                        </MultiBinding>
-                                    </Label.Visibility>
-                                </Label>
+                                <Label x:Name="MbrFdrThreshold" Content=" MBR FDR Threshold" />
                             </StackPanel>
 
                             <!-- Multiplex Options -->

--- a/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml
+++ b/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml
@@ -545,6 +545,39 @@
                                     <ToolTip Content="Use peptide sequences shared between proteins for protein quantification" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500" />
                                 </ToolTipService.ToolTip>
                             </CheckBox>
+                            <StackPanel Orientation="Horizontal">
+                                <local:DoubleTextBoxControl x:Name="MbrFdrThresholdTextBox" Width="45" Height="20">
+                                    <TextBox.IsEnabled>
+                                        <MultiBinding Converter="{StaticResource boolOrConverter}">
+                                            <Binding  ElementName="CheckBoxLFQ" Path ="IsChecked"/>
+                                            <Binding  ElementName="CheckBoxLFQwSpectralRecovery" Path ="IsChecked"/>
+                                        </MultiBinding>
+                                    </TextBox.IsEnabled>
+                                    <TextBox.Visibility>
+                                        <MultiBinding Converter="{StaticResource boolOr2VisConverter}">
+                                            <Binding  ElementName="CheckBoxLFQ" Path ="IsChecked"/>
+                                            <Binding  ElementName="CheckBoxLFQwSpectralRecovery" Path ="IsChecked"/>
+                                        </MultiBinding>
+                                    </TextBox.Visibility>
+                                    <ToolTipService.ToolTip>
+                                        <ToolTip Content="FDR Threshold for MBR Results" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500" />
+                                    </ToolTipService.ToolTip>
+                                </local:DoubleTextBoxControl>
+                                <Label x:Name="MbrFdrThreshold" Content=" MBR FDR Threshold">
+                                    <Label.IsEnabled>
+                                        <MultiBinding Converter="{StaticResource boolOrConverter}">
+                                            <Binding  ElementName="CheckBoxLFQ" Path ="IsChecked"/>
+                                            <Binding  ElementName="CheckBoxLFQwSpectralRecovery" Path ="IsChecked"/>
+                                        </MultiBinding>
+                                    </Label.IsEnabled>
+                                    <Label.Visibility>
+                                        <MultiBinding Converter="{StaticResource boolOr2VisConverter}">
+                                            <Binding  ElementName="CheckBoxLFQ" Path ="IsChecked"/>
+                                            <Binding  ElementName="CheckBoxLFQwSpectralRecovery" Path ="IsChecked"/>
+                                        </MultiBinding>
+                                    </Label.Visibility>
+                                </Label>
+                            </StackPanel>
 
                             <!-- Multiplex Options -->
                             <StackPanel Orientation="Horizontal" Margin="5 5 5 0" Grid.Column="0" Grid.Row="0">

--- a/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml.cs
@@ -261,6 +261,8 @@ namespace MetaMorpheusGUI
             CheckBoxQuantifyUnlabeledForSilac.IsChecked = task.CommonParameters.DigestionParams.GeneratehUnlabeledProteinsForSilac;
             PeakFindingToleranceTextBox.Text = task.SearchParameters.QuantifyPpmTol.ToString(CultureInfo.InvariantCulture);
             CheckBoxMatchBetweenRuns.IsChecked = task.SearchParameters.MatchBetweenRuns;
+            MbrFdrThresholdTextBox.Text = task.SearchParameters.MbrFdrThreshold.ToString(CultureInfo.InvariantCulture);
+            MbrFdrThresholdTextBox.Text = task.SearchParameters.MbrFdrThreshold.ToString(CultureInfo.InvariantCulture);
             CheckBoxNormalize.IsChecked = task.SearchParameters.Normalize;
             ModPepsAreUnique.IsChecked = task.SearchParameters.ModPeptidesAreDifferent;
             CheckBoxHistogramAnalysis.IsChecked = task.SearchParameters.DoHistogramAnalysis;
@@ -441,6 +443,7 @@ namespace MetaMorpheusGUI
                 MaxThreadsTextBox.Text, 
                 MinScoreAllowed.Text,
                 PeakFindingToleranceTextBox.Text, 
+                MbrFdrThresholdTextBox.Text,
                 HistogramBinWidthTextBox.Text, 
                 DeconHostViewModel.PrecursorDeconvolutionParameters.MaxAssumedChargeState.ToString(), 
                 NumberOfPeaksToKeepPerWindowTextBox.Text,
@@ -640,6 +643,7 @@ namespace MetaMorpheusGUI
             TheTask.SearchParameters.MultiplexModId = (string)MultiplexComboBox.SelectedItem;
             TheTask.SearchParameters.Normalize = CheckBoxNormalize.IsChecked.Value;
             TheTask.SearchParameters.MatchBetweenRuns = CheckBoxMatchBetweenRuns.IsChecked.Value;
+            TheTask.SearchParameters.MbrFdrThreshold = double.Parse(MbrFdrThresholdTextBox.Text, CultureInfo.InvariantCulture);
             TheTask.SearchParameters.ModPeptidesAreDifferent = ModPepsAreUnique.IsChecked.Value;
             TheTask.SearchParameters.QuantifyPpmTol = double.Parse(PeakFindingToleranceTextBox.Text, CultureInfo.InvariantCulture);
             TheTask.SearchParameters.SearchTarget = CheckBoxTarget.IsChecked.Value;

--- a/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml.cs
@@ -262,7 +262,6 @@ namespace MetaMorpheusGUI
             PeakFindingToleranceTextBox.Text = task.SearchParameters.QuantifyPpmTol.ToString(CultureInfo.InvariantCulture);
             CheckBoxMatchBetweenRuns.IsChecked = task.SearchParameters.MatchBetweenRuns;
             MbrFdrThresholdTextBox.Text = task.SearchParameters.MbrFdrThreshold.ToString(CultureInfo.InvariantCulture);
-            MbrFdrThresholdTextBox.Text = task.SearchParameters.MbrFdrThreshold.ToString(CultureInfo.InvariantCulture);
             CheckBoxNormalize.IsChecked = task.SearchParameters.Normalize;
             ModPepsAreUnique.IsChecked = task.SearchParameters.ModPeptidesAreDifferent;
             CheckBoxHistogramAnalysis.IsChecked = task.SearchParameters.DoHistogramAnalysis;

--- a/MetaMorpheus/GUI/TaskWindows/XLSearchTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/XLSearchTaskWindow.xaml.cs
@@ -239,7 +239,7 @@ namespace MetaMorpheusGUI
 
             if (!GlobalGuiSettings.CheckTaskSettingsValidity(XLPrecusorMsTlTextBox.Text, productMassToleranceTextBox.Text, missedCleavagesTextBox.Text,
                 maxModificationIsoformsTextBox.Text, MinPeptideLengthTextBox.Text, MaxPeptideLengthTextBox.Text, maxThreadsTextBox.Text, minScoreAllowed.Text,
-                fieldNotUsed, fieldNotUsed, DeconHostViewModel.PrecursorDeconvolutionParameters.MaxAssumedChargeState.ToString(), TopNPeaksTextBox.Text, MinRatioTextBox.Text, null, null, numberOfDatabaseSearchesTextBox.Text, 
+                fieldNotUsed, fieldNotUsed, fieldNotUsed, DeconHostViewModel.PrecursorDeconvolutionParameters.MaxAssumedChargeState.ToString(), TopNPeaksTextBox.Text, MinRatioTextBox.Text, null, null, numberOfDatabaseSearchesTextBox.Text, 
                 fieldNotUsed, fieldNotUsed, null, null, null))
             {
                 return;

--- a/MetaMorpheus/GUI/Util/GlobalGuiSettings.cs
+++ b/MetaMorpheus/GUI/Util/GlobalGuiSettings.cs
@@ -23,6 +23,7 @@ namespace MetaMorpheusGUI
             string maxThreads,
             string minScore,
             string peakFindingTolerance,
+            string mbrFdrThreshold,
             string histogramBinWidth,
             string deconMaxAssumedCharge,
             string numberOfPeaksToKeepPerWindow,
@@ -50,6 +51,7 @@ namespace MetaMorpheusGUI
                 (CheckMaxThreads(maxThreads)),
                 (CheckMinScoreAllowed(minScore)),
                 (CheckPeakFindingTolerance(peakFindingTolerance)),
+                (CheckMbrFdrThreshold(mbrFdrThreshold)),
                 (CheckHistogramBinWidth(histogramBinWidth)),
                 (CheckDeconvolutionMaxAssumedChargeState(deconMaxAssumedCharge)),
                 (CheckTopNPeaks(numberOfPeaksToKeepPerWindow)),
@@ -271,7 +273,18 @@ namespace MetaMorpheusGUI
             }
             return true;
         }
-      
+
+        public static bool CheckMbrFdrThreshold(string text)
+        {
+            if (!double.TryParse(text, NumberStyles.Any, CultureInfo.InvariantCulture, out double mbrFdrThreshold) || mbrFdrThreshold > 1)
+            {
+                MessageBox.Show("The MBR FDR Threshold is invalid. \n You entered " + '"' + text + '"' + "\n Please enter a positive number less than or equal to 1.");
+                return false;
+            }
+            return true;
+        }
+        
+
         public static bool CheckHistogramBinWidth(string text)
         {
             if (!double.TryParse(text, NumberStyles.Any, CultureInfo.InvariantCulture, out double binWidth) || binWidth < 0 || binWidth > 1)

--- a/MetaMorpheus/GUI/Util/GlobalGuiSettings.cs
+++ b/MetaMorpheus/GUI/Util/GlobalGuiSettings.cs
@@ -278,7 +278,7 @@ namespace MetaMorpheusGUI
         {
             if (!double.TryParse(text, NumberStyles.Any, CultureInfo.InvariantCulture, out double mbrFdrThreshold) || mbrFdrThreshold > 1)
             {
-                MessageBox.Show("The MBR FDR Threshold is invalid. \n You entered " + '"' + text + '"' + "\n Please enter a positive number less than or equal to 1.");
+                MessageBox.Show("The MBR Q-Value Threshold is invalid. \n You entered " + '"' + text + '"' + "\n Please enter a positive number less than or equal to 1.");
                 return false;
             }
             return true;

--- a/MetaMorpheus/TaskLayer/FilteredPsms.cs
+++ b/MetaMorpheus/TaskLayer/FilteredPsms.cs
@@ -162,18 +162,23 @@ namespace TaskLayer
                 {
                     yield return psm;
                 }
-                else if (filterType == FilterType.PepQValue)
+                else if (psm.GetFdrInfo(filterAtPeptideLevel) != null)
                 {
-                    if (psm.GetFdrInfo(filterAtPeptideLevel).PEP_QValue <= qValueThreshold)
+                    switch(filterType)
                     {
-                        yield return psm;
-                    }
-                }
-                else
-                {
-                    if (psm.GetFdrInfo(filterAtPeptideLevel).QValue <= qValueThreshold && psm.GetFdrInfo(filterAtPeptideLevel).QValueNotch <= qValueThreshold)
-                    {
-                        yield return psm;
+                        case FilterType.PepQValue:
+                            if (psm.GetFdrInfo(filterAtPeptideLevel).PEP_QValue <= qValueThreshold)
+                            {
+                                yield return psm;
+                            }
+                            break;
+                        case FilterType.QValue:
+                        default:
+                            if (psm.GetFdrInfo(filterAtPeptideLevel).QValue <= qValueThreshold && psm.GetFdrInfo(filterAtPeptideLevel).QValueNotch <= qValueThreshold)
+                            {
+                                yield return psm;
+                            }
+                            break;
                     }
                 }
             }

--- a/MetaMorpheus/TaskLayer/SearchTask/PostSearchAnalysisTask.cs
+++ b/MetaMorpheus/TaskLayer/SearchTask/PostSearchAnalysisTask.cs
@@ -288,11 +288,21 @@ namespace TaskLayer
             // get PSMs to pass to FlashLFQ
             var psmsForQuantification = FilteredPsms.Filter(Parameters.AllPsms,
                 CommonParameters,
-                includeDecoys: false,
+                includeDecoys: Parameters.SearchParameters.MatchBetweenRuns, // Decoys are required for PIP-ECHO, but are not written to the output file
                 includeContaminants: true,
                 includeAmbiguous: false,
                 includeAmbiguousMods: false,
                 includeHighQValuePsms: false);
+
+            // Only these peptides will be written to the AllQuantifiedPeptides.tsv output file
+            var peptideSequencesForQuantification = FilteredPsms.Filter(Parameters.AllPsms,
+                CommonParameters,
+                includeDecoys: false,
+                includeContaminants: true,
+                includeAmbiguous: false,
+                includeAmbiguousMods: false,
+                includeHighQValuePsms: false,
+                filterAtPeptideLevel: true).Select(p => p.FullSequence).ToList();
 
             // pass protein group info for each PSM
             var psmToProteinGroups = new Dictionary<SpectralMatch, List<FlashLFQ.ProteinGroup>>();
@@ -501,12 +511,22 @@ namespace TaskLayer
             var flashLFQIdentifications = new List<Identification>();
             foreach (var spectraFile in psmsGroupedByFile)
             {
-                var rawfileinfo = spectraFileInfo.Where(p => p.FullFilePathWithExtension.Equals(spectraFile.Key)).First();
+                var rawfileinfo = spectraFileInfo.First(p => p.FullFilePathWithExtension.Equals(spectraFile.Key));
 
                 foreach (var psm in spectraFile)
                 {
-                    flashLFQIdentifications.Add(new Identification(rawfileinfo, psm.BaseSequence, psm.FullSequence,
-                        psm.BioPolymerWithSetModsMonoisotopicMass.Value, psm.ScanRetentionTime, psm.ScanPrecursorCharge, psmToProteinGroups[psm]));
+                    flashLFQIdentifications.Add(
+                        new Identification(
+                            fileInfo: rawfileinfo,
+                            psm.BaseSequence, 
+                            psm.FullSequence,
+                            psm.BioPolymerWithSetModsMonoisotopicMass.Value, 
+                            psm.ScanRetentionTime, 
+                            psm.ScanPrecursorCharge, 
+                            psmToProteinGroups[psm],
+                            psmScore: psm.Score,
+                            qValue: psmsForQuantification.FilterType == FilterType.QValue ? psm.FdrInfo.QValue : psm.FdrInfo.PEP_QValue,
+                            decoy: psm.IsDecoy));
                 }
             }
 
@@ -517,7 +537,9 @@ namespace TaskLayer
                 ppmTolerance: Parameters.SearchParameters.QuantifyPpmTol,
                 matchBetweenRunsPpmTolerance: Parameters.SearchParameters.QuantifyPpmTol,  // If these tolerances are not equivalent, then MBR will falsely classify peptides found in the initial search as MBR peaks
                 matchBetweenRuns: Parameters.SearchParameters.MatchBetweenRuns,
+                matchBetweenRunsFdrThreshold: Parameters.SearchParameters.MbrFdrThreshold,
                 useSharedPeptidesForProteinQuant: Parameters.SearchParameters.UseSharedPeptidesForLFQ,
+                peptideSequencesToQuantify: Parameters.SearchParameters.SilacLabels == null ? peptideSequencesForQuantification : null, // Silac is doing it's own thing, no need to pass in peptide sequences
                 silent: true,
                 maxThreads: CommonParameters.MaxThreadsToUsePerFile);
 

--- a/MetaMorpheus/TaskLayer/SearchTask/SearchParameters.cs
+++ b/MetaMorpheus/TaskLayer/SearchTask/SearchParameters.cs
@@ -18,6 +18,7 @@ namespace TaskLayer
             UseSharedPeptidesForLFQ = false;
             DoSpectralRecovery = false;
             QuantifyPpmTol = 5;
+            MbrFdrThreshold = 0.01;
             SearchTarget = true;
             DecoyType = DecoyType.Reverse;
             DoHistogramAnalysis = false;
@@ -67,6 +68,7 @@ namespace TaskLayer
         public bool ModPeptidesAreDifferent { get; set; }
         public bool NoOneHitWonders { get; set; }
         public bool MatchBetweenRuns { get; set; }
+        public double MbrFdrThreshold { get; set; }
         public bool Normalize { get; set; }
         public double QuantifyPpmTol { get; set; }
         public bool DoHistogramAnalysis { get; set; }


### PR DESCRIPTION
The current version of mzLib has had some significant changes made to MBR in FlashLFQ.

This update supports those changes.


- Added property to SearchParameters - MbrFdrThreshold. This controls the FDR of MBR identifications
    - Added text box in Search Task to allow users to set this parameter

- Call to the FlashLFQ engine in PostSearchAnalysisTask receives additional argument - PeptidesToQuantify
    - This ensures that only peptides with a **peptide-level Q-value** <0.01 are written to the output and used to calculate protein intensities 

- Identifications passed in to FlashLFQ now have additional information: Score, Q-value, and bool isDecoy. 