### PR TITLE
Use proper tolerances in Calibration DataPoint Acquisition.

### DIFF
--- a/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationTask.cs
+++ b/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationTask.cs
@@ -14,7 +14,6 @@ using System.Linq;
 using Omics.Modifications;
 using Readers;
 using UsefulProteomicsDatabases;
-using System.Threading.Tasks;
 
 namespace TaskLayer
 {
@@ -36,9 +35,10 @@ namespace TaskLayer
         private static readonly int NumRequiredMs2Datapoints = 80;
         private static readonly double PrecursorMultiplier = 3;
         private static readonly double ProductMultiplier = 6;
-        public static readonly double MaxPrecursorTolerance = 40;
-        public static readonly double MaxProductTolerance = 150;
+        private static readonly double MaxPrecursorTolerance = 40;
+        private static readonly double MaxProductTolerance = 150;
         public const string CalibSuffix = "-calib";
+
         protected override MyTaskResults RunSpecific(string OutputFolder, List<DbForTask> dbFilenameList, List<string> currentRawFileList, string taskId, FileSpecificParameters[] fileSettingsList)
         {
             LoadModifications(taskId, out var variableModifications, out var fixedModifications, out var localizeableModificationTypes);
@@ -116,8 +116,8 @@ namespace TaskLayer
                     }
                     // set the mass tolerances for the file specific parameters
                     // we use a multiplier of 4 for the tolerance for files that are not calibrated
-                    fileSpecificParams.PrecursorMassTolerance = new PpmTolerance(Math.Round((4 * acquisitionResults.PsmPrecursorIqrPpmError) + Math.Abs(acquisitionResults.PsmPrecursorMedianPpmError),1));
-                    fileSpecificParams.ProductMassTolerance = new PpmTolerance(Math.Round((4 * acquisitionResults.PsmProductIqrPpmError) + Math.Abs(acquisitionResults.PsmProductMedianPpmError),1));
+                    fileSpecificParams.PrecursorMassTolerance = new PpmTolerance(Math.Round((PrecursorMultiplier * acquisitionResults.PsmPrecursorIqrPpmError) + Math.Abs(acquisitionResults.PsmPrecursorMedianPpmError),1));
+                    fileSpecificParams.ProductMassTolerance = new PpmTolerance(Math.Round((ProductMultiplier * acquisitionResults.PsmProductIqrPpmError) + Math.Abs(acquisitionResults.PsmProductMedianPpmError),1));
 
                     // generate calibration function and shift data points
                     Status("Calibrating...", new List<string> { taskId, "Individual Spectra Files" });

--- a/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationTask.cs
+++ b/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationTask.cs
@@ -231,6 +231,8 @@ namespace TaskLayer
             Log("Searching with productMassTolerance: " + initProdTol, new List<string> { taskId, "Individual Spectra Files", fileNameWithoutExtension });
 
             bool writeSpectralLibrary = false;
+            combinedParameters.PrecursorMassTolerance = initPrecTol;
+            combinedParameters.ProductMassTolerance = initProdTol;
             _ = new ClassicSearchEngine(allPsmsArray, listOfSortedms2Scans, variableModifications, fixedModifications, null, null, null, proteinList, searchMode, combinedParameters,
                 FileSpecificParameters, null, new List<string> { taskId, "Individual Spectra Files", fileNameWithoutExtension }, writeSpectralLibrary).Run();
             List<SpectralMatch> allPsms = allPsmsArray.Where(b => b != null).ToList();

--- a/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationTask.cs
+++ b/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationTask.cs
@@ -215,8 +215,7 @@ namespace TaskLayer
             MyTaskResults.NewFileSpecificTomls.Add(tomlName);
         }
 
-        private DataPointAquisitionResults GetDataAcquisitionResults(MsDataFile myMsDataFile, string currentDataFile, List<Modification> variableModifications,
-            List<Modification> fixedModifications, List<Protein> proteinList, string taskId, CommonParameters combinedParameters, Tolerance initPrecTol, Tolerance initProdTol)
+        private DataPointAquisitionResults GetDataAcquisitionResults(MsDataFile myMsDataFile, string currentDataFile, List<Modification> variableModifications, List<Modification> fixedModifications, List<Protein> proteinList, string taskId, CommonParameters combinedParameters, Tolerance initPrecTol, Tolerance initProdTol)
         {
             string fileNameWithoutExtension = Path.GetFileNameWithoutExtension(currentDataFile);
             MassDiffAcceptor searchMode = initPrecTol is PpmTolerance ?

--- a/MetaMorpheus/Test/CalibrationRetainsProperTolerances.cs
+++ b/MetaMorpheus/Test/CalibrationRetainsProperTolerances.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Collections.Generic;
+using EngineLayer.ClassicSearch;
+using EngineLayer;
+using System.Reflection;
+using NUnit.Framework;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using EngineLayer.Calibration;
+using TaskLayer;
+using EngineLayer.FdrAnalysis;
+using MzLibUtil;
+
+namespace Test
+{
+    [TestFixture]
+    [ExcludeFromCodeCoverage]
+    public class CalibrationRetainsProperTolerances
+    {
+        [Test]
+        public void EnsureTolerancesAreCorrectThroughout()
+        {
+            // set up directories
+            string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"CaliConsistencyTest");
+            if (Directory.Exists(outputFolder))
+                Directory.Delete(outputFolder, true);
+            Directory.CreateDirectory(outputFolder);
+
+            // set up input data
+            string nonCalibratedFilePath = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\SmallCalibratible_Yeast.mzML");
+            string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\smalldb.fasta");
+
+            // define expected values
+            int expectedCalibrationCount = 2;
+            int expectedClassicSearchCount = 3;
+            int expectedDataPointAcquisitionCount = 3;
+            int expectedFdrAnalysisEngineCount = 3;
+
+            // These expected tolerances are for the second and third classic search that is run. 
+            // They are magic numbers and should only be used to ensure engine tolerance consistency, not accuracy. 
+            // They will likely need to be changed if Calibration changes.  
+            double[] expectedPrecursorTolerances = [CalibrationTask.MaxPrecursorTolerance, 9.1, 6.3];
+            double[] expectedProductTolerances = [CalibrationTask.MaxProductTolerance, 10.2, 12.7];
+
+            int classicSearchEngineCount = 0;
+            int calibrationEngineCount = 0;
+            int dataPointAcquisitionCount = 0;
+            int fdrAnalysisEngineCount = 0;
+
+            List<(double precursor, double product, double expectedPrecursor, double expectedProduct)> classicSearchResults = new();
+            List<(double precursor, double product, double expectedPrecursor, double expectedProduct)> calibrationResults = new();
+            List<(double precursor, double product, double expectedPrecursor, double expectedProduct)> dataPointAcquisitionResults = new();
+
+            // Ensure we catch the end of all engines running and record the tolerances
+            MetaMorpheusEngine.FinishedSingleEngineHandler += (sender, e) =>
+            {
+                switch (sender)
+                {
+                    case null:
+                        Assert.Fail("Cannot check engine type");
+                        break;
+                    case ClassicSearchEngine cse:
+                        {
+                            classicSearchEngineCount++;
+
+                            // Ensure precursor tol and mass diff acceptor agree
+                            var precursor = cse.CommonParameters.PrecursorMassTolerance.Value;
+                            var searchMode = GetSearchMode(cse);
+                            var massDiffAcceptorString = searchMode.ToProseString();
+                            var precursorFromAcceptor = double.Parse(massDiffAcceptorString.Split(' ')[0]);
+                            Assert.That(precursor, Is.EqualTo(precursorFromAcceptor));
+
+                            var product = cse.CommonParameters.ProductMassTolerance.Value;
+
+                            var expectedPrecursor = expectedPrecursorTolerances[classicSearchEngineCount - 1];
+                            var expectedProduct = expectedProductTolerances[classicSearchEngineCount - 1];
+
+                            classicSearchResults.Add((precursor, product, expectedPrecursor, expectedProduct));
+                        }
+                        break;
+                    case CalibrationEngine cale:
+                        {
+                            calibrationEngineCount++;
+
+                            var precursor = cale.CommonParameters.PrecursorMassTolerance.Value;
+                            var product = cale.CommonParameters.ProductMassTolerance.Value;
+
+                            var expectedPrecursor = expectedPrecursorTolerances[calibrationEngineCount - 1];
+                            var expectedProduct = expectedProductTolerances[calibrationEngineCount - 1];
+
+                            calibrationResults.Add((precursor, product, expectedPrecursor, expectedProduct));
+                        }
+                        break;
+                    case DataPointAcquisitionEngine dpae:
+                        {
+                            dataPointAcquisitionCount++;
+                            var precursor = ((Tolerance)dpae.GetType().GetField("PrecursorMassTolerance", BindingFlags.NonPublic | BindingFlags.Instance)!
+                                .GetValue(dpae)!).Value;
+                            var product = ((Tolerance)dpae.GetType().GetField("ProductMassTolerance", BindingFlags.NonPublic | BindingFlags.Instance)!
+                                    .GetValue(dpae)!).Value;
+
+                            var expectedPrecursor = expectedPrecursorTolerances[dataPointAcquisitionCount - 1];
+                            var expectedProduct = expectedProductTolerances[dataPointAcquisitionCount - 1];
+
+                            dataPointAcquisitionResults.Add((precursor, product, expectedPrecursor, expectedProduct));
+                        }
+                        break;
+                    case FdrAnalysisEngine fdre:
+                        fdrAnalysisEngineCount++;
+                        break;
+
+                    default:
+                        Assert.Fail("Unexpected Engine Type");
+                        break;
+                }
+            };
+
+            // run calibration
+            CalibrationTask calibrationTask = new();
+            calibrationTask.RunTask(outputFolder, [new DbForTask(myDatabase, false)], [nonCalibratedFilePath], "test");
+
+            Assert.That(calibrationEngineCount, Is.EqualTo(expectedCalibrationCount));
+            Assert.That(classicSearchEngineCount, Is.EqualTo(expectedClassicSearchCount));
+            Assert.That(dataPointAcquisitionCount, Is.EqualTo(expectedDataPointAcquisitionCount));
+            Assert.That(fdrAnalysisEngineCount, Is.EqualTo(expectedFdrAnalysisEngineCount));
+
+            foreach (var result in classicSearchResults)
+            {
+                Assert.That(result.precursor, Is.EqualTo(result.expectedPrecursor));
+                Assert.That(result.product, Is.EqualTo(result.expectedProduct));
+            }
+
+            foreach (var result in calibrationResults)
+            {
+                Assert.That(result.precursor, Is.EqualTo(result.expectedPrecursor));
+                Assert.That(result.product, Is.EqualTo(result.expectedProduct));
+            }
+
+            foreach (var result in dataPointAcquisitionResults)
+            {
+                Assert.That(result.precursor, Is.EqualTo(result.expectedPrecursor));
+                Assert.That(result.product, Is.EqualTo(result.expectedProduct));
+            }
+        }
+
+        private static MassDiffAcceptor GetSearchMode(ClassicSearchEngine engine)
+        {
+            // Get the type of the ClassicSearchEngine
+            Type type = typeof(ClassicSearchEngine);
+
+            // Get the private field 'SearchMode'
+            FieldInfo fieldInfo = type.GetField("SearchMode", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            // Get the value of the 'SearchMode' field from the instance of ClassicSearchEngine
+            return (MassDiffAcceptor)fieldInfo!.GetValue(engine);
+        }
+    }
+}


### PR DESCRIPTION
A few issues were present in the calibration task. 

1. The precursor and product multipliers were only used sometimes, otherwise they were both 4. 
2. The new tolerances were not being used in the search engine meant to tell us if calibration improved our search results or not