### PR TITLE
Bp notch comparer cleanup

### DIFF
--- a/MetaMorpheus/EngineLayer/BioPolymerNotchFragmentIonComparer.cs
+++ b/MetaMorpheus/EngineLayer/BioPolymerNotchFragmentIonComparer.cs
@@ -2,13 +2,10 @@
 using Omics.Fragmentation;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace EngineLayer
 {
-    public class BioPolymerNotchFragmentIonComparer<T> : Comparer<(int notch, IBioPolymerWithSetMods pwsm, List<MatchedFragmentIon> ions)>
+    public class BioPolymerNotchFragmentIonComparer : Comparer<(int notch, IBioPolymerWithSetMods pwsm, List<MatchedFragmentIon> ions)>
     {
         /// <summary>
         /// Returns greater than 0 if x is better than y, less than 0 if y is better than x, and 0 if they are equal.
@@ -20,10 +17,25 @@ namespace EngineLayer
             if (x.notch != y.notch)
                 return -1 * x.notch.CompareTo(y.notch); // Lower notch is better
 
-            if (x.ions?.Count != y.ions?.Count && !ReferenceEquals(x.ions, null))
-                return x.ions.Count.CompareTo(y.ions?.Count); // More ions are better
+            // Matched Ions is a nullable list, so we need to check for null
+            if (x.ions == null && y.ions == null)
+                return 0; // Both are null, they are equal
+            if (x.ions == null)
+                return -1; // x is null, y is better
+            if (y.ions == null)
+                return 1; // y is null, x is better
+            if (x.ions.Count != y.ions.Count)
+                return -1 * x.ions.Count.CompareTo(y.ions.Count); // More ions are better
 
-            if(x.pwsm.NumMods !=  y.pwsm.NumMods)
+            // Bpwsm is a nullable property, so we need to check for null
+            if (x.pwsm == null && y.pwsm == null)
+                return 0;
+            if (x.pwsm == null)
+                return 1; // Null Bpwsm is considered worse
+            if (y.pwsm == null)
+                return -1; // Null Bpwsm is considered worse
+
+            if (x.pwsm.NumMods !=  y.pwsm.NumMods)
                 return -1 * x.pwsm.NumMods.CompareTo(y.pwsm.NumMods); // Fewer mods are better
 
             if(x.pwsm.FullSequence != y.pwsm.FullSequence)

--- a/MetaMorpheus/EngineLayer/BioPolymerNotchFragmentIonComparer.cs
+++ b/MetaMorpheus/EngineLayer/BioPolymerNotchFragmentIonComparer.cs
@@ -2,6 +2,7 @@
 using Omics.Fragmentation;
 using System;
 using System.Collections.Generic;
+// ReSharper disable ConditionIsAlwaysTrueOrFalse
 
 namespace EngineLayer
 {
@@ -25,23 +26,35 @@ namespace EngineLayer
             if (y.ions == null)
                 return 1; // y is null, x is better
             if (x.ions.Count != y.ions.Count)
-                return -1 * x.ions.Count.CompareTo(y.ions.Count); // More ions are better
+                return x.ions.Count.CompareTo(y.ions.Count); // More ions are better
 
             // Bpwsm is a nullable property, so we need to check for null
             if (x.pwsm == null && y.pwsm == null)
                 return 0;
             if (x.pwsm == null)
-                return 1; // Null Bpwsm is considered worse
+                return -1; // x is null, y is better
             if (y.pwsm == null)
-                return -1; // Null Bpwsm is considered worse
+                return 1; // y is null, x is better
 
-            if (x.pwsm.NumMods !=  y.pwsm.NumMods)
+            if (x.pwsm.NumMods != y.pwsm.NumMods)
                 return -1 * x.pwsm.NumMods.CompareTo(y.pwsm.NumMods); // Fewer mods are better
 
             if(x.pwsm.FullSequence != y.pwsm.FullSequence)
                 return -1 * String.Compare(x.pwsm.FullSequence, y.pwsm.FullSequence); // (reverse) Alphabetical ordering of full sequence
-
-            if(x.pwsm.Parent.Accession != y.pwsm.Parent.Accession) // This will break if the protein accession is not set (I'm not sure if that's possible)
+            
+            if (x.pwsm.Parent == null && y.pwsm.Parent == null)
+                return 0;
+            if (x.pwsm.Parent == null)
+                return -1; // x is null, y is better
+            if (y.pwsm.Parent == null)
+                return 1; // y is null, x is better
+            if (x.pwsm.Parent.Accession == null && y.pwsm.Parent.Accession == null)
+                return 0;
+            if (x.pwsm.Parent.Accession == null)
+                return -1; // x is null, y is better
+            if (y.pwsm.Parent.Accession == null)
+                return 1; // y is null, x is better
+            if (x.pwsm.Parent.Accession != y.pwsm.Parent.Accession) // This will break if the protein accession is not set (I'm not sure if that's possible)
                 return -1 * String.Compare(x.pwsm.Parent.Accession, y.pwsm.Parent.Accession); // (reverse) Alphabetical ordering of protein accession
 
             return -1 * x.pwsm.OneBasedStartResidue.CompareTo(y.pwsm.OneBasedStartResidue);                                                                  

--- a/MetaMorpheus/EngineLayer/SpectralMatch.cs
+++ b/MetaMorpheus/EngineLayer/SpectralMatch.cs
@@ -124,7 +124,7 @@ namespace EngineLayer
         #region Search
         public DigestionParams DigestionParams { get; }
 
-        public static BioPolymerNotchFragmentIonComparer<(int notch, IBioPolymerWithSetMods pwsm, List<MatchedFragmentIon> ions)> BioPolymerNotchFragmentIonComparer = new();
+        public static BioPolymerNotchFragmentIonComparer BioPolymerNotchFragmentIonComparer = new();
 
         // TODO: The BioPolymerWithSetModsToMatchingFragments dictionary should be more tightly coupled to the _BestMatchingBioPolymersWithSetMods list,
         // so that the two are always in sync. This would make the code more robust and easier to understand.

--- a/MetaMorpheus/Test/BioPolymerNotchFragmentIonComparerTest.cs
+++ b/MetaMorpheus/Test/BioPolymerNotchFragmentIonComparerTest.cs
@@ -1,12 +1,9 @@
-﻿using Easy.Common.Extensions;
-using EngineLayer;
+﻿using EngineLayer;
 using NUnit.Framework;
-using Omics;
 using Omics.Fragmentation;
 using Proteomics;
 using Proteomics.ProteolyticDigestion;
 using System.Collections.Generic;
-using System.Linq;
 using System.Reflection;
 using Omics.Modifications;
 
@@ -15,29 +12,31 @@ namespace Test
     [TestFixture]
     public static class BioPolymerNotchFragmentIonComparerTest
     {
-        private static BioPolymerNotchFragmentIonComparer<(int, IBioPolymerWithSetMods, List<MatchedFragmentIon>)> comparer;
+        private static BioPolymerNotchFragmentIonComparer comparer;
         private static Protein exampleProtein;
         private static PeptideWithSetModifications examplePwsm;
         private static MatchedFragmentIon exampleIon;
         private static PropertyInfo fullSequenceProperty;
         private static FieldInfo modDictField;
+        private static List<MatchedFragmentIon> emptyList;
 
         [SetUp]
         public static void Setup()
         {
-            comparer = new BioPolymerNotchFragmentIonComparer<(int, IBioPolymerWithSetMods, List<MatchedFragmentIon>)>();
+            comparer = new BioPolymerNotchFragmentIonComparer();
             exampleProtein = new Protein("PEPTIDEK", "accession");
             examplePwsm = new PeptideWithSetModifications("PEPTIDEK", null, p: exampleProtein);
             exampleIon = new MatchedFragmentIon(new Product(ProductType.b, FragmentationTerminus.N, 1, 1, 1, 0), 100, 100, 1);
             fullSequenceProperty = examplePwsm.GetType().GetProperty("FullSequence", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
             modDictField = examplePwsm.GetType().GetField("_allModsOneIsNterminus", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            emptyList = new();
         }
 
         [Test]
         public static void Compare_DifferentNotches()
         {
-            var x = (0, _examplePwsm: examplePwsm, new List<MatchedFragmentIon>());
-            var y = (2, _examplePwsm: examplePwsm, new List<MatchedFragmentIon>());
+            var x = (0, _examplePwsm: examplePwsm, emptyList);
+            var y = (2, _examplePwsm: examplePwsm, emptyList);
             Assert.That(comparer.Compare(x, y), Is.GreaterThan(0));
         }
 
@@ -45,7 +44,7 @@ namespace Test
         public static void Compare_DifferentFragmentIonCounts()
         {
             var x = (1, _examplePwsm: examplePwsm, new List<MatchedFragmentIon> { exampleIon });
-            var y = (1, _examplePwsm: examplePwsm, new List<MatchedFragmentIon>());
+            var y = (1, _examplePwsm: examplePwsm, emptyList);
             Assert.That(comparer.Compare(x, y), Is.GreaterThan(0));
         }
 
@@ -60,8 +59,8 @@ namespace Test
                     {1, new Modification() },
                     {4, new Modification() }
                 });
-            var x = (0, _examplePwsm: examplePwsm, new List<MatchedFragmentIon>());
-            var y = (0, modifiedPwsm, new List<MatchedFragmentIon>());
+            var x = (0, _examplePwsm: examplePwsm, emptyList);
+            var y = (0, modifiedPwsm, emptyList);
             Assert.That(comparer.Compare(x, y), Is.GreaterThan(0));
 
             // double check that mods are considered before sequence
@@ -78,8 +77,8 @@ namespace Test
             fullSequenceProperty.SetValue(modifiedPwsmSecond, "PEP[Oxidation]TIDEK");
 
             // Full sequences are compared alphabetically, and '[' comes before 'E'
-            var x = (0, modifiedPwsmFirst, new List<MatchedFragmentIon>());
-            var y = (0, modifiedPwsmSecond, new List<MatchedFragmentIon>());
+            var x = (0, modifiedPwsmFirst, emptyList);
+            var y = (0, modifiedPwsmSecond, emptyList);
             Assert.That(comparer.Compare(x, y), Is.GreaterThan(0));
         }
 
@@ -88,21 +87,95 @@ namespace Test
         {
             var protein1 = new Protein("PEPTIDEK", "accession1");
             var protein2 = new Protein("PEPTIDEK", "accession2");
-            var x = (1, new PeptideWithSetModifications("PEPTIDEK", null, p: protein1), new List<MatchedFragmentIon>());
-            var y = (1, new PeptideWithSetModifications("PEPTIDEK", null, p: protein2), new List<MatchedFragmentIon>());
+            var x = (1, new PeptideWithSetModifications("PEPTIDEK", null, p: protein1), emptyList);
+            var y = (1, new PeptideWithSetModifications("PEPTIDEK", null, p: protein2), emptyList);
             Assert.That(comparer.Compare(x, y), Is.GreaterThan(0));
         }
 
         [Test]
         public static void Compare_DifferentStartResidues()
         {
-            var x = (1, new PeptideWithSetModifications("PEPTIDEK", null, p: exampleProtein, oneBasedStartResidueInProtein: 1), new List<MatchedFragmentIon>());
-            var y = (1, new PeptideWithSetModifications("PEPTIDEK", null, p: exampleProtein, oneBasedStartResidueInProtein: 5), new List<MatchedFragmentIon>());
+            var x = (1, new PeptideWithSetModifications("PEPTIDEK", null, p: exampleProtein, oneBasedStartResidueInProtein: 1), emptyList);
+            var y = (1, new PeptideWithSetModifications("PEPTIDEK", null, p: exampleProtein, oneBasedStartResidueInProtein: 5), emptyList);
             Assert.That(comparer.Compare(x, y), Is.GreaterThan(0));
         }
+
+        [Test]
+        public static void Compare_NullPwsm()
+        {
+            var x = (0, (PeptideWithSetModifications)null, emptyList);
+            var y = (0, examplePwsm, emptyList);
+            Assert.That(comparer.Compare(x, y), Is.LessThan(0));
+
+            x = (0, examplePwsm, emptyList);
+            y = (0, null, emptyList);
+            Assert.That(comparer.Compare(x, y), Is.GreaterThan(0));
+
+            x = (0, null, emptyList);
+            y = (0, null, emptyList);
+            Assert.That(comparer.Compare(x, y), Is.EqualTo(0));
+        }
+
+        [Test]
+        public static void Compare_NullFragmentIons_DoesNotCrash()
+        {
+            var protein1 = new Protein("PEPTIDEK", "accession1");
+            var peptide = new PeptideWithSetModifications("PEPTIDEK", null, p: protein1);
+            List<MatchedFragmentIon> nullList = null;
+
+            var x = (1, peptide, nullList);
+            var y = (1, peptide, emptyList);
+            Assert.That(comparer.Compare(x, y), Is.LessThan(0));
+
+            x = (1, peptide, emptyList);
+            y = (1, peptide, nullList);
+            Assert.That(comparer.Compare(x, y), Is.GreaterThan(0));
+
+            x = (1, peptide, nullList);
+            y = (1, peptide, nullList);
+            Assert.That(comparer.Compare(x, y), Is.EqualTo(0));
+        }
+
+        [Test]
+        public static void Compare_NullParentAccessions()
+        {
+            var protein1 = new Protein("PEPTIDEK", null);
+            var protein2 = new Protein("PEPTIDEK", "accession");
+
+            var nullAccessionPeptide = new PeptideWithSetModifications("PEPTIDEK", null, p: protein1);
+            var normalPeptide = new PeptideWithSetModifications("PEPTIDEK", null, p: protein2);
+
+            var x = (1, peptide1: nullAccessionPeptide, emptyList);
+            var y = (1, peptide2: normalPeptide, emptyList);
+            Assert.That(comparer.Compare(x, y), Is.LessThan(0));
+
+            x = (1, normalPeptide, emptyList);
+            y = (1, nullAccessionPeptide, emptyList);
+            Assert.That(comparer.Compare(x, y), Is.GreaterThan(0));
+
+            x = (1, nullAccessionPeptide, emptyList);
+            y = (1, nullAccessionPeptide, emptyList);
+            Assert.That(comparer.Compare(x, y), Is.EqualTo(0));
+        }
+
+        [Test]
+        public static void Compare_NullParent()
+        {
+            var nullProteinPeptide = new PeptideWithSetModifications("PEPTIDEK", null, p: null);
+            var normalPeptide = new PeptideWithSetModifications("PEPTIDEK", null, p: exampleProtein);
+
+            var x = (1, peptide1: nullProteinPeptide, emptyList);
+            var y = (1, peptide2: normalPeptide, emptyList);
+            Assert.That(comparer.Compare(x, y), Is.LessThan(0));
+
+            x = (1, normalPeptide, emptyList);
+            y = (1, nullProteinPeptide, emptyList);
+            Assert.That(comparer.Compare(x, y), Is.GreaterThan(0));
+
+            x = (1, nullProteinPeptide, emptyList);
+            y = (1, nullProteinPeptide, emptyList);
+            Assert.That(comparer.Compare(x, y), Is.EqualTo(0));
+        }
     }
-
-  
-
 }
 


### PR DESCRIPTION
This pull request includes several changes to improve the robustness and readability of the `BioPolymerNotchFragmentIonComparer` class and its associated tests. The most important changes include removing unnecessary type parameters, adding null checks, and updating test cases to reflect these changes.
