### PR TITLE
Scan with index and notch update

### DIFF
--- a/MetaMorpheus/EngineLayer/ClassicSearch/ClassicSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/ClassicSearch/ClassicSearchEngine.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Omics.Modifications;
 using System.Collections.Concurrent;
+using EngineLayer.Util;
 
 namespace EngineLayer.ClassicSearch
 {

--- a/MetaMorpheus/EngineLayer/ClassicSearch/ClassicSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/ClassicSearch/ClassicSearchEngine.cs
@@ -132,8 +132,9 @@ namespace EngineLayer.ClassicSearch
                             // score each scan that has an acceptable precursor mass
                             foreach (ScanWithIndexAndNotchInfo scan in GetAcceptableScans(peptide.MonoisotopicMass, SearchMode))
                             {
+                                Ms2ScanWithSpecificMass theScan = ArrayOfSortedMS2Scans[scan.ScanIndex];
                                 var dissociationType = CommonParameters.DissociationType == DissociationType.Autodetect ?
-                                    scan.TheScan.TheScan.DissociationType.Value : CommonParameters.DissociationType;
+                                    theScan.TheScan.DissociationType.Value : CommonParameters.DissociationType;
 
                                 if (!targetFragmentsForEachDissociationType.TryGetValue(dissociationType, out var peptideTheorProducts))
                                 {
@@ -148,11 +149,11 @@ namespace EngineLayer.ClassicSearch
                                 }
 
                                 // match theoretical target ions to spectrum
-                                List<MatchedFragmentIon> matchedIons = MatchFragmentIons(scan.TheScan, peptideTheorProducts, CommonParameters,
+                                List<MatchedFragmentIon> matchedIons = MatchFragmentIons(theScan, peptideTheorProducts, CommonParameters,
                                         matchAllCharges: WriteSpectralLibrary);
 
                                 // calculate the peptide's score
-                                double thisScore = CalculatePeptideScore(scan.TheScan.TheScan, matchedIons, fragmentsCanHaveDifferentCharges: WriteSpectralLibrary);
+                                double thisScore = CalculatePeptideScore(theScan.TheScan, matchedIons, fragmentsCanHaveDifferentCharges: WriteSpectralLibrary);
 
                                 AddPeptideCandidateToPsm(scan, thisScore, peptide, matchedIons);
 
@@ -193,12 +194,12 @@ namespace EngineLayer.ClassicSearch
             {
                 reversedOnTheFlyDecoy.Fragment(dissociationType, CommonParameters.DigestionParams.FragmentationTerminus, decoyTheoreticalFragments);
             }
-
-            var decoyMatchedIons = MatchFragmentIons(scan.TheScan, decoyTheoreticalFragments, CommonParameters,
+            Ms2ScanWithSpecificMass theScan = ArrayOfSortedMS2Scans[scan.ScanIndex];
+            var decoyMatchedIons = MatchFragmentIons(theScan, decoyTheoreticalFragments, CommonParameters,
                 matchAllCharges: WriteSpectralLibrary);
 
             // calculate decoy's score
-            var decoyScore = CalculatePeptideScore(scan.TheScan.TheScan, decoyMatchedIons, fragmentsCanHaveDifferentCharges: WriteSpectralLibrary);
+            var decoyScore = CalculatePeptideScore(theScan.TheScan, decoyMatchedIons, fragmentsCanHaveDifferentCharges: WriteSpectralLibrary);
 
             AddPeptideCandidateToPsm(scan, decoyScore, reversedOnTheFlyDecoy, decoyMatchedIons);
         }
@@ -220,7 +221,7 @@ namespace EngineLayer.ClassicSearch
                     {
                         if (PeptideSpectralMatches[scan.ScanIndex] == null)
                         {
-                            PeptideSpectralMatches[scan.ScanIndex] = new PeptideSpectralMatch(peptide, scan.Notch, thisScore, scan.ScanIndex, scan.TheScan, CommonParameters, matchedIons, 0);
+                            PeptideSpectralMatches[scan.ScanIndex] = new PeptideSpectralMatch(peptide, scan.Notch, thisScore, scan.ScanIndex, ArrayOfSortedMS2Scans[scan.ScanIndex], CommonParameters, matchedIons, 0);
                         }
                         else
                         {
@@ -233,7 +234,7 @@ namespace EngineLayer.ClassicSearch
 
         private IEnumerable<ScanWithIndexAndNotchInfo> GetAcceptableScans(double peptideMonoisotopicMass, MassDiffAcceptor searchMode)
         {
-            foreach (AllowedIntervalWithNotch allowedIntervalWithNotch in searchMode.GetAllowedPrecursorMassIntervalsFromTheoreticalMass(peptideMonoisotopicMass).ToList())
+            foreach (AllowedIntervalWithNotch allowedIntervalWithNotch in searchMode.GetAllowedPrecursorMassIntervalsFromTheoreticalMass(peptideMonoisotopicMass))
             {
                 DoubleRange allowedInterval = allowedIntervalWithNotch.AllowedInterval;
                 int scanIndex = GetFirstScanWithMassOverOrEqual(allowedInterval.Minimum);
@@ -242,8 +243,7 @@ namespace EngineLayer.ClassicSearch
                     var scanMass = MyScanPrecursorMasses[scanIndex];
                     while (scanMass <= allowedInterval.Maximum)
                     {
-                        var scan = ArrayOfSortedMS2Scans[scanIndex];
-                        yield return new ScanWithIndexAndNotchInfo(scan, allowedIntervalWithNotch.Notch, scanIndex);
+                        yield return new ScanWithIndexAndNotchInfo(allowedIntervalWithNotch.Notch, scanIndex);
                         scanIndex++;
                         if (scanIndex == ArrayOfSortedMS2Scans.Length)
                         {

--- a/MetaMorpheus/EngineLayer/ClassicSearch/MiniClassicSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/ClassicSearch/MiniClassicSearchEngine.cs
@@ -61,14 +61,14 @@ namespace EngineLayer.ClassicSearch
             }
 
             // score each scan that has an acceptable precursor mass
-            IEnumerable<ScanWithIndexAndNotchInfo> acceptableScans = GetAcceptableScans(donorPwsm.MonoisotopicMass, peakApexRT, SearchMode); // GetAcceptableScans is asynchronous, in case you care
+            IEnumerable<ExtendedScanWithIndexAndNotchInfo> acceptableScans = GetAcceptableScans(donorPwsm.MonoisotopicMass, peakApexRT, SearchMode); // GetAcceptableScans is asynchronous, in case you care
             if (!acceptableScans.Any())
             {
                 return null;
             }
 
             List<SpectralMatch> acceptablePsms = new();
-            foreach (ScanWithIndexAndNotchInfo scan in acceptableScans)
+            foreach (ExtendedScanWithIndexAndNotchInfo scan in acceptableScans)
             {
                 var dissociationType = FileSpecificParameters.DissociationType == DissociationType.Autodetect ?
                     scan.TheScan.TheScan.DissociationType.Value : FileSpecificParameters.DissociationType;
@@ -159,7 +159,7 @@ namespace EngineLayer.ClassicSearch
             }
         }
 
-        private IEnumerable<ScanWithIndexAndNotchInfo> GetAcceptableScans(double peptideMonoisotopicMass, double apexRT, MassDiffAcceptor searchMode)
+        private IEnumerable<ExtendedScanWithIndexAndNotchInfo> GetAcceptableScans(double peptideMonoisotopicMass, double apexRT, MassDiffAcceptor searchMode)
         {
             Ms2ScanWithSpecificMass[] arrayOfSortedMs2Scans = GetScansInWindow(apexRT);
             double[] myScanPrecursorMasses = arrayOfSortedMs2Scans.Select(p => p.PrecursorMass).ToArray();
@@ -173,7 +173,7 @@ namespace EngineLayer.ClassicSearch
                     while (scanMass <= allowedInterval.Maximum)
                     {
                         var scan = arrayOfSortedMs2Scans[scanIndex];
-                        yield return new ScanWithIndexAndNotchInfo(scan, allowedIntervalWithNotch.Notch, scanIndex);
+                        yield return new ExtendedScanWithIndexAndNotchInfo(scan, allowedIntervalWithNotch.Notch, scanIndex);
                         scanIndex++;
                         if (scanIndex == arrayOfSortedMs2Scans.Length)
                         {

--- a/MetaMorpheus/EngineLayer/ClassicSearch/MiniClassicSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/ClassicSearch/MiniClassicSearchEngine.cs
@@ -1,4 +1,5 @@
-﻿using MassSpectrometry;
+﻿using EngineLayer.Util;
+using MassSpectrometry;
 using MassSpectrometry.MzSpectra;
 using MzLibUtil;
 using Omics;

--- a/MetaMorpheus/EngineLayer/ScanWithIndexAndNotchInfo.cs
+++ b/MetaMorpheus/EngineLayer/ScanWithIndexAndNotchInfo.cs
@@ -1,16 +1,19 @@
 ﻿namespace EngineLayer
 {
-    internal class ScanWithIndexAndNotchInfo
+    internal class ScanWithIndexAndNotchInfo(int notch, int scanIndex)
     {
-        public Ms2ScanWithSpecificMass TheScan;
-        public int Notch;
-        public int ScanIndex;
+        public readonly int Notch = notch;
+        public readonly int ScanIndex = scanIndex;
+    }
 
-        public ScanWithIndexAndNotchInfo(Ms2ScanWithSpecificMass theScan, int notch, int scanIndex)
-        {
-            TheScan = theScan;
-            Notch = notch;
-            ScanIndex = scanIndex;
-        }
+    /// <summary>
+    /// For use in MiniClassicSearchEngine
+    /// </summary>
+    /// <param name="scan"></param>
+    /// <param name="notch"></param>
+    /// <param name="scanIndex"></param>
+    internal class ExtendedScanWithIndexAndNotchInfo(Ms2ScanWithSpecificMass scan, int notch, int scanIndex) : ScanWithIndexAndNotchInfo(notch, scanIndex)
+    {
+        public readonly Ms2ScanWithSpecificMass TheScan = scan;
     }
 }

--- a/MetaMorpheus/EngineLayer/Util/ScanWithIndexAndNotchInfo.cs
+++ b/MetaMorpheus/EngineLayer/Util/ScanWithIndexAndNotchInfo.cs
@@ -1,4 +1,4 @@
-﻿namespace EngineLayer
+﻿namespace EngineLayer.Util
 {
     internal class ScanWithIndexAndNotchInfo(int notch, int scanIndex)
     {

--- a/MetaMorpheus/Test/XLTest.cs
+++ b/MetaMorpheus/Test/XLTest.cs
@@ -1492,24 +1492,31 @@ namespace Test
             // read results from TSV
             var psmFromTsv = PsmTsvReader.ReadTsv(outputFile, out var warnings).First();
 
-            Assert.That(psmFromTsv.ChildScanMatchedIons.Count == 1
-                && psmFromTsv.ChildScanMatchedIons.First().Key == 3
-                && psmFromTsv.ChildScanMatchedIons.First().Value.Count == 21);
+            Assert.That(psmFromTsv.ChildScanMatchedIons.Count, Is.EqualTo(1));
+            Assert.That(psmFromTsv.ChildScanMatchedIons.First().Key, Is.EqualTo(3));
+            Assert.That(psmFromTsv.ChildScanMatchedIons.First().Value.Count, Is.EqualTo(21));
 
-            Assert.That(psmFromTsv.BetaPeptideChildScanMatchedIons.Count == 1
-                && psmFromTsv.BetaPeptideChildScanMatchedIons.First().Key == 3
-                && psmFromTsv.BetaPeptideChildScanMatchedIons.First().Value.Count == 25
-                && psmFromTsv.BetaPeptideProteinAccession.Equals("BSA|BSA2")
-                && psmFromTsv.BetaPeptideProteinLinkSite == 211
-                && psmFromTsv.BetaPeptideTheoreticalMass.Equals("989.550558768"));
+            Assert.That(psmFromTsv.BetaPeptideChildScanMatchedIons.Count, Is.EqualTo(1));
+            Assert.That(psmFromTsv.BetaPeptideChildScanMatchedIons.First().Key, Is.EqualTo(3));
+            Assert.That(psmFromTsv.BetaPeptideChildScanMatchedIons.First().Value.Count, Is.EqualTo(25));
+            // Race condition causes the order of accessions to differ 
+            //Assert.That(psmFromTsv.BetaPeptideProteinAccession, Is.EqualTo("BSA|BSA2"));
+            Assert.That(psmFromTsv.BetaPeptideProteinAccession, Does.Contain("BSA"));
+            Assert.That(psmFromTsv.BetaPeptideProteinAccession, Does.Contain("BSA2"));
+            Assert.That(psmFromTsv.BetaPeptideProteinLinkSite, Is.EqualTo(211));
+            Assert.That(psmFromTsv.BetaPeptideTheoreticalMass, Is.EqualTo("989.550558768"));
 
-            Assert.That(psmFromTsv.CrossType.Equals("Cross")
-                && psmFromTsv.LinkResidues.Equals("K")
-                && psmFromTsv.ProteinLinkSite == 455
-                && psmFromTsv.ParentIons.Equals("2;2"));
+            Assert.That(psmFromTsv.CrossType, Is.EqualTo("Cross"));
+            Assert.That(psmFromTsv.LinkResidues, Is.EqualTo("K"));
+            Assert.That(psmFromTsv.ProteinLinkSite, Is.EqualTo(455));
+            Assert.That(psmFromTsv.ParentIons, Is.EqualTo("2;2"));
 
             Assert.That(csm.Accession == null && csm.BetaPeptide.Accession == null);
-            Assert.That(psmFromTsv.ProteinAccession == "BSA|BSA2");
+
+            // Race condition causes the order of accessions to differ 
+            //Assert.That(psmFromTsv.ProteinAccession == "BSA|BSA2");
+            Assert.That(psmFromTsv.ProteinAccession, Does.Contain("BSA"));
+            Assert.That(psmFromTsv.ProteinAccession, Does.Contain("BSA2"));
             Assert.That(psmFromTsv.UniqueSequence, Is.EqualTo(psmFromTsv.FullSequence + psmFromTsv.BetaPeptideFullSequence));
 
             File.Delete(outputFile);


### PR DESCRIPTION
`ScanWithIndexAndNotchInfo` is a small class that is created, used, and destroyed a bunch of times, very very quickly. There is no reason we need to carry around the `Ms2ScanWithSpecificMass` every time we create one of these objects when the `ScanWithIndexAndNotchInfo` contains the index of the scan. 

The scan has been removed from the object. 

This 1-to-1 mapping of index to scan breaks down in `MiniClassicSearchEngine`, so that class will maintain original functionality. 




Adjusted the Ms2Ms2 test to not break 50% of the time