### PR TITLE
Top down default use internal ions

### DIFF
--- a/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml.cs
@@ -902,6 +902,7 @@ namespace MetaMorpheusGUI
                             CheckBoxNoQuant.IsChecked = true;
                             MassDiffAccept3mm.IsChecked = true;
                             maxModificationIsoformsTextBox.Text = "4096";
+                            MinInternalFragmentLengthTextBox.Text = "10";
                             //uncheck all variable mods
                             foreach (var mod in VariableModTypeForTreeViewObservableCollection)
                             {

--- a/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml.cs
@@ -902,6 +902,7 @@ namespace MetaMorpheusGUI
                             CheckBoxNoQuant.IsChecked = true;
                             MassDiffAccept3mm.IsChecked = true;
                             maxModificationIsoformsTextBox.Text = "4096";
+                            InternalIonsCheckBox.IsChecked = true;
                             MinInternalFragmentLengthTextBox.Text = "10";
                             //uncheck all variable mods
                             foreach (var mod in VariableModTypeForTreeViewObservableCollection)

--- a/MetaMorpheus/GUI/Util/UpdateGUISettings.cs
+++ b/MetaMorpheus/GUI/Util/UpdateGUISettings.cs
@@ -83,9 +83,10 @@ namespace MetaMorpheusGUI
                         "\t-Use '60' for 'Deconvolution Max Assumed Charge State'\n" +
                         "\t-Uncheck 'Trim MS2 Peaks'\n" +
                         "\t-Uncheck all variable mods (Please use a GPTMD database instead)\n" +
+                        "\t-GPTMD TASK ONLY: Search for only acetylation, phosphorylation, and oxidation of M\n\n" +
                         "\t-SEARCH TASK ONLY: Check 'No Quantification'\n" +
                         "\t-SEARCH TASK ONLY: Check '1, 2, or 3 Missed Monoisotopic Peaks'\n" +
-                        "\t-GPTMD TASK ONLY: Search for only acetylation, phosphorylation, and oxidation of M\n\n" +
+                        "\t-SEARCH TASK ONLY: Check 'Internal Ions - Min Internal Length 10'\n" +
                     "Would you like to use these recommended settings?");
 
                 if (results.UseSettings)

--- a/MetaMorpheus/GUI/Util/UpdateGUISettings.cs
+++ b/MetaMorpheus/GUI/Util/UpdateGUISettings.cs
@@ -83,7 +83,7 @@ namespace MetaMorpheusGUI
                         "\t-Use '60' for 'Deconvolution Max Assumed Charge State'\n" +
                         "\t-Uncheck 'Trim MS2 Peaks'\n" +
                         "\t-Uncheck all variable mods (Please use a GPTMD database instead)\n" +
-                        "\t-GPTMD TASK ONLY: Search for only acetylation, phosphorylation, and oxidation of M\n\n" +
+                        "\t-GPTMD TASK ONLY: Search for only acetylation, phosphorylation, and oxidation of M\n" +
                         "\t-SEARCH TASK ONLY: Check 'No Quantification'\n" +
                         "\t-SEARCH TASK ONLY: Check '1, 2, or 3 Missed Monoisotopic Peaks'\n" +
                         "\t-SEARCH TASK ONLY: Check 'Internal Ions - Min Internal Length 10'\n" +

--- a/MetaMorpheus/GUI/Views/ProteaseSpecificParamsMsgBox.xaml
+++ b/MetaMorpheus/GUI/Views/ProteaseSpecificParamsMsgBox.xaml
@@ -5,12 +5,12 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:MetaMorpheusGUI"
         mc:Ignorable="d"
-        Height="253.921" Width="545.393"
+        Height="275" Width="545.393"
         WindowStartupLocation="CenterScreen"
         ResizeMode="NoResize">
     <Grid Margin="5,5,5,5">
         <StackPanel>
-            <Label Name="Label" Margin="5" Height="150" Width="500"/>
+            <Label Name="Label" Margin="5" Width="600"/>
             <CheckBox Name="DoNotAskAgainCheckBox" Content="Remember my decision and don't ask me again." HorizontalAlignment="Center">
                 <ToolTipService.ToolTip>
                     <ToolTip Content="This decision can be changed by editing the file MetaMorpheus/GUIsettings.toml"  ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500" />


### PR DESCRIPTION
Propose "Use Internal Ions" = true
"Min Internal Ion Length" = 10
for top-down search in default toml.

In the large Jurkat dataset with xml we got the following results with default toml:

All target PSMs with q-value <= 0.01: 41719
All target proteoforms with q-value <= 0.01: 3082
All target protein groups with q-value <= 0.01 (1% FDR): 209

Using internal ions gave the following:

All target PSMs with q-value <= 0.01: 39437
All target proteoforms with q-value <= 0.01: 5958
All target protein groups with q-value <= 0.01 (1% FDR): 145


