### PR TITLE
Changed GPTMD back to the way it was

### DIFF
--- a/MetaMorpheus/EngineLayer/Gptmd/GptmdEngine.cs
+++ b/MetaMorpheus/EngineLayer/Gptmd/GptmdEngine.cs
@@ -14,7 +14,9 @@ namespace EngineLayer.Gptmd
 {
     public class GptmdEngine : MetaMorpheusEngine
     {
+        // It is assumed that there is a one-to-one correspondence between the psms in AllIdentifications and the scans in AllScans
         private readonly List<SpectralMatch> AllIdentifications;
+        private readonly List<Ms2ScanWithSpecificMass> AllScans;
         private readonly IEnumerable<Tuple<double, double>> Combos;
         private readonly List<Modification> GptmdModifications;
         private readonly Dictionary<string, Tolerance> FilePathToPrecursorMassTolerance; // this exists because of file-specific tolerances
@@ -32,7 +34,6 @@ namespace EngineLayer.Gptmd
             CommonParameters commonParameters, 
             List<(string fileName, CommonParameters fileSpecificParameters)> fileSpecificParameters, 
             List<string> nestedIds,
-            Ms2ScanWithSpecificMass[] dataScans,
             Dictionary<string, HashSet<Tuple<int, Modification>>> modDictionary) 
             : base(commonParameters, fileSpecificParameters, nestedIds)
         {
@@ -40,7 +41,6 @@ namespace EngineLayer.Gptmd
             GptmdModifications = gptmdModifications;
             Combos = combos;
             FilePathToPrecursorMassTolerance = filePathToPrecursorMassTolerance;
-            ArrayOfSortedMS2Scans = dataScans;
             ModDictionary = modDictionary ?? new Dictionary<string, HashSet<Tuple<int, Modification>>>();
         }
 
@@ -118,7 +118,7 @@ namespace EngineLayer.Gptmd
                                     {
                                         var scores = new List<double>();
                                         var dissociationType = CommonParameters.DissociationType == DissociationType.Autodetect ?
-                                            ArrayOfSortedMS2Scans[psms[i].ScanIndex].TheScan.DissociationType.Value : CommonParameters.DissociationType;
+                                            psms[i].Ms2Scan.DissociationType.Value : CommonParameters.DissociationType;
 
                                         scores = CalculatePeptideScores(newPeptides, dissociationType, psms[i]);
 
@@ -205,7 +205,7 @@ namespace EngineLayer.Gptmd
                 var peptideTheorProducts = new List<Product>();
                 peptide.Fragment(dissociationType, CommonParameters.DigestionParams.FragmentationTerminus, peptideTheorProducts);
 
-                var scan = ArrayOfSortedMS2Scans[psm.ScanIndex].TheScan;
+                var scan = psm.Ms2Scan;
                 var precursorMass = psm.ScanPrecursorMass;
                 var precursorCharge = psm.ScanPrecursorCharge;
                 var fileName = psm.FullFilePath;

--- a/MetaMorpheus/EngineLayer/Gptmd/GptmdEngine.cs
+++ b/MetaMorpheus/EngineLayer/Gptmd/GptmdEngine.cs
@@ -16,14 +16,11 @@ namespace EngineLayer.Gptmd
     {
         // It is assumed that there is a one-to-one correspondence between the psms in AllIdentifications and the scans in AllScans
         private readonly List<SpectralMatch> AllIdentifications;
-        private readonly List<Ms2ScanWithSpecificMass> AllScans;
         private readonly IEnumerable<Tuple<double, double>> Combos;
         private readonly List<Modification> GptmdModifications;
         private readonly Dictionary<string, Tolerance> FilePathToPrecursorMassTolerance; // this exists because of file-specific tolerances
         //The ScoreTolerance property is used to differentiatie when a PTM candidate is added to a peptide. We check the score at each position and then add that mod where the score is highest.
         private readonly double ScoreTolerance = 0.1;
-
-        public Ms2ScanWithSpecificMass[] ArrayOfSortedMS2Scans { get; init; }
         public Dictionary<string, HashSet<Tuple<int, Modification>>> ModDictionary { get; init; }
 
         public GptmdEngine(

--- a/MetaMorpheus/EngineLayer/SpectralMatch.cs
+++ b/MetaMorpheus/EngineLayer/SpectralMatch.cs
@@ -70,6 +70,9 @@ namespace EngineLayer
         public double PrecursorFractionalIntensity { get; }
         public double ScanPrecursorMass { get; }
         public string FullFilePath { get; private set; }
+        /// <summary>
+        /// Refers to the index of the Ms2ScanWithSpecificMass in an array of Ms2ScansWithSpecificMass that is sorted by precursor mass
+        /// </summary>
         public int ScanIndex { get; }
         public int NumDifferentMatchingPeptides { get { return _BestMatchingBioPolymersWithSetMods.Count; } }
 
@@ -117,6 +120,24 @@ namespace EngineLayer
                 return this._BestMatchingBioPolymersWithSetMods.Select(p => Math.Round((this.ScanPrecursorMass - p.SpecificBioPolymer.MonoisotopicMass) / p.SpecificBioPolymer.MonoisotopicMass * 1e6, 2)).ToList();
             }
         }
+
+        #region GPTMD
+
+        /// <summary>
+        /// This property is only used by the GPTMD Task
+        /// </summary>
+        public MsDataScan Ms2Scan { get; private set; }
+
+        /// <summary>
+        /// This should only be called within the GPTMD Task
+        /// </summary>
+        /// <param name="scan"></param>
+        public void SetMs2Scan(MsDataScan scan)
+        {
+            Ms2Scan = scan;
+        }
+
+        #endregion
 
         #region Search
         public DigestionParams DigestionParams { get; }

--- a/MetaMorpheus/Test/GPTMDengineTest.cs
+++ b/MetaMorpheus/Test/GPTMDengineTest.cs
@@ -41,9 +41,8 @@ namespace Test
 
             var fsp = new List<(string fileName, CommonParameters fileSpecificParameters)>();
             fsp.Add(("", new CommonParameters()));
-            Ms2ScanWithSpecificMass[] scanArray = Array.Empty<Ms2ScanWithSpecificMass>();
 
-            var engine = new GptmdEngine(allResultingIdentifications, gptmdModifications, combos, new Dictionary<string, Tolerance> { { "filepath", precursorMassTolerance } }, new CommonParameters(), fsp, new List<string>(), scanArray, null);
+            var engine = new GptmdEngine(allResultingIdentifications, gptmdModifications, combos, new Dictionary<string, Tolerance> { { "filepath", precursorMassTolerance } }, new CommonParameters(), fsp, new List<string>(), null);
             var res = (GptmdResults)engine.Run();
             Assert.That(res.Mods.Count, Is.EqualTo(0));
 
@@ -60,12 +59,11 @@ namespace Test
             var peptidesWithSetModifications = new List<PeptideWithSetModifications> { modPep };
             SpectralMatch newPsm = new PeptideSpectralMatch(peptidesWithSetModifications.First(), 0, 0, 0, scan, commonParameters, new List<MatchedFragmentIon>());
 
-            Tolerance fragmentTolerance = new AbsoluteTolerance(0.01);
-
             newPsm.SetFdrValues(1, 0, 0, 1, 0, 0, 0, 0);
+            newPsm.SetMs2Scan(scan.TheScan);
             allResultingIdentifications.Add(newPsm);
 
-            engine = new GptmdEngine(allResultingIdentifications, gptmdModifications, combos, new Dictionary<string, Tolerance> { { "filepath", precursorMassTolerance } }, new CommonParameters(), null, new List<string>(), new Ms2ScanWithSpecificMass[] { scan }, null);
+            engine = new GptmdEngine(allResultingIdentifications, gptmdModifications, combos, new Dictionary<string, Tolerance> { { "filepath", precursorMassTolerance } }, new CommonParameters(), null, new List<string>(), null);
             res = (GptmdResults)engine.Run();
             Assert.That(res.Mods.Count, Is.EqualTo(1));
             Assert.That(res.Mods["accession"].Count, Is.EqualTo(numModifiedResidues));
@@ -101,6 +99,10 @@ namespace Test
                 commonParameters, fsp, new List<string>()).Run());
 
             var nonNullPsms = allPsmsArray.Where(p => p != null).ToList();
+            foreach(var psm in nonNullPsms)
+            {
+                psm.SetMs2Scan(listOfSortedms2Scans[psm.ScanIndex].TheScan);
+            }
             GptmdParameters g = new GptmdParameters();
             List<Modification> gptmdModifications = GlobalVariables.AllModsKnown.OfType<Modification>().Where(b => g.ListOfModsGptmd.Contains((b.ModificationType, b.IdWithMotif))).ToList();
             var reducedMods = new List<Modification>();
@@ -111,10 +113,8 @@ namespace Test
                     reducedMods.Add(mod);
                 }
             }
-
             
-            var engine = new GptmdEngine(nonNullPsms, reducedMods, new List<Tuple<double, double>>(), new Dictionary<string, Tolerance> { { @"TestData\SmallCalibratible_Yeast.mzML", precursorMassTolerance } }, commonParameters, fsp, new List<string>(),
-                listOfSortedms2Scans, null);
+            var engine = new GptmdEngine(nonNullPsms, reducedMods, new List<Tuple<double, double>>(), new Dictionary<string, Tolerance> { { @"TestData\SmallCalibratible_Yeast.mzML", precursorMassTolerance } }, commonParameters, fsp, new List<string>(), null);
             var res = (GptmdResults)engine.Run();
             Assert.That(8, Is.EqualTo(res.Mods.Count));
         }
@@ -163,9 +163,10 @@ namespace Test
             Tolerance fragmentTolerance = new AbsoluteTolerance(0.01);
 
             match.SetFdrValues(1, 0, 0, 1, 0, 0, 0, 0);
+            match.SetMs2Scan(scan.TheScan);
             allIdentifications = new List<SpectralMatch> { match };
 
-            var engine = new GptmdEngine(allIdentifications, gptmdModifications, combos, new Dictionary<string, Tolerance> { { "filepath", precursorMassTolerance } }, new CommonParameters(), null, new List<string>(), new Ms2ScanWithSpecificMass[] {scan}, null);
+            var engine = new GptmdEngine(allIdentifications, gptmdModifications, combos, new Dictionary<string, Tolerance> { { "filepath", precursorMassTolerance } }, new CommonParameters(), null, new List<string>(), null);
             var res = (GptmdResults)engine.Run();
             Assert.That(res.Mods.Count, Is.EqualTo(numModHashes));
             Assert.That(res.Mods["accession"].Count, Is.EqualTo(numModifiedResidues));
@@ -203,9 +204,10 @@ namespace Test
             Tolerance fragmentTolerance = new AbsoluteTolerance(0.01);
 
             match.SetFdrValues(1, 0, 0, 1, 0, 0, 0, 0);
+            match.SetMs2Scan(scan.TheScan);
             allIdentifications = new List<SpectralMatch> { match };
 
-            var engine = new GptmdEngine(allIdentifications, gptmdModifications, combos, new Dictionary<string, Tolerance> { { "filepath", precursorMassTolerance } }, new CommonParameters(), null, new List<string>(), new Ms2ScanWithSpecificMass[] {scan}, null);
+            var engine = new GptmdEngine(allIdentifications, gptmdModifications, combos, new Dictionary<string, Tolerance> { { "filepath", precursorMassTolerance } }, new CommonParameters(), null, new List<string>(), null);
             var res = (GptmdResults)engine.Run();
         }
 


### PR DESCRIPTION
My recent refactor to the GPTMD engine decreases the number of modified peptides identified in bottom-up data. This PR reverts those changes. 

 - SpectralMatch: Spectral match now has an Ms2Scan property that is only used within the GPTMD task
 - GPTMDTask: FDR analysis is now done on all PSMs from all files at once, instead of file-by-file
 - GPTMDEngine: The engine now gets the MsDataScan directly from the Ms2Scan property of each PSM