### PR TITLE
Removed Double Range from AllowedIntervalWithNotch

### DIFF
--- a/MetaMorpheus/EngineLayer/ClassicSearch/ClassicSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/ClassicSearch/ClassicSearchEngine.cs
@@ -235,12 +235,11 @@ namespace EngineLayer.ClassicSearch
         {
             foreach (AllowedIntervalWithNotch allowedIntervalWithNotch in searchMode.GetAllowedPrecursorMassIntervalsFromTheoreticalMass(peptideMonoisotopicMass).ToList())
             {
-                DoubleRange allowedInterval = allowedIntervalWithNotch.AllowedInterval;
-                int scanIndex = GetFirstScanWithMassOverOrEqual(allowedInterval.Minimum);
+                int scanIndex = GetFirstScanWithMassOverOrEqual(allowedIntervalWithNotch.Minimum);
                 if (scanIndex < ArrayOfSortedMS2Scans.Length)
                 {
                     var scanMass = MyScanPrecursorMasses[scanIndex];
-                    while (scanMass <= allowedInterval.Maximum)
+                    while (scanMass <= allowedIntervalWithNotch.Maximum)
                     {
                         var scan = ArrayOfSortedMS2Scans[scanIndex];
                         yield return new ScanWithIndexAndNotchInfo(scan, allowedIntervalWithNotch.Notch, scanIndex);

--- a/MetaMorpheus/EngineLayer/ClassicSearch/MiniClassicSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/ClassicSearch/MiniClassicSearchEngine.cs
@@ -165,12 +165,11 @@ namespace EngineLayer.ClassicSearch
             double[] myScanPrecursorMasses = arrayOfSortedMs2Scans.Select(p => p.PrecursorMass).ToArray();
             foreach (AllowedIntervalWithNotch allowedIntervalWithNotch in searchMode.GetAllowedPrecursorMassIntervalsFromTheoreticalMass(peptideMonoisotopicMass).ToList())
             {
-                DoubleRange allowedInterval = allowedIntervalWithNotch.AllowedInterval;
-                int scanIndex = GetFirstScanWithMassOverOrEqual(allowedInterval.Minimum, myScanPrecursorMasses);
+                int scanIndex = GetFirstScanWithMassOverOrEqual(allowedIntervalWithNotch.Minimum, myScanPrecursorMasses);
                 if (scanIndex < arrayOfSortedMs2Scans.Length)
                 {
                     var scanMass = myScanPrecursorMasses[scanIndex];
-                    while (scanMass <= allowedInterval.Maximum)
+                    while (scanMass <= allowedIntervalWithNotch.Maximum)
                     {
                         var scan = arrayOfSortedMs2Scans[scanIndex];
                         yield return new ScanWithIndexAndNotchInfo(scan, allowedIntervalWithNotch.Notch, scanIndex);

--- a/MetaMorpheus/EngineLayer/CrosslinkSearch/CrosslinkSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/CrosslinkSearch/CrosslinkSearchEngine.cs
@@ -406,9 +406,9 @@ namespace EngineLayer.CrosslinkSearch
 
                         double betaMass = pre.Item1 - PrecursorMassTable[id] - Crosslinker.TotalMass;
 
-                        double betaMassLow = XLPrecusorSearchMode.GetAllowedPrecursorMassIntervalsFromObservedMass(betaMass).First().AllowedInterval.Minimum;
+                        double betaMassLow = XLPrecusorSearchMode.GetAllowedPrecursorMassIntervalsFromObservedMass(betaMass).First().Minimum;
 
-                        double betaMassHigh = XLPrecusorSearchMode.GetAllowedPrecursorMassIntervalsFromObservedMass(betaMass).First().AllowedInterval.Maximum;
+                        double betaMassHigh = XLPrecusorSearchMode.GetAllowedPrecursorMassIntervalsFromObservedMass(betaMass).First().Maximum;
 
                         int betaMassLowIndex = BinarySearchGetIndex(NextPrecursorMassTable, betaMassLow);
 

--- a/MetaMorpheus/EngineLayer/ModernSearch/ModernSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/ModernSearch/ModernSearchEngine.cs
@@ -101,8 +101,8 @@ namespace EngineLayer.ModernSearch
             // this is just PRELIMINARY precursor-mass filtering	
             // additional checks are made later to ensure that the theoretical precursor mass is acceptable
             List<AllowedIntervalWithNotch> notches = MassDiffAcceptor.GetAllowedPrecursorMassIntervalsFromObservedMass(scan.PrecursorMass).ToList();
-            double lowestMassPeptideToLookFor = notches.Min(p => p.AllowedInterval.Minimum);
-            double highestMassPeptideToLookFor = notches.Max(p => p.AllowedInterval.Maximum);
+            double lowestMassPeptideToLookFor = notches.Min(p => p.Minimum);
+            double highestMassPeptideToLookFor = notches.Max(p => p.Maximum);
 
             // clear the scoring table to score the new scan (conserves memory compared to allocating a new array)
             Array.Clear(scoringTable, 0, scoringTable.Length);

--- a/MetaMorpheus/EngineLayer/NonSpecificEnzymeSearch/NonSpecificEnzymeSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/NonSpecificEnzymeSearch/NonSpecificEnzymeSearchEngine.cs
@@ -88,8 +88,8 @@ namespace EngineLayer.NonSpecificEnzymeSearch
                         List<AllowedIntervalWithNotch> validIntervals = MassDiffAcceptor.GetAllowedPrecursorMassIntervalsFromObservedMass(scan.PrecursorMass).ToList(); //get all valid notches
                         foreach (AllowedIntervalWithNotch interval in validIntervals)
                         {
-                            int obsPrecursorFloorMz = (int)Math.Floor(interval.AllowedInterval.Minimum * FragmentBinsPerDalton);
-                            int obsPrecursorCeilingMz = (int)Math.Ceiling(interval.AllowedInterval.Maximum * FragmentBinsPerDalton);
+                            int obsPrecursorFloorMz = (int)Math.Floor(interval.Minimum * FragmentBinsPerDalton);
+                            int obsPrecursorCeilingMz = (int)Math.Ceiling(interval.Maximum * FragmentBinsPerDalton);
 
                             foreach (ProductType pt in ProductTypesToSearch)
                             {

--- a/MetaMorpheus/EngineLayer/PrecursorSearchModes/AllowedIntervalWithNotch.cs
+++ b/MetaMorpheus/EngineLayer/PrecursorSearchModes/AllowedIntervalWithNotch.cs
@@ -1,17 +1,13 @@
-﻿using MzLibUtil;
+﻿namespace EngineLayer;
 
-namespace EngineLayer
+public class AllowedIntervalWithNotch(double minimum, double maximum, int notch)
 {
-    public class AllowedIntervalWithNotch
+    public readonly double Minimum = minimum;
+    public readonly double Maximum = maximum;
+    public readonly int Notch = notch;
+
+    public bool Contains(double value)
     {
-        public DoubleRange AllowedInterval;
-
-        public AllowedIntervalWithNotch(DoubleRange doubleRange, int j)
-        {
-            AllowedInterval = doubleRange;
-            Notch = j;
-        }
-
-        public int Notch { get; }
+        return value >= Minimum && value <= Maximum;
     }
 }

--- a/MetaMorpheus/EngineLayer/PrecursorSearchModes/DotMassDiffAcceptor.cs
+++ b/MetaMorpheus/EngineLayer/PrecursorSearchModes/DotMassDiffAcceptor.cs
@@ -36,7 +36,8 @@ namespace EngineLayer
         {
             for (int j = 0; j < AcceptableSortedMassShifts.Length; j++)
             {
-                yield return new AllowedIntervalWithNotch(Tolerance.GetRange(peptideMonoisotopicMass + AcceptableSortedMassShifts[j]), j);
+                var mass = peptideMonoisotopicMass + AcceptableSortedMassShifts[j];
+                yield return new AllowedIntervalWithNotch(Tolerance.GetMinimumValue(mass), Tolerance.GetMaximumValue(mass), j);
             }
         }
 
@@ -44,7 +45,8 @@ namespace EngineLayer
         {
             for (int j = 0; j < AcceptableSortedMassShifts.Length; j++)
             {
-                yield return new AllowedIntervalWithNotch(Tolerance.GetRange(peptideMonoisotopicMass - AcceptableSortedMassShifts[j]), j);
+                var mass = peptideMonoisotopicMass - AcceptableSortedMassShifts[j];
+                yield return new AllowedIntervalWithNotch(Tolerance.GetMinimumValue(mass), Tolerance.GetMaximumValue(mass), j);
             }
         }
 

--- a/MetaMorpheus/EngineLayer/PrecursorSearchModes/IntervalMassDiffAcceptor.cs
+++ b/MetaMorpheus/EngineLayer/PrecursorSearchModes/IntervalMassDiffAcceptor.cs
@@ -34,12 +34,12 @@ namespace EngineLayer
 
         public override IEnumerable<AllowedIntervalWithNotch> GetAllowedPrecursorMassIntervalsFromTheoreticalMass(double peptideMonoisotopicMass)
         {
-            return Intervals.Select(b => new AllowedIntervalWithNotch(new DoubleRange(peptideMonoisotopicMass + b.Minimum, peptideMonoisotopicMass + b.Maximum), 0));
+            return Intervals.Select(b => new AllowedIntervalWithNotch(peptideMonoisotopicMass + b.Minimum, peptideMonoisotopicMass + b.Maximum, 0));
         }
 
         public override IEnumerable<AllowedIntervalWithNotch> GetAllowedPrecursorMassIntervalsFromObservedMass(double peptideMonoisotopicMass)
         {
-            return Intervals.Select(b => new AllowedIntervalWithNotch(new DoubleRange(peptideMonoisotopicMass - b.Maximum, peptideMonoisotopicMass - b.Minimum), 0));
+            return Intervals.Select(b => new AllowedIntervalWithNotch(peptideMonoisotopicMass - b.Maximum, peptideMonoisotopicMass - b.Minimum, 0));
         }
 
         public override string ToString()

--- a/MetaMorpheus/EngineLayer/PrecursorSearchModes/OpenMassDiffAcceptor.cs
+++ b/MetaMorpheus/EngineLayer/PrecursorSearchModes/OpenMassDiffAcceptor.cs
@@ -17,12 +17,12 @@ namespace EngineLayer
 
         public override IEnumerable<AllowedIntervalWithNotch> GetAllowedPrecursorMassIntervalsFromTheoreticalMass(double peptideMonoisotopicMass)
         {
-            yield return new AllowedIntervalWithNotch(new DoubleRange(Double.NegativeInfinity, Double.PositiveInfinity), 0);
+            yield return new AllowedIntervalWithNotch(double.NegativeInfinity, double.PositiveInfinity, 0);
         }
 
         public override IEnumerable<AllowedIntervalWithNotch> GetAllowedPrecursorMassIntervalsFromObservedMass(double peptideMonoisotopicMass)
         {
-            yield return new AllowedIntervalWithNotch(new DoubleRange(Double.NegativeInfinity, Double.PositiveInfinity), 0);
+            yield return new AllowedIntervalWithNotch(double.NegativeInfinity, double.PositiveInfinity, 0);
         }
 
         public override string ToProseString()

--- a/MetaMorpheus/EngineLayer/PrecursorSearchModes/SingleAbsoluteAroundZeroMassDiffAcceptor.cs
+++ b/MetaMorpheus/EngineLayer/PrecursorSearchModes/SingleAbsoluteAroundZeroMassDiffAcceptor.cs
@@ -20,11 +20,11 @@ namespace EngineLayer
 
         public override IEnumerable<AllowedIntervalWithNotch> GetAllowedPrecursorMassIntervalsFromTheoreticalMass(double peptideMonoisotopicMass)
         {
-            yield return new AllowedIntervalWithNotch(new DoubleRange(peptideMonoisotopicMass - Value, peptideMonoisotopicMass + Value), 0);
+            yield return new AllowedIntervalWithNotch(peptideMonoisotopicMass - Value, peptideMonoisotopicMass + Value, 0);
         }
         public override IEnumerable<AllowedIntervalWithNotch> GetAllowedPrecursorMassIntervalsFromObservedMass(double peptideMonoisotopicMass)
         {
-            yield return new AllowedIntervalWithNotch(new DoubleRange(peptideMonoisotopicMass - Value, peptideMonoisotopicMass + Value), 0);
+            yield return new AllowedIntervalWithNotch(peptideMonoisotopicMass - Value, peptideMonoisotopicMass + Value, 0);
         }
 
         public override string ToString()

--- a/MetaMorpheus/EngineLayer/PrecursorSearchModes/SinglePpmAroundZeroMassDiffAcceptor.cs
+++ b/MetaMorpheus/EngineLayer/PrecursorSearchModes/SinglePpmAroundZeroMassDiffAcceptor.cs
@@ -21,12 +21,12 @@ namespace EngineLayer
         public override IEnumerable<AllowedIntervalWithNotch> GetAllowedPrecursorMassIntervalsFromTheoreticalMass(double peptideMonoisotopicMass)
         {
             var diff = PpmTolerance / 1e6 * peptideMonoisotopicMass;
-            yield return new AllowedIntervalWithNotch(new DoubleRange(peptideMonoisotopicMass - diff, peptideMonoisotopicMass + diff), 0);
+            yield return new AllowedIntervalWithNotch(peptideMonoisotopicMass - diff, peptideMonoisotopicMass + diff, 0);
         }
         public override IEnumerable<AllowedIntervalWithNotch> GetAllowedPrecursorMassIntervalsFromObservedMass(double peptideMonoisotopicMass)
         {
             var diff = PpmTolerance / 1e6 * peptideMonoisotopicMass;
-            yield return new AllowedIntervalWithNotch(new DoubleRange(peptideMonoisotopicMass - diff, peptideMonoisotopicMass + diff), 0);
+            yield return new AllowedIntervalWithNotch(peptideMonoisotopicMass - diff, peptideMonoisotopicMass + diff, 0);
         }
 
         public override string ToProseString()

--- a/MetaMorpheus/Test/SearchModesTest.cs
+++ b/MetaMorpheus/Test/SearchModesTest.cs
@@ -18,8 +18,8 @@ namespace Test
             Assert.That(sm.Accepts(0.5, 4) >= 0);
             Assert.That(!(sm.Accepts(0.5, 0.5) >= 0));
             Assert.That(sm.Accepts(1, 1) >= 0);
-            Assert.That(sm.GetAllowedPrecursorMassIntervalsFromTheoreticalMass(0.5).First().AllowedInterval.Minimum, Is.EqualTo(2));
-            Assert.That(sm.GetAllowedPrecursorMassIntervalsFromTheoreticalMass(2).First().AllowedInterval.Minimum, Is.EqualTo(0.5));
+            Assert.That(sm.GetAllowedPrecursorMassIntervalsFromTheoreticalMass(0.5).First().Minimum, Is.EqualTo(2));
+            Assert.That(sm.GetAllowedPrecursorMassIntervalsFromTheoreticalMass(2).First().Minimum, Is.EqualTo(0.5));
         }
 
         [Test]
@@ -40,10 +40,10 @@ namespace Test
 
             var theList = dsm1.GetAllowedPrecursorMassIntervalsFromTheoreticalMass(100).ToList();
 
-            Assert.That(theList[0].AllowedInterval.Minimum, Is.EqualTo(99.9));
-            Assert.That(theList[0].AllowedInterval.Maximum, Is.EqualTo(100.1));
-            Assert.That(theList[1].AllowedInterval.Minimum, Is.EqualTo(100.9));
-            Assert.That(theList[1].AllowedInterval.Maximum, Is.EqualTo(101.1));
+            Assert.That(theList[0].Minimum, Is.EqualTo(99.9));
+            Assert.That(theList[0].Maximum, Is.EqualTo(100.1));
+            Assert.That(theList[1].Minimum, Is.EqualTo(100.9));
+            Assert.That(theList[1].Maximum, Is.EqualTo(101.1));
 
             var dsm2 = new DotMassDiffAcceptor("test2", new double[] { 0, 1 }, new PpmTolerance(5));
 
@@ -61,14 +61,14 @@ namespace Test
 
             var theList2 = dsm2.GetAllowedPrecursorMassIntervalsFromTheoreticalMass(1000).ToList();
 
-            Assert.That(theList2[0].AllowedInterval.Contains(1000));
+            Assert.That(theList2[0].Contains(1000));
 
-            Assert.That(1000 * (1 + 5.0 / 1e6 / 1.0000001) < theList2[0].AllowedInterval.Maximum);
-            Assert.That(1000 * (1 - 5.0 / 1e6 / 1.0000001) > theList2[0].AllowedInterval.Minimum);
-            Assert.That(1000 * (1 + 5.0 / 1e6 * 1.0000001) > theList2[0].AllowedInterval.Maximum);
-            Assert.That(1000 * (1 - 5.0 / 1e6 * 1.0000001) < theList2[0].AllowedInterval.Minimum);
+            Assert.That(1000 * (1 + 5.0 / 1e6 / 1.0000001) < theList2[0].Maximum);
+            Assert.That(1000 * (1 - 5.0 / 1e6 / 1.0000001) > theList2[0].Minimum);
+            Assert.That(1000 * (1 + 5.0 / 1e6 * 1.0000001) > theList2[0].Maximum);
+            Assert.That(1000 * (1 - 5.0 / 1e6 * 1.0000001) < theList2[0].Minimum);
 
-            Assert.That(theList2[1].AllowedInterval.Contains(1001));
+            Assert.That(theList2[1].Contains(1001));
         }
 
         // Accept if scanPrecursorMass*peptideMass>=1.
@@ -85,12 +85,12 @@ namespace Test
 
             public override IEnumerable<AllowedIntervalWithNotch> GetAllowedPrecursorMassIntervalsFromTheoreticalMass(double peptideMonoisotopicMass)
             {
-                yield return new AllowedIntervalWithNotch(new DoubleRange(1 / peptideMonoisotopicMass, double.MaxValue), 1);
+                yield return new AllowedIntervalWithNotch(1 / peptideMonoisotopicMass, double.MaxValue, 1);
             }
 
             public override IEnumerable<AllowedIntervalWithNotch> GetAllowedPrecursorMassIntervalsFromObservedMass(double peptideMonoisotopicMass)
             {
-                yield return new AllowedIntervalWithNotch(new DoubleRange(double.MinValue, 1 / peptideMonoisotopicMass), 1);
+                yield return new AllowedIntervalWithNotch(double.MinValue, 1 / peptideMonoisotopicMass, 1);
             }
 
             public override string ToProseString()


### PR DESCRIPTION
The double range inside `AllowedIntervalWithNotch` was only used to access the Minimum and Maximum properties. This means we are taking the time to construct and garbage collect the `DoubleRange` only to use a double property. 

This PR removes the `DoubleRange` and instead stores a double for minimum and maximum. 