### PR TITLE
Removed unused property in SpectralMatch

### DIFF
--- a/MetaMorpheus/EngineLayer/ClassicSearch/ClassicSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/ClassicSearch/ClassicSearchEngine.cs
@@ -226,7 +226,7 @@ namespace EngineLayer.ClassicSearch
                         }
                         else
                         {
-                            PeptideSpectralMatches[scan.ScanIndex].AddOrReplace(peptide, thisScore, scan.Notch, CommonParameters.ReportAllAmbiguity, matchedIons, 0);
+                            PeptideSpectralMatches[scan.ScanIndex].AddOrReplace(peptide, thisScore, scan.Notch, CommonParameters.ReportAllAmbiguity, matchedIons);
                         }
                     }
                 }

--- a/MetaMorpheus/EngineLayer/ClassicSearch/ClassicSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/ClassicSearch/ClassicSearchEngine.cs
@@ -222,7 +222,7 @@ namespace EngineLayer.ClassicSearch
                     {
                         if (PeptideSpectralMatches[scan.ScanIndex] == null)
                         {
-                            PeptideSpectralMatches[scan.ScanIndex] = new PeptideSpectralMatch(peptide, scan.Notch, thisScore, scan.ScanIndex, ArrayOfSortedMS2Scans[scan.ScanIndex], CommonParameters, matchedIons, 0);
+                            PeptideSpectralMatches[scan.ScanIndex] = new PeptideSpectralMatch(peptide, scan.Notch, thisScore, scan.ScanIndex, ArrayOfSortedMS2Scans[scan.ScanIndex], CommonParameters, matchedIons);
                         }
                         else
                         {

--- a/MetaMorpheus/EngineLayer/ClassicSearch/MiniClassicSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/ClassicSearch/MiniClassicSearchEngine.cs
@@ -93,7 +93,7 @@ namespace EngineLayer.ClassicSearch
                 double thisScore = MetaMorpheusEngine.CalculatePeptideScore(scan.TheScan.TheScan, matchedIons);
 
                 // Add psm to list
-                acceptablePsms.Add(new PeptideSpectralMatch(donorPwsm, scan.Notch, thisScore, scan.ScanIndex, scan.TheScan, FileSpecificParameters, matchedIons, 0));
+                acceptablePsms.Add(new PeptideSpectralMatch(donorPwsm, scan.Notch, thisScore, scan.ScanIndex, scan.TheScan, FileSpecificParameters, matchedIons));
             }
 
             IEnumerable<SpectralMatch> matchedSpectra = acceptablePsms.Where(p => p != null);

--- a/MetaMorpheus/EngineLayer/ModernSearch/ModernSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/ModernSearch/ModernSearchEngine.cs
@@ -358,7 +358,7 @@ namespace EngineLayer.ModernSearch
                 }
                 else
                 {
-                    PeptideSpectralMatches[scanIndex].AddOrReplace(peptide, thisScore, notch, CommonParameters.ReportAllAmbiguity, matchedIons, 0);
+                    PeptideSpectralMatches[scanIndex].AddOrReplace(peptide, thisScore, notch, CommonParameters.ReportAllAmbiguity, matchedIons);
                 }
             }
 

--- a/MetaMorpheus/EngineLayer/NonSpecificEnzymeSearch/NonSpecificEnzymeSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/NonSpecificEnzymeSearch/NonSpecificEnzymeSearchEngine.cs
@@ -143,7 +143,7 @@ namespace EngineLayer.NonSpecificEnzymeSearch
                                             }
                                             else
                                             {
-                                                localPeptideSpectralMatches[ms2ArrayIndex].AddOrReplace(peptide, thisScore, notch, CommonParameters.ReportAllAmbiguity, matchedIons, 0);
+                                                localPeptideSpectralMatches[ms2ArrayIndex].AddOrReplace(peptide, thisScore, notch, CommonParameters.ReportAllAmbiguity, matchedIons);
                                             }
                                         }
                                     }

--- a/MetaMorpheus/EngineLayer/OligoSpectralMatch.cs
+++ b/MetaMorpheus/EngineLayer/OligoSpectralMatch.cs
@@ -15,7 +15,7 @@ public class OligoSpectralMatch : SpectralMatch
     public OligoSpectralMatch(IBioPolymerWithSetMods peptide, int notch, double score, int scanIndex,
         Ms2ScanWithSpecificMass scan, CommonParameters commonParameters,
         List<MatchedFragmentIon> matchedFragmentIons, double xcorr = 0) : base(peptide, notch, score, scanIndex,
-        scan, commonParameters, matchedFragmentIons, xcorr)
+        scan, commonParameters, matchedFragmentIons)
     {
 
     }

--- a/MetaMorpheus/EngineLayer/OligoSpectralMatch.cs
+++ b/MetaMorpheus/EngineLayer/OligoSpectralMatch.cs
@@ -13,9 +13,8 @@ namespace EngineLayer;
 public class OligoSpectralMatch : SpectralMatch
 {
     public OligoSpectralMatch(IBioPolymerWithSetMods peptide, int notch, double score, int scanIndex,
-        Ms2ScanWithSpecificMass scan, CommonParameters commonParameters,
-        List<MatchedFragmentIon> matchedFragmentIons, double xcorr = 0) : base(peptide, notch, score, scanIndex,
-        scan, commonParameters, matchedFragmentIons)
+        Ms2ScanWithSpecificMass scan, CommonParameters commonParameters, List<MatchedFragmentIon> matchedFragmentIons) 
+        : base(peptide, notch, score, scanIndex, scan, commonParameters, matchedFragmentIons)
     {
 
     }

--- a/MetaMorpheus/EngineLayer/PeptideSpectralMatch.cs
+++ b/MetaMorpheus/EngineLayer/PeptideSpectralMatch.cs
@@ -12,7 +12,7 @@ namespace EngineLayer
         public PeptideSpectralMatch(IBioPolymerWithSetMods peptide, int notch, double score, int scanIndex,
             Ms2ScanWithSpecificMass scan, CommonParameters commonParameters,
             List<MatchedFragmentIon> matchedFragmentIons, double xcorr = 0) : base(peptide, notch, score, scanIndex,
-            scan, commonParameters, matchedFragmentIons, xcorr)
+            scan, commonParameters, matchedFragmentIons)
         {
 
         }

--- a/MetaMorpheus/EngineLayer/PeptideSpectralMatch.cs
+++ b/MetaMorpheus/EngineLayer/PeptideSpectralMatch.cs
@@ -10,12 +10,12 @@ namespace EngineLayer
     public class PeptideSpectralMatch : SpectralMatch
     {
         public PeptideSpectralMatch(IBioPolymerWithSetMods peptide, int notch, double score, int scanIndex,
-            Ms2ScanWithSpecificMass scan, CommonParameters commonParameters,
-            List<MatchedFragmentIon> matchedFragmentIons, double xcorr = 0) : base(peptide, notch, score, scanIndex,
-            scan, commonParameters, matchedFragmentIons)
+            Ms2ScanWithSpecificMass scan, CommonParameters commonParameters, List<MatchedFragmentIon> matchedFragmentIons) 
+            : base(peptide, notch, score, scanIndex, scan, commonParameters, matchedFragmentIons)
         {
 
         }
+
         #region Silac
             
 
@@ -49,7 +49,5 @@ namespace EngineLayer
         {
         }
         #endregion
-
-
     }
 }

--- a/MetaMorpheus/EngineLayer/SpectralMatch.cs
+++ b/MetaMorpheus/EngineLayer/SpectralMatch.cs
@@ -17,7 +17,7 @@ namespace EngineLayer
     {
         public const double ToleranceForScoreDifferentiation = 1e-9;
 
-        protected SpectralMatch(IBioPolymerWithSetMods peptide, int notch, double score, int scanIndex, Ms2ScanWithSpecificMass scan, CommonParameters commonParameters, List<MatchedFragmentIon> matchedFragmentIons, double xcorr = 0)
+        protected SpectralMatch(IBioPolymerWithSetMods peptide, int notch, double score, int scanIndex, Ms2ScanWithSpecificMass scan, CommonParameters commonParameters, List<MatchedFragmentIon> matchedFragmentIons)
         {
             _BestMatchingBioPolymersWithSetMods = new List<SpectralMatchHypothesis>();
             ScanIndex = scanIndex;
@@ -35,13 +35,12 @@ namespace EngineLayer
             PrecursorFractionalIntensity = scan.PrecursorFractionalIntensity;
             DigestionParams = commonParameters.DigestionParams;
             BioPolymersWithSetModsToMatchingFragments = new Dictionary<IBioPolymerWithSetMods, List<MatchedFragmentIon>>();
-            Xcorr = xcorr;
             NativeId = scan.NativeId;
             RunnerUpScore = commonParameters.ScoreCutoff;
             MsDataScan = scan.TheScan;
             SpectralAngle = -1;
 
-            AddOrReplace(peptide, score, notch, true, matchedFragmentIons, xcorr);
+            AddOrReplace(peptide, score, notch, true, matchedFragmentIons);
         }
 
         public MsDataScan MsDataScan { get; set; }
@@ -92,7 +91,6 @@ namespace EngineLayer
         public PsmData PsmData_forPEPandPercolator { get; set; }
 
         public double Score { get; private set; }
-        public double Xcorr;
         public double SpectralAngle { get; set; }
         public string NativeId; // this is a property of the scan. used for mzID writing
 
@@ -145,7 +143,7 @@ namespace EngineLayer
             }
         }
 
-        public void AddOrReplace(IBioPolymerWithSetMods pwsm, double newScore, int notch, bool reportAllAmbiguity, List<MatchedFragmentIon> matchedFragmentIons, double newXcorr)
+        public void AddOrReplace(IBioPolymerWithSetMods pwsm, double newScore, int notch, bool reportAllAmbiguity, List<MatchedFragmentIon> matchedFragmentIons)
         {
             if (newScore - Score > ToleranceForScoreDifferentiation) //if new score beat the old score, overwrite it
             {
@@ -157,7 +155,6 @@ namespace EngineLayer
                     RunnerUpScore = Score;
                 }
                 Score = newScore;
-                Xcorr = newXcorr;
 
                 BioPolymersWithSetModsToMatchingFragments.Clear();
                 BioPolymersWithSetModsToMatchingFragments.Add(pwsm, matchedFragmentIons);
@@ -381,7 +378,6 @@ namespace EngineLayer
             ScanIndex = psm.ScanIndex;
             FdrInfo = psm.FdrInfo;
             Score = psm.Score;
-            Xcorr = psm.Xcorr;
             RunnerUpScore = psm.RunnerUpScore;
             IsDecoy = psm.IsDecoy;
             IsContaminant = psm.IsContaminant;

--- a/MetaMorpheus/Test/FdrTest.cs
+++ b/MetaMorpheus/Test/FdrTest.cs
@@ -74,7 +74,7 @@ namespace Test
             Ms2ScanWithSpecificMass scan3 = new Ms2ScanWithSpecificMass(mzLibScan3, pep3.MonoisotopicMass.ToMz(1), 1, null, new CommonParameters());
             SpectralMatch psm3 = new PeptideSpectralMatch(pep3, 0, 1, 2, scan3, commonParameters, new List<MatchedFragmentIon>());
 
-            psm3.AddOrReplace(pep4, 1, 1, true, new List<MatchedFragmentIon>(), 0);
+            psm3.AddOrReplace(pep4, 1, 1, true, new List<MatchedFragmentIon>());
 
             var newPsms = new List<SpectralMatch> { psm1, psm2, psm3 };
             foreach (SpectralMatch psm in newPsms)
@@ -134,7 +134,7 @@ namespace Test
             Ms2ScanWithSpecificMass scan3 = new Ms2ScanWithSpecificMass(mzLibScan3, pep3.MonoisotopicMass.ToMz(1), 1, null, new CommonParameters());
             SpectralMatch psm3 = new PeptideSpectralMatch(pep3, 0, 1, 2, scan3, commonParameters, new List<MatchedFragmentIon>());
 
-            psm3.AddOrReplace(pep4, 1, 1, true, new List<MatchedFragmentIon>(), 0);
+            psm3.AddOrReplace(pep4, 1, 1, true, new List<MatchedFragmentIon>());
 
             var newPsms = new List<SpectralMatch> { psm1, psm2, psm3 };
             foreach (SpectralMatch psm in newPsms)
@@ -496,8 +496,8 @@ namespace Test
             PeptideWithSetModifications pwsm = new PeptideWithSetModifications(new Protein("PEPTIDE", "ACCESSION", "ORGANISM"), new DigestionParams(), 1, 2, CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0);
 
             SpectralMatch psm = new PeptideSpectralMatch(pwsm, 0, 1, 1, scan, new CommonParameters(), new List<MatchedFragmentIon>());
-            psm.AddOrReplace(pwsm, 1, 1, true, new List<MatchedFragmentIon>(), 0);
-            psm.AddOrReplace(pwsm, 1, 2, true, new List<MatchedFragmentIon>(), 0);
+            psm.AddOrReplace(pwsm, 1, 1, true, new List<MatchedFragmentIon>());
+            psm.AddOrReplace(pwsm, 1, 2, true, new List<MatchedFragmentIon>());
             psm.SetFdrValues(1, 0, 0, 1, 0, 0, 1, 0);
             psm.PeptideFdrInfo = new FdrInfo();
 
@@ -667,7 +667,7 @@ namespace Test
 
             PeptideWithSetModifications pwsm = new PeptideWithSetModifications(new Protein("PEPTIDE", "ACCESSION", "ORGANISM"), new DigestionParams(), 1, 2, CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0);
 
-            psm1.AddOrReplace(pwsm, 10, 1, true, new List<MatchedFragmentIon>(), 0);
+            psm1.AddOrReplace(pwsm, 10, 1, true, new List<MatchedFragmentIon>());
 
             Assert.That(psm1.BestMatchingBioPolymersWithSetMods.Count(), Is.EqualTo(2));
 

--- a/MetaMorpheus/Test/FdrTest.cs
+++ b/MetaMorpheus/Test/FdrTest.cs
@@ -663,7 +663,7 @@ namespace Test
                     2, 1, true, Polarity.Positive, double.NaN, null, null, MZAnalyzerType.Orbitrap, double.NaN, null, null, "scan=1", double.NaN, null, null, double.NaN, null, DissociationType.AnyActivationType, 1, null),
                 100, 1, null, new CommonParameters(), null);
 
-            SpectralMatch psm1 = new PeptideSpectralMatch(new PeptideWithSetModifications(new Protein("PEPTIDE", "ACCESSION", "ORGANISM"), new DigestionParams(), 1, 2, CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0), 0, 10, 1, scanB, new CommonParameters(), new List<MatchedFragmentIon>(), 0);
+            SpectralMatch psm1 = new PeptideSpectralMatch(new PeptideWithSetModifications(new Protein("PEPTIDE", "ACCESSION", "ORGANISM"), new DigestionParams(), 1, 2, CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0), 0, 10, 1, scanB, new CommonParameters(), new List<MatchedFragmentIon>());
 
             PeptideWithSetModifications pwsm = new PeptideWithSetModifications(new Protein("PEPTIDE", "ACCESSION", "ORGANISM"), new DigestionParams(), 1, 2, CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0);
 

--- a/MetaMorpheus/Test/ModificationAnalysisTest.cs
+++ b/MetaMorpheus/Test/ModificationAnalysisTest.cs
@@ -140,7 +140,7 @@ namespace Test
             fsp.Add(("", CommonParameters));
 
             SpectralMatch myPsm = new PeptideSpectralMatch(pwsm1, 0, 10, 0, scan, new CommonParameters(), new List<MatchedFragmentIon>());
-            myPsm.AddOrReplace(pwsm2, 10, 0, true, new List<MatchedFragmentIon>(),0);
+            myPsm.AddOrReplace(pwsm2, 10, 0, true, new List<MatchedFragmentIon>());
             
             myPsm.ResolveAllAmbiguities();
 

--- a/MetaMorpheus/Test/MultiProteaseParsimonyTest.cs
+++ b/MetaMorpheus/Test/MultiProteaseParsimonyTest.cs
@@ -53,10 +53,10 @@ namespace Test
             Ms2ScanWithSpecificMass scan = new Ms2ScanWithSpecificMass(dfb, 2, 0, "File", new CommonParameters());
 
             SpectralMatch psmPEPR_T = new PeptideSpectralMatch(pepA_1T, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
-            psmPEPR_T.AddOrReplace(pepA_2T, 10, 0, true, new List<MatchedFragmentIon>(),0);
-            psmPEPR_T.AddOrReplace(pepA_3T, 10, 0, true, new List<MatchedFragmentIon>(),0);
+            psmPEPR_T.AddOrReplace(pepA_2T, 10, 0, true, new List<MatchedFragmentIon>());
+            psmPEPR_T.AddOrReplace(pepA_3T, 10, 0, true, new List<MatchedFragmentIon>());
             SpectralMatch psmPEPR_A = new PeptideSpectralMatch(pepA_2A, 0, 10, 0, scan, commonParameters_ArgC, new List<MatchedFragmentIon>());
-            psmPEPR_A.AddOrReplace(pepA_3A, 10, 0, true, new List<MatchedFragmentIon>(),0);
+            psmPEPR_A.AddOrReplace(pepA_3A, 10, 0, true, new List<MatchedFragmentIon>());
             SpectralMatch psmABCK_T = new PeptideSpectralMatch(pepB_1T, 0, 10, 0, scan, commonParameters_Tryp, new List<MatchedFragmentIon>());
 
             List<SpectralMatch> psms = new List<SpectralMatch> { psmPEPR_T, psmPEPR_A, psmABCK_T };
@@ -140,9 +140,9 @@ namespace Test
             Ms2ScanWithSpecificMass scan = new Ms2ScanWithSpecificMass(dfb, 2, 0, "File", new CommonParameters());
 
             SpectralMatch psmABC_Dp1 = new PeptideSpectralMatch(pepA_1Dp1, 0, 10, 0, scan, commonParameters1, new List<MatchedFragmentIon>());
-            psmABC_Dp1.AddOrReplace(pepA_2Dp1, 10, 0, true, new List<MatchedFragmentIon>(),0);
+            psmABC_Dp1.AddOrReplace(pepA_2Dp1, 10, 0, true, new List<MatchedFragmentIon>());
             SpectralMatch psmABC_Dp2 = new PeptideSpectralMatch(pepA_1Dp2, 0, 10, 0, scan, commonParameters2, new List<MatchedFragmentIon>());
-            psmABC_Dp2.AddOrReplace(pepA_2Dp2, 10, 0, true, new List<MatchedFragmentIon>(),0);
+            psmABC_Dp2.AddOrReplace(pepA_2Dp2, 10, 0, true, new List<MatchedFragmentIon>());
             SpectralMatch psmEFG_Dp1 = new PeptideSpectralMatch(pepB_2Dp1, 0, 10, 0, scan, commonParameters1, new List<MatchedFragmentIon>());
 
             // builds psm list to match to peptides
@@ -221,7 +221,7 @@ namespace Test
             SpectralMatch psmABC_Dp2 = new PeptideSpectralMatch(pepB_2Dp2, 0, 10, 0, scan, commonParameters2, new List<MatchedFragmentIon>());
             SpectralMatch psmEFGABC_Dp1 = new PeptideSpectralMatch(pepC_2Dp1, 0, 10, 0, scan, commonParameters, new List<MatchedFragmentIon>());
             SpectralMatch psmXYZ_Dp1 = new PeptideSpectralMatch(pepA_1Dp1, 0, 10, 0, scan, commonParameters, new List<MatchedFragmentIon>());
-            psmXYZ_Dp1.AddOrReplace(pepA_2Dp1, 10, 0, true, new List<MatchedFragmentIon>(),0);
+            psmXYZ_Dp1.AddOrReplace(pepA_2Dp1, 10, 0, true, new List<MatchedFragmentIon>());
 
             // builds psm list to match to peptides
             List<SpectralMatch> psms = new List<SpectralMatch>() { psmABC_Dp1, psmABC_Dp2, psmEFGABC_Dp1, psmXYZ_Dp1 };
@@ -479,7 +479,7 @@ namespace Test
 
             SpectralMatch psmABC_Dp1 = new PeptideSpectralMatch(pepA_1Dp1, 0, 10, 0, scan, commonParameters, new List<MatchedFragmentIon>());
             SpectralMatch psmABC_Dp2 = new PeptideSpectralMatch(pepA_2Dp2, 0, 10, 0, scan, commonParameters2, new List<MatchedFragmentIon>());
-            psmABC_Dp2.AddOrReplace(pepA_3Dp2, 10, 0, true, new List<MatchedFragmentIon>(),0);
+            psmABC_Dp2.AddOrReplace(pepA_3Dp2, 10, 0, true, new List<MatchedFragmentIon>());
 
             // builds psm list to match to peptides
             List<SpectralMatch> psms = new List<SpectralMatch>() { psmABC_Dp1, psmABC_Dp2 };
@@ -814,9 +814,9 @@ namespace Test
 
             SpectralMatch psmABC_Alpha = new PeptideSpectralMatch(pepABC_1Alpha, 0, 10, 0, scan, commonParameters, new List<MatchedFragmentIon>());
             SpectralMatch psmABC_Beta = new PeptideSpectralMatch(pepABC_2Beta, 0, 10, 0, scan, commonParameters2, new List<MatchedFragmentIon>());
-            psmABC_Beta.AddOrReplace(pepABC_4Beta, 10, 0, true, new List<MatchedFragmentIon>(),0);
+            psmABC_Beta.AddOrReplace(pepABC_4Beta, 10, 0, true, new List<MatchedFragmentIon>());
             SpectralMatch psmEFG_Beta = new PeptideSpectralMatch(pepEFG_3Beta, 0, 10, 0, scan, commonParameters2, new List<MatchedFragmentIon>());
-            psmEFG_Beta.AddOrReplace(pepEFG_4Beta, 10, 0, true, new List<MatchedFragmentIon>(),0);
+            psmEFG_Beta.AddOrReplace(pepEFG_4Beta, 10, 0, true, new List<MatchedFragmentIon>());
 
             List<SpectralMatch> psms = new List<SpectralMatch> { psmABC_Alpha, psmABC_Beta, psmEFG_Beta };
             psms.ForEach(j => j.ResolveAllAmbiguities());
@@ -883,13 +883,13 @@ namespace Test
             Ms2ScanWithSpecificMass scan = new Ms2ScanWithSpecificMass(dfb, 2, 0, "File", new CommonParameters());
 
             SpectralMatch psmABCK_T = new PeptideSpectralMatch(pepABCK_1T, 0, 10, 0, scan, commonParameters_tryp, new List<MatchedFragmentIon>());
-            psmABCK_T.AddOrReplace(pepABCK_2T, 10, 0, true, new List<MatchedFragmentIon>(),0);
+            psmABCK_T.AddOrReplace(pepABCK_2T, 10, 0, true, new List<MatchedFragmentIon>());
             SpectralMatch psmABCK_L = new PeptideSpectralMatch(pepABCK_1L, 0, 10, 0, scan, commonParameters_LysC, new List<MatchedFragmentIon>());
-            psmABCK_L.AddOrReplace(pepABCK_2L, 10, 0, true, new List<MatchedFragmentIon>(),0);
+            psmABCK_L.AddOrReplace(pepABCK_2L, 10, 0, true, new List<MatchedFragmentIon>());
             SpectralMatch psmXYZK_T = new PeptideSpectralMatch(pepXYZK_1T, 0, 10, 0, scan, commonParameters_LysC, new List<MatchedFragmentIon>());
-            psmXYZK_T.AddOrReplace(pepXYZK_2T, 10, 0, true, new List<MatchedFragmentIon>(),0);
+            psmXYZK_T.AddOrReplace(pepXYZK_2T, 10, 0, true, new List<MatchedFragmentIon>());
             SpectralMatch psmXYZK_L = new PeptideSpectralMatch(pepXYZK_1L, 0, 10, 0, scan, commonParameters_LysC, new List<MatchedFragmentIon>());
-            psmXYZK_L.AddOrReplace(pepXYZK_2L, 10, 0, true, new List<MatchedFragmentIon>(),0);
+            psmXYZK_L.AddOrReplace(pepXYZK_2L, 10, 0, true, new List<MatchedFragmentIon>());
 
             List<SpectralMatch> psms = new List<SpectralMatch> { psmABCK_T, psmABCK_L, psmXYZK_T, psmXYZK_L };
             psms.ForEach(j => j.ResolveAllAmbiguities());
@@ -957,9 +957,9 @@ namespace Test
             Ms2ScanWithSpecificMass scan = new Ms2ScanWithSpecificMass(dfb, 2, 0, "File", new CommonParameters());
 
             SpectralMatch psmABC_Dash = new PeptideSpectralMatch(pepABC_1Dash, 0, 10, 0, scan, commonParameters, new List<MatchedFragmentIon>());
-            psmABC_Dash.AddOrReplace(pepABC_2Dash, 10, 0, true, new List<MatchedFragmentIon>(),0);
+            psmABC_Dash.AddOrReplace(pepABC_2Dash, 10, 0, true, new List<MatchedFragmentIon>());
             SpectralMatch psmABC_G = new PeptideSpectralMatch(pepABC_2G, 0, 10, 0, scan, commonParameters2, new List<MatchedFragmentIon>());
-            psmABC_G.AddOrReplace(pepABC_3G, 10, 0, true, new List<MatchedFragmentIon>(),0);
+            psmABC_G.AddOrReplace(pepABC_3G, 10, 0, true, new List<MatchedFragmentIon>());
 
             List<SpectralMatch> psms = new List<SpectralMatch> { psmABC_Dash, psmABC_G };
             psms.ForEach(j => j.ResolveAllAmbiguities());

--- a/MetaMorpheus/Test/PsmTsvWriterTests.cs
+++ b/MetaMorpheus/Test/PsmTsvWriterTests.cs
@@ -61,7 +61,7 @@ namespace Test
             mfi.Add(new MatchedFragmentIon(p, 1, 1, 1));
             SpectralMatch myPsm = new PeptideSpectralMatch(pwsm1, 0, 10, 0, scan, new CommonParameters(), mfi);
 
-            myPsm.AddOrReplace(pwsm2, 10, 0, true, mfi, 10);
+            myPsm.AddOrReplace(pwsm2, 10, 0, true, mfi);
 
             myPsm.ResolveAllAmbiguities();
 
@@ -87,7 +87,7 @@ namespace Test
             myPsm.RemoveThisAmbiguousPeptide(tentativeSpectralMatch);
 
             PeptideWithSetModifications pwsm3 = new PeptideWithSetModifications(protein1, new DigestionParams(), 2, 9, CleavageSpecificity.Unknown, null, 0, allModsOneIsNterminus1, 0);
-            myPsm.AddOrReplace(pwsm3, 10, 0, true, mfi, 10);
+            myPsm.AddOrReplace(pwsm3, 10, 0, true, mfi);
 
             myPsm.ResolveAllAmbiguities();
 

--- a/MetaMorpheus/Test/PsvTsvTest.cs
+++ b/MetaMorpheus/Test/PsvTsvTest.cs
@@ -295,32 +295,32 @@ namespace Test
             //second highest score 9. delta score 1
             PeptideSpectralMatch psmTwo = new(pepOne, 0, 8, 0, ms2ScanOneMzTen, commonParams,
                 new List<MatchedFragmentIon>());
-            psmTwo.AddOrReplace(pepTwo, 9, 0, true, new List<MatchedFragmentIon>(), 0);
+            psmTwo.AddOrReplace(pepTwo, 9, 0, true, new List<MatchedFragmentIon>());
 
             //second highest score 9. delta score 0.1
             PeptideSpectralMatch psmThree = new(pepOne, 0, 8.90000000000000000000000000000, 0, ms2ScanOneMzTen, commonParams,
                 new List<MatchedFragmentIon>());
-            psmThree.AddOrReplace(pepTwo, 9, 0, true, new List<MatchedFragmentIon>(), 0);
+            psmThree.AddOrReplace(pepTwo, 9, 0, true, new List<MatchedFragmentIon>());
 
             //third highest score delta score 1. ppm error -888657.54 low
             PeptideSpectralMatch psmFour = new(pepOne, 0, 7, 0, ms2ScanOneMzTwenty, commonParams,
                 new List<MatchedFragmentIon>());
-            psmFour.AddOrReplace(pepFour, 8, 0, true, new List<MatchedFragmentIon>(), 0);
+            psmFour.AddOrReplace(pepFour, 8, 0, true, new List<MatchedFragmentIon>());
 
             //third highest score 8. delta score 1. ppm error -947281.29 high
             PeptideSpectralMatch psmFive = new(pepOne, 0, 7, 0, ms2ScanOneMzTen, commonParams,
                 new List<MatchedFragmentIon>());
-            psmFive.AddOrReplace(pepFour, 8, 0, true, new List<MatchedFragmentIon>(), 0);
+            psmFive.AddOrReplace(pepFour, 8, 0, true, new List<MatchedFragmentIon>());
 
             //fourth highest score 7. delta score 1. same ppm error
             PeptideSpectralMatch psmSix = new(pepOne, 0, 6, 0, ms2ScanTwoMzTwenty, commonParams,
                 new List<MatchedFragmentIon>());
-            psmSix.AddOrReplace(pepSix, 7, 0, true, new List<MatchedFragmentIon>(), 0);
+            psmSix.AddOrReplace(pepSix, 7, 0, true, new List<MatchedFragmentIon>());
 
             //fourth highest score 7. delta score 1. same ppm error
             PeptideSpectralMatch psmSeven = new(pepOne, 0, 6, 0, ms2ScanThreeMzTwenty, commonParams,
                 new List<MatchedFragmentIon>());
-            psmSeven.AddOrReplace(pepSix, 7, 0, true, new List<MatchedFragmentIon>(), 0);
+            psmSeven.AddOrReplace(pepSix, 7, 0, true, new List<MatchedFragmentIon>());
 
             List<PeptideSpectralMatch> psms = new List<PeptideSpectralMatch> { psmFour, psmOne, psmThree, psmSeven, psmTwo, psmFive, psmSix };
             psms.ForEach(j => j.ResolveAllAmbiguities());

--- a/MetaMorpheus/Test/RobTest.cs
+++ b/MetaMorpheus/Test/RobTest.cs
@@ -98,7 +98,7 @@ namespace Test
             {
                 if (temp.TryGetValue(peptide.BaseSequence, out var psm))
                 {
-                    psm.AddOrReplace(peptide, 1, 0, true, new List<MatchedFragmentIon>(),0);
+                    psm.AddOrReplace(peptide, 1, 0, true, new List<MatchedFragmentIon>());
                 }
                 else
                 {

--- a/MetaMorpheus/Test/StefanParsimonyTest.cs
+++ b/MetaMorpheus/Test/StefanParsimonyTest.cs
@@ -179,7 +179,7 @@ namespace Test
             };
 
             // this PSM has a target and a decoy
-            psms[0].AddOrReplace(pep2, 1, 0, true, new List<MatchedFragmentIon>() { mfiC3, mfiC4 }, 0);
+            psms[0].AddOrReplace(pep2, 1, 0, true, new List<MatchedFragmentIon>() { mfiC3, mfiC4 });
 
             psms.ForEach(p => p.ResolveAllAmbiguities());
             psms.ForEach(p => p.SetFdrValues(0, 0, 0, 0, 0, 0, 0, 0));

--- a/MetaMorpheus/Test/TestPsm.cs
+++ b/MetaMorpheus/Test/TestPsm.cs
@@ -93,7 +93,7 @@ namespace Test
             // Start with a psm matched to a peptide with oxidation on I and one matched product ion
             SpectralMatch psm = new PeptideSpectralMatch(pepWithOxidationOnI, 1, 2, 3, scan, commonParameters, new List<MatchedFragmentIon> { bIon });
             // add a pwsm matched to a peptide with oxidation on P, one matched product ion, and one matched diagnostic ion (scores are identical as diagnostic ions aren't scored)
-            psm.AddOrReplace(pepWithOxidationOnP, 2, 1, true, twoIonList, 0);
+            psm.AddOrReplace(pepWithOxidationOnP, 2, 1, true, twoIonList);
 
             Assert.That(psm.BestMatchingBioPolymersWithSetMods.Count(), Is.EqualTo(2));
 
@@ -304,7 +304,7 @@ namespace Test
             Ms2ScanWithSpecificMass scanWithMass = new Ms2ScanWithSpecificMass(msDataScan, 4, 1, null, commonParameters);
 
             SpectralMatch psm = new PeptideSpectralMatch(target, 0, 1, 1, scanWithMass, commonParameters, null);
-            psm.AddOrReplace(decoy, 1, 0, true, null, 0);
+            psm.AddOrReplace(decoy, 1, 0, true, null);
 
             Assert.That(psm.BestMatchingBioPolymersWithSetMods.Count(), Is.EqualTo(2));
             Assert.That(psm.BestMatchingBioPolymersWithSetMods.Any(p => p.SpecificBioPolymer.Parent.IsDecoy));
@@ -330,7 +330,7 @@ namespace Test
             Ms2ScanWithSpecificMass scanWithMass = new Ms2ScanWithSpecificMass(msDataScan, 4, 1, null, commonParameters);
 
             SpectralMatch psm = new PeptideSpectralMatch(target, 0, 1, 1, scanWithMass, commonParameters, null);
-            psm.AddOrReplace(decoy, 1, 0, true, null, 0);
+            psm.AddOrReplace(decoy, 1, 0, true, null);
 
             Assert.That(psm.BestMatchingBioPolymersWithSetMods.Count(), Is.EqualTo(2));
             Assert.That(psm.BestMatchingBioPolymersWithSetMods.Any(p => p.SpecificBioPolymer.Parent.IsDecoy));
@@ -494,7 +494,7 @@ namespace Test
 
             PeptideWithSetModifications pwsm = new PeptideWithSetModifications(new Protein("PEPTIDE", "ACCESSION", "ORGANISM"), new DigestionParams(), 1, 2, CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0);
 
-            psm1.AddOrReplace(pwsm, 11, 1, true, new List<MatchedFragmentIon>(), 0);
+            psm1.AddOrReplace(pwsm, 11, 1, true, new List<MatchedFragmentIon>());
 
             Assert.That(psm1.BestMatchingBioPolymersWithSetMods.Count(), Is.EqualTo(1));
 

--- a/MetaMorpheus/Test/TestPsm.cs
+++ b/MetaMorpheus/Test/TestPsm.cs
@@ -490,7 +490,7 @@ namespace Test
                     2, 1, true, Polarity.Positive, double.NaN, null, null, MZAnalyzerType.Orbitrap, double.NaN, null, null, "scan=1", double.NaN, null, null, double.NaN, null, DissociationType.AnyActivationType, 1, null),
                 100, 1, null, new CommonParameters(), null);
 
-            SpectralMatch psm1 = new PeptideSpectralMatch(new PeptideWithSetModifications(new Protein("PEPTIDE", "ACCESSION", "ORGANISM"), new DigestionParams(), 1, 2, CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0), 0, 10, 1, scanB, new CommonParameters(), new List<MatchedFragmentIon>(), 0);
+            SpectralMatch psm1 = new PeptideSpectralMatch(new PeptideWithSetModifications(new Protein("PEPTIDE", "ACCESSION", "ORGANISM"), new DigestionParams(), 1, 2, CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0), 0, 10, 1, scanB, new CommonParameters(), new List<MatchedFragmentIon>());
 
             PeptideWithSetModifications pwsm = new PeptideWithSetModifications(new Protein("PEPTIDE", "ACCESSION", "ORGANISM"), new DigestionParams(), 1, 2, CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0);
 
@@ -513,7 +513,7 @@ namespace Test
                     2, 1, true, Polarity.Positive, double.NaN, null, null, MZAnalyzerType.Orbitrap, double.NaN, null, null, "scan=1", double.NaN, null, null, double.NaN, null, DissociationType.AnyActivationType, 1, null),
                 100, 1, null, new CommonParameters(), null);
 
-            SpectralMatch psm1 = new PeptideSpectralMatch(new PeptideWithSetModifications(new Protein("PEPTIDE", "ACCESSION", "ORGANISM"), new DigestionParams(), 1, 2, CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0), 0, 10, 1, scanB, new CommonParameters(), new List<MatchedFragmentIon>(), 0);
+            SpectralMatch psm1 = new PeptideSpectralMatch(new PeptideWithSetModifications(new Protein("PEPTIDE", "ACCESSION", "ORGANISM"), new DigestionParams(), 1, 2, CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0), 0, 10, 1, scanB, new CommonParameters(), new List<MatchedFragmentIon>());
 
             PeptideWithSetModifications pwsm = new PeptideWithSetModifications(new Protein("PEPTIDE", "ACCESSION", "ORGANISM"), new DigestionParams(), 1, 2, CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0);
 

--- a/MetaMorpheus/Test/XLTest.cs
+++ b/MetaMorpheus/Test/XLTest.cs
@@ -368,7 +368,7 @@ namespace Test
             Protein protForwardAsDecoy = new Protein(sequence: "VPEPTIDELPEPTIDEAPEPTIDE", accession: "DECOY", isDecoy: true);
             PeptideWithSetModifications pwsmV_D = new PeptideWithSetModifications(protForwardAsDecoy, new DigestionParams(), 1, 8, CleavageSpecificity.Full, "VPEPTIDE", 0, mod, 0, null);
 
-            csmOne.AddOrReplace(pwsmV_D, 3, 0, true, new List<MatchedFragmentIon>(), 0);
+            csmOne.AddOrReplace(pwsmV_D, 3, 0, true, new List<MatchedFragmentIon>());
             csmOne.ResolveAllAmbiguities();
             Assert.That(csmOne.BestMatchingBioPolymersWithSetMods.Count() == 1);
             Assert.That(!csmOne.BestMatchingBioPolymersWithSetMods.First().SpecificBioPolymer.Parent.IsDecoy);


### PR DESCRIPTION
Xcorr was an unused property in SpectralMatch that was almost always passed as 0. It has now been removed. 