### PR TITLE
Generalize MetaDraw to use SpectrumMatchFromTsv

### DIFF
--- a/MetaMorpheus/GUI/MetaDraw/MetaDraw.xaml.cs
+++ b/MetaMorpheus/GUI/MetaDraw/MetaDraw.xaml.cs
@@ -642,7 +642,7 @@ namespace MetaMorpheusGUI
 
             foreach (var cell in dataGridScanNums.SelectedItems)
             {
-                var psm = (PsmFromTsv)cell;
+                var psm = (SpectrumMatchFromTsv)cell;
                 psms.Add(psm);
             }
 

--- a/MetaMorpheus/GUI/MetaDraw/MetaDraw.xaml.cs
+++ b/MetaMorpheus/GUI/MetaDraw/MetaDraw.xaml.cs
@@ -19,6 +19,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 using Omics.Fragmentation;
+using Readers;
 
 namespace MetaMorpheusGUI
 {
@@ -49,10 +50,10 @@ namespace MetaMorpheusGUI
 
             InitializeColorSettingsView();
             MetaDrawLogic = new MetaDrawLogic();
-            BindingOperations.EnableCollectionSynchronization(MetaDrawLogic.PsmResultFilePaths, MetaDrawLogic.ThreadLocker);
+            BindingOperations.EnableCollectionSynchronization(MetaDrawLogic.SpectralMatchResultFilePaths, MetaDrawLogic.ThreadLocker);
             BindingOperations.EnableCollectionSynchronization(MetaDrawLogic.SpectraFilePaths, MetaDrawLogic.ThreadLocker);
             BindingOperations.EnableCollectionSynchronization(MetaDrawLogic.FilteredListOfPsms, MetaDrawLogic.ThreadLocker);
-            BindingOperations.EnableCollectionSynchronization(MetaDrawLogic.PsmsGroupedByFile, MetaDrawLogic.ThreadLocker);
+            BindingOperations.EnableCollectionSynchronization(MetaDrawLogic.SpectralMatchesGroupedByFile, MetaDrawLogic.ThreadLocker);
 
             itemsControlSampleViewModel = new ParentChildScanPlotsView();
             ParentChildScanViewPlots.DataContext = itemsControlSampleViewModel;
@@ -122,11 +123,11 @@ namespace MetaMorpheusGUI
             }
             else if (AcceptedResultsFormats.Contains(theExtension))
             {
-                if (!MetaDrawLogic.PsmResultFilePaths.Contains(filePath))
+                if (!MetaDrawLogic.SpectralMatchResultFilePaths.Contains(filePath))
                 {
-                    MetaDrawLogic.PsmResultFilePaths.Add(filePath);
+                    MetaDrawLogic.SpectralMatchResultFilePaths.Add(filePath);
 
-                    if (MetaDrawLogic.PsmResultFilePaths.Count == 1)
+                    if (MetaDrawLogic.SpectralMatchResultFilePaths.Count == 1)
                     {
                         psmFileNameLabel.Text = filePath;
                         psmFileNameLabelStat.Text = filePath;
@@ -137,10 +138,10 @@ namespace MetaMorpheusGUI
                         psmFileNameLabelStat.Text = "[Mouse over to view files]";
                     }
 
-                    psmFileNameLabel.ToolTip = string.Join("\n", MetaDrawLogic.PsmResultFilePaths);
+                    psmFileNameLabel.ToolTip = string.Join("\n", MetaDrawLogic.SpectralMatchResultFilePaths);
                     resetPsmFileButton.IsEnabled = true;
 
-                    psmFileNameLabelStat.ToolTip = string.Join("\n", MetaDrawLogic.PsmResultFilePaths);
+                    psmFileNameLabelStat.ToolTip = string.Join("\n", MetaDrawLogic.SpectralMatchResultFilePaths);
                     resetPsmFileButtonStat.IsEnabled = true;
                 }
             }
@@ -180,7 +181,7 @@ namespace MetaMorpheusGUI
             MetaDrawLogic.CleanUpCurrentlyDisplayedPlots();
             wholeSequenceCoverageHorizontalScroll.ScrollToLeftEnd();
             plotView.Visibility = Visibility.Visible;
-            PsmFromTsv psm = (PsmFromTsv)dataGridScanNums.SelectedItem;
+            SpectrumMatchFromTsv psm = (SpectrumMatchFromTsv)dataGridScanNums.SelectedItem;
 
             List<MatchedFragmentIon> oldMatchedIons = null;
             if (FragmentationReanalysisViewModel.Persist && sender is DataGrid)
@@ -194,7 +195,7 @@ namespace MetaMorpheusGUI
             {
                 ClearPresentationArea();
                 chimeraPlot.Visibility = Visibility.Visible;
-                List<PsmFromTsv> chimericPsms = MetaDrawLogic.FilteredListOfPsms
+                List<SpectrumMatchFromTsv> chimericPsms = MetaDrawLogic.FilteredListOfPsms
                     .Where(p => p.Ms2ScanNumber == psm.Ms2ScanNumber && p.FileNameWithoutExtension == psm.FileNameWithoutExtension).ToList();
                 MetaDrawLogic.DisplayChimeraSpectra(chimeraPlot, chimericPsms, out List<string> error);
                 if (error != null && error.Count > 0)
@@ -226,7 +227,7 @@ namespace MetaMorpheusGUI
                     // set to first and break the loop if casted successfully
                     foreach (var ambiguousResult in AmbiguousSequenceOptionBox.Items)
                     {
-                        psm = ambiguousResult as PsmFromTsv;
+                        psm = ambiguousResult as SpectrumMatchFromTsv;
                         if (psm != null)
                             break;
                     }
@@ -238,7 +239,7 @@ namespace MetaMorpheusGUI
                 // selecting a different ambiguous result from the combobox in child scan view
                 else
                 {
-                    psm = (PsmFromTsv)AmbiguousSequenceOptionBox.SelectedItem;
+                    psm = (SpectrumMatchFromTsv)AmbiguousSequenceOptionBox.SelectedItem;
                 }
 
                 if (FragmentationReanalysisViewModel.Persist || sender is FragmentationReanalysisViewModel)
@@ -260,7 +261,7 @@ namespace MetaMorpheusGUI
                 var fullSeqs = psm.FullSequence.Split('|');
                 foreach (var fullSeq in fullSeqs)
                 {
-                    PsmFromTsv oneAmbiguousPsm = new(psm, fullSeq);
+                    SpectrumMatchFromTsv oneAmbiguousPsm = psm.ReplaceFullSequence(fullSeq);
                     AmbiguousSequenceOptionBox.Items.Add(oneAmbiguousPsm);
                 }
                 return;
@@ -300,11 +301,11 @@ namespace MetaMorpheusGUI
             {
                 
                 int descriptionLineCount = MetaDrawSettings.SpectrumDescription.Count(p => p.Value);
-                if (psm.ProteinName.IsNotNullOrEmptyOrWhiteSpace())
+                if (psm.Name.IsNotNullOrEmptyOrWhiteSpace())
                 {
-                    descriptionLineCount += (int)Math.Floor((psm.ProteinName.Length - 20) / 26.0);
+                    descriptionLineCount += (int)Math.Floor((psm.Name.Length - 20) / 26.0);
                 }
-                if (psm.ProteinAccession.Length > 10)
+                if (psm.Accession.Length > 10)
                     descriptionLineCount++;
                 double verticalOffset = descriptionLineCount * 14;
                 
@@ -490,7 +491,7 @@ namespace MetaMorpheusGUI
                 return;
             }
 
-            if (!MetaDrawLogic.PsmResultFilePaths.Any())
+            if (!MetaDrawLogic.SpectralMatchResultFilePaths.Any())
             {
                 MessageBox.Show("Please add a search result file.");
                 return;
@@ -517,7 +518,7 @@ namespace MetaMorpheusGUI
             }
 
             PsmStatPlotFiles.Clear();
-            foreach (var item in MetaDrawLogic.PsmsGroupedByFile)
+            foreach (var item in MetaDrawLogic.SpectralMatchesGroupedByFile)
             {
                 PsmStatPlotFiles.Add(item.Key);
             }
@@ -568,15 +569,15 @@ namespace MetaMorpheusGUI
             }
 
             SetSequenceDrawingPositionSettings();
-            List<PsmFromTsv> items = new List<PsmFromTsv>();
+            List<SpectrumMatchFromTsv> items = new();
 
             foreach (var cell in dataGridScanNums.SelectedItems)
             {
-                var psm = (PsmFromTsv)cell;
+                var psm = (SpectrumMatchFromTsv)cell;
                 items.Add(psm);
             }
 
-            string directoryPath = Path.Combine(Path.GetDirectoryName(MetaDrawLogic.PsmResultFilePaths.First()), "MetaDrawExport",
+            string directoryPath = Path.Combine(Path.GetDirectoryName(MetaDrawLogic.SpectralMatchResultFilePaths.First()), "MetaDrawExport",
                     DateTime.Now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
 
 
@@ -637,7 +638,7 @@ namespace MetaMorpheusGUI
                 return;
             }
 
-            List<PsmFromTsv> psms = new List<PsmFromTsv>();
+            List<SpectrumMatchFromTsv> psms = new();
 
             foreach (var cell in dataGridScanNums.SelectedItems)
             {
@@ -645,7 +646,7 @@ namespace MetaMorpheusGUI
                 psms.Add(psm);
             }
 
-            string directoryPath = Path.Combine(Path.GetDirectoryName(MetaDrawLogic.PsmResultFilePaths.First()),
+            string directoryPath = Path.Combine(Path.GetDirectoryName(MetaDrawLogic.SpectralMatchResultFilePaths.First()),
                 "MetaDrawExport",    
                 DateTime.Now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
 
@@ -679,9 +680,9 @@ namespace MetaMorpheusGUI
                 return;
             }
 
-            string directoryPath = Path.Combine(Path.GetDirectoryName(MetaDrawLogic.PsmResultFilePaths.First()), "MetaDrawExport",
+            string directoryPath = Path.Combine(Path.GetDirectoryName(MetaDrawLogic.SpectralMatchResultFilePaths.First()), "MetaDrawExport",
                     DateTime.Now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
-            PsmFromTsv psm = (PsmFromTsv)dataGridScanNums.SelectedItem;
+            SpectrumMatchFromTsv psm = (SpectrumMatchFromTsv)dataGridScanNums.SelectedItem;
             MetaDrawLogic.ExportSequenceCoverage(sequenceText, map, directoryPath, psm);
             
             if (Directory.Exists(directoryPath))
@@ -698,9 +699,9 @@ namespace MetaMorpheusGUI
                 return;
             }
 
-            string directoryPath = Path.Combine(Path.GetDirectoryName(MetaDrawLogic.PsmResultFilePaths.First()), "MetaDrawExport",
+            string directoryPath = Path.Combine(Path.GetDirectoryName(MetaDrawLogic.SpectralMatchResultFilePaths.First()), "MetaDrawExport",
                     DateTime.Now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
-            PsmFromTsv psm = (PsmFromTsv)dataGridScanNums.SelectedItem;
+            SpectrumMatchFromTsv psm = (SpectrumMatchFromTsv)dataGridScanNums.SelectedItem;
 
             int width = (int)SequenceAnnotationGrid.ActualWidth;
             MetaDrawLogic.ExportAnnotatedSequence(sequenceAnnotationCanvas, SequenceCoveragePtmLegendControl, psm, directoryPath, width);
@@ -722,7 +723,7 @@ namespace MetaMorpheusGUI
         private void loadFilesButtonStat_Click(object sender, RoutedEventArgs e)
         {
             // check for validity
-            if (!MetaDrawLogic.PsmResultFilePaths.Any())
+            if (!MetaDrawLogic.SpectralMatchResultFilePaths.Any())
             {
                 MessageBox.Show("Please add a search result file.");
                 return;
@@ -738,7 +739,7 @@ namespace MetaMorpheusGUI
             MetaDrawLogic.LoadFiles(loadSpectra: false, loadPsms: true);
 
             PsmStatPlotFiles.Clear();
-            foreach (var item in MetaDrawLogic.PsmsGroupedByFile)
+            foreach (var item in MetaDrawLogic.SpectralMatchesGroupedByFile)
             {
                 PsmStatPlotFiles.Add(item.Key);
             }
@@ -765,7 +766,7 @@ namespace MetaMorpheusGUI
                 return;
             }
 
-            if (!MetaDrawLogic.PsmResultFilePaths.Any())
+            if (!MetaDrawLogic.SpectralMatchResultFilePaths.Any())
             {
                 MessageBox.Show("No PSMs are loaded!");
                 return;
@@ -778,7 +779,7 @@ namespace MetaMorpheusGUI
             }
 
             var plotName = selectedItem as string;
-            var fileDirectory = Path.Combine(Path.GetDirectoryName(MetaDrawLogic.PsmResultFilePaths.First()), "MetaDrawExport",
+            var fileDirectory = Path.Combine(Path.GetDirectoryName(MetaDrawLogic.SpectralMatchResultFilePaths.First()), "MetaDrawExport",
                     DateTime.Now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture));
             var fileName = String.Concat(plotName, ".pdf");
 
@@ -821,12 +822,12 @@ namespace MetaMorpheusGUI
             }
 
             // get psms from selected source files
-            ObservableCollection<PsmFromTsv> psms = new ObservableCollection<PsmFromTsv>();
-            Dictionary<string, ObservableCollection<PsmFromTsv>> psmsBSF = new Dictionary<string, ObservableCollection<PsmFromTsv>>();
+            ObservableCollection<SpectrumMatchFromTsv> psms = new();
+            Dictionary<string, ObservableCollection<SpectrumMatchFromTsv>> psmsBSF = new();
             foreach (string fileName in selectSourceFileListBox.SelectedItems)
             {
-                psmsBSF.Add(fileName, MetaDrawLogic.PsmsGroupedByFile[fileName]);
-                foreach (PsmFromTsv psm in MetaDrawLogic.PsmsGroupedByFile[fileName])
+                psmsBSF.Add(fileName, MetaDrawLogic.SpectralMatchesGroupedByFile[fileName]);
+                foreach (SpectrumMatchFromTsv psm in MetaDrawLogic.SpectralMatchesGroupedByFile[fileName])
                 {
                     psms.Add(psm);
                 }
@@ -886,10 +887,10 @@ namespace MetaMorpheusGUI
         /// <param name="e"></param>
         private void wholeSequenceCoverageHorizontalScroll_Scroll(object sender, ScrollChangedEventArgs e)
         {
-            PsmFromTsv psm = (PsmFromTsv)dataGridScanNums.SelectedItem;
+            SpectrumMatchFromTsv psm = (SpectrumMatchFromTsv)dataGridScanNums.SelectedItem;
             if (AmbiguousSequenceOptionBox.Items.Count > 1 && AmbiguousSequenceOptionBox.SelectedItem != null)
             {
-                psm = (PsmFromTsv)AmbiguousSequenceOptionBox.SelectedItem;
+                psm = (SpectrumMatchFromTsv)AmbiguousSequenceOptionBox.SelectedItem;
 
                 // Draw the matched ions for the first ambiguous sequence only
                 if (AmbiguousSequenceOptionBox.SelectedIndex == 0)
@@ -922,10 +923,10 @@ namespace MetaMorpheusGUI
             }
 
             wholeSequenceCoverageHorizontalScroll.ScrollToLeftEnd();
-            PsmFromTsv psm = (PsmFromTsv)dataGridScanNums.SelectedItem;
+            SpectrumMatchFromTsv psm = (SpectrumMatchFromTsv)dataGridScanNums.SelectedItem;
             if (AmbiguousSequenceOptionBox.Items.Count > 1 && AmbiguousSequenceOptionBox.SelectedItem != null)
             {
-                psm = (PsmFromTsv)AmbiguousSequenceOptionBox.SelectedItem;
+                psm = (SpectrumMatchFromTsv)AmbiguousSequenceOptionBox.SelectedItem;
                 wholeSequenceCoverageHorizontalScroll.Visibility = Visibility.Visible;
 
                 // Draw the matched ions for the first ambiguous sequence only
@@ -965,10 +966,10 @@ namespace MetaMorpheusGUI
             {
                 offset = 0;
             }
-            PsmFromTsv psm = (PsmFromTsv)dataGridScanNums.SelectedItem;
+            SpectrumMatchFromTsv psm = (SpectrumMatchFromTsv)dataGridScanNums.SelectedItem;
             if (AmbiguousSequenceOptionBox.Items.Count > 1 && AmbiguousSequenceOptionBox.SelectedItem != null)
             {
-                psm = (PsmFromTsv)AmbiguousSequenceOptionBox.SelectedItem;
+                psm = (SpectrumMatchFromTsv)AmbiguousSequenceOptionBox.SelectedItem;
             }
 
             int lettersOnScreen = (int)Math.Round((width - 10) / MetaDrawSettings.AnnotatedSequenceTextSpacing, 0);
@@ -1005,7 +1006,7 @@ namespace MetaMorpheusGUI
             }
 
             PtmLegend.DecreaseResiduesPerSegment();
-            PsmFromTsv psm = (PsmFromTsv)dataGridScanNums.SelectedItem;
+            SpectrumMatchFromTsv psm = (SpectrumMatchFromTsv)dataGridScanNums.SelectedItem;
             MetaDrawLogic.DisplaySequences(null, null, sequenceAnnotationCanvas, psm);
         }
 
@@ -1017,7 +1018,7 @@ namespace MetaMorpheusGUI
         private void residuesPerSegmentcmdUp_Click(object sender, RoutedEventArgs e)
         {
             PtmLegend.IncreaseResiduesPerSegment();
-            PsmFromTsv psm = (PsmFromTsv)dataGridScanNums.SelectedItem;
+            SpectrumMatchFromTsv psm = (SpectrumMatchFromTsv)dataGridScanNums.SelectedItem;
             MetaDrawLogic.DisplaySequences(null, null, sequenceAnnotationCanvas, psm);
         }
 
@@ -1035,7 +1036,7 @@ namespace MetaMorpheusGUI
             }
 
             PtmLegend.DecreaseSegmentsPerRow();
-            PsmFromTsv psm = (PsmFromTsv)dataGridScanNums.SelectedItem;
+            SpectrumMatchFromTsv psm = (SpectrumMatchFromTsv)dataGridScanNums.SelectedItem;
             MetaDrawLogic.DisplaySequences(null, null, sequenceAnnotationCanvas, psm);
         }
 
@@ -1047,14 +1048,14 @@ namespace MetaMorpheusGUI
         private void segmentsPerRowcmdUp_Click(object sender, RoutedEventArgs e)
         {
             PtmLegend.IncreaseSegmentsPerRow();
-            PsmFromTsv psm = (PsmFromTsv)dataGridScanNums.SelectedItem;
+            SpectrumMatchFromTsv psm = (SpectrumMatchFromTsv)dataGridScanNums.SelectedItem;
             MetaDrawLogic.DisplaySequences(null, null, sequenceAnnotationCanvas, psm);
         }
 
 
         private void MetaDrawTabControl_OnSelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            PsmFromTsv selectedPsm = (PsmFromTsv)dataGridScanNums.SelectedItem;
+            SpectrumMatchFromTsv selectedPsm = (SpectrumMatchFromTsv)dataGridScanNums.SelectedItem;
 
             if (e.OriginalSource is not TabControl) // only clicking on different MetaDrawTabs will trigger this event
                 return;
@@ -1138,7 +1139,7 @@ namespace MetaMorpheusGUI
         internal void SearchWithNewIons_OnClick(object sender, RoutedEventArgs e)
         {
             // find currently selected psm
-            var psm = dataGridScanNums.SelectedItem as PsmFromTsv;
+            var psm = dataGridScanNums.SelectedItem as SpectrumMatchFromTsv;
             if (psm is null)
                 return;
             
@@ -1156,7 +1157,7 @@ namespace MetaMorpheusGUI
         /// Replaces matched fragment ions on a psm with new ion types after a quick search
         /// </summary>
         /// <param name="psm"></param>
-        private void ReplaceFragmentIonsOnPsmFromFragmentReanalysisViewModel(PsmFromTsv psm)
+        private void ReplaceFragmentIonsOnPsmFromFragmentReanalysisViewModel(SpectrumMatchFromTsv psm)
         {
             var scan = MetaDrawLogic.GetMs2ScanFromPsm(psm);
             var newIons = FragmentationReanalysisViewModel.MatchIonsWithNewTypes(scan, psm);

--- a/MetaMorpheus/GuiFunctions/MetaDraw/DrawnSequence.cs
+++ b/MetaMorpheus/GuiFunctions/MetaDraw/DrawnSequence.cs
@@ -12,6 +12,8 @@ using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Shapes;
 using Proteomics;
+using Readers;
+using Omics;
 
 namespace GuiFunctions
 {
@@ -24,8 +26,8 @@ namespace GuiFunctions
         public Canvas SequenceDrawingCanvas;
         public bool Stationary;
         public bool Annotation;
-        public PsmFromTsv SpectrumMatch;
-        public DrawnSequence(Canvas sequenceDrawingCanvas, PsmFromTsv psm, bool stationary, bool annotation = false)
+        public SpectrumMatchFromTsv SpectrumMatch;
+        public DrawnSequence(Canvas sequenceDrawingCanvas, SpectrumMatchFromTsv psm, bool stationary, bool annotation = false)
         {
             SequenceDrawingCanvas = sequenceDrawingCanvas;
             SpectrumMatch = psm;
@@ -56,11 +58,11 @@ namespace GuiFunctions
         /// <param name="yLoc"></param>
         /// <param name="matchedFragmentIons"></param>
         /// <param name="canvas"></param>
-        /// <param name="psm"></param>
-        public void AnnotateBaseSequence(string baseSequence, string fullSequence, int yLoc, List<MatchedFragmentIon> matchedFragmentIons, PsmFromTsv psm, 
+        /// <param name="match"></param>
+        public void AnnotateBaseSequence(string baseSequence, string fullSequence, int yLoc, List<MatchedFragmentIon> matchedFragmentIons, SpectrumMatchFromTsv match, 
             bool stationary = false, int annotationRow = 0, int chunkPositionInRow = 0)
         {
-            if (!Annotation && (psm.BetaPeptideBaseSequence == null || !psm.BetaPeptideBaseSequence.Equals(baseSequence)))
+            if (!Annotation && match is PsmFromTsv psm && (psm.BetaPeptideBaseSequence == null || !psm.BetaPeptideBaseSequence.Equals(baseSequence)))
             {
                 ClearCanvas(SequenceDrawingCanvas);
             }
@@ -68,14 +70,14 @@ namespace GuiFunctions
             int spacing = 12;
 
             int psmStartResidue;
-            if (psm.StartAndEndResiduesInProtein is null or "")
+            if (match.StartAndEndResiduesInParentSequence is null or "")
             {
                 psmStartResidue = 0;
                 MetaDrawSettings.DrawNumbersUnderStationary = false;
             }
             else
             {
-                psmStartResidue = int.Parse(psm.StartAndEndResiduesInProtein.Split("to")[0].Replace("[", ""));
+                psmStartResidue = int.Parse(match.StartAndEndResiduesInParentSequence.Split("to")[0].Replace("[", ""));
             }
      
 
@@ -146,7 +148,7 @@ namespace GuiFunctions
                     if (ion.NeutralTheoreticalProduct.SecondaryProductType == null)
                     {
                         string annotation = ion.NeutralTheoreticalProduct.ProductType + "" + ion.NeutralTheoreticalProduct.FragmentNumber;
-                        OxyColor oxycolor = psm.VariantCrossingIons.Contains(ion) ?
+                        OxyColor oxycolor = match.VariantCrossingIons != null && match.VariantCrossingIons.Contains(ion) ?
                             MetaDrawSettings.VariantCrossColor : MetaDrawSettings.ProductTypeToColor[ion.NeutralTheoreticalProduct.ProductType];
                         Color color = Color.FromArgb(oxycolor.A, oxycolor.R, oxycolor.G, oxycolor.B);
 
@@ -158,25 +160,26 @@ namespace GuiFunctions
                         int residue;
                         if (Stationary)
                         {
-                            residue = ion.NeutralTheoreticalProduct.AminoAcidPosition - MetaDrawSettings.FirstAAonScreenIndex;
+                            residue = ion.NeutralTheoreticalProduct.ResiduePosition - MetaDrawSettings.FirstAAonScreenIndex;
                         }
                         else if (Annotation)
                         {
-                            residue = ion.NeutralTheoreticalProduct.AminoAcidPosition + (chunkPositionInRow) - (MetaDrawSettings.SequenceAnnotaitonResiduesPerSegment * MetaDrawSettings.SequenceAnnotationSegmentPerRow * annotationRow);
+                            residue = ion.NeutralTheoreticalProduct.ResiduePosition + (chunkPositionInRow) - (MetaDrawSettings.SequenceAnnotaitonResiduesPerSegment * MetaDrawSettings.SequenceAnnotationSegmentPerRow * annotationRow);
                         }
                         else
                         {
-                            residue = ion.NeutralTheoreticalProduct.AminoAcidPosition;
+                            residue = ion.NeutralTheoreticalProduct.ResiduePosition;
                         }
                         
                         double x = residue * MetaDrawSettings.AnnotatedSequenceTextSpacing + 11 + MetaDrawSettings.ProductTypeToXOffset[ion.NeutralTheoreticalProduct.ProductType];
                         double y = yLoc + MetaDrawSettings.ProductTypeToYOffset[ion.NeutralTheoreticalProduct.ProductType];
-
-                        if (ion.NeutralTheoreticalProduct.Terminus == FragmentationTerminus.C)
+                        
+                        var terminus = ion.NeutralTheoreticalProduct.Terminus;
+                        if (terminus is FragmentationTerminus.C or FragmentationTerminus.ThreePrime)
                         {
                             DrawCTermIon(SequenceDrawingCanvas, new Point(x, y), color, annotation);
                         }
-                        else if (ion.NeutralTheoreticalProduct.Terminus == FragmentationTerminus.N)
+                        else if (terminus is FragmentationTerminus.N or FragmentationTerminus.FivePrime)
                         {
                             DrawNTermIon(SequenceDrawingCanvas, new Point(x, y), color, annotation);
                         }
@@ -184,7 +187,7 @@ namespace GuiFunctions
                     }
                 }
             }
-            AnnotateModifications(psm, SequenceDrawingCanvas, fullSequence, yLoc, chunkPositionInRow: chunkPositionInRow, annotationRow: annotationRow, annotation: Annotation);
+            AnnotateModifications(match, SequenceDrawingCanvas, fullSequence, yLoc, chunkPositionInRow: chunkPositionInRow, annotationRow: annotationRow, annotation: Annotation);
         }
 
         /// <summary>
@@ -196,15 +199,15 @@ namespace GuiFunctions
         /// <param name="yLoc"></param>
         /// <param name="spacer"></param>
         /// <param name="xShift"></param>
-        public static void AnnotateModifications(PsmFromTsv spectrumMatch, Canvas sequenceDrawingCanvas, string fullSequence, int yLoc, double? spacer = null, int xShift = 12, int chunkPositionInRow = 0, int annotationRow = 0, bool annotation = false)
+        public static void AnnotateModifications(SpectrumMatchFromTsv spectrumMatch, Canvas sequenceDrawingCanvas, string fullSequence, int yLoc, double? spacer = null, int xShift = 12, int chunkPositionInRow = 0, int annotationRow = 0, bool annotation = false)
         {
-            var peptide = new PeptideWithSetModifications(fullSequence, GlobalVariables.AllModsKnownDictionary);
+            IBioPolymerWithSetMods peptide = spectrumMatch.ToBioPolymerWithSetMods();
 
             // read glycans if applicable
             List<Tuple<int, string, double>> localGlycans = null;
-            if (spectrumMatch.GlycanLocalizationLevel != null)
+            if (spectrumMatch is PsmFromTsv { GlycanLocalizationLevel: not null } psm)
             {
-                localGlycans = PsmFromTsv.ReadLocalizedGlycan(spectrumMatch.LocalizedGlycan);
+                localGlycans = SpectrumMatchFromTsv.ReadLocalizedGlycan(psm.LocalizedGlycan);
             }
 
             // annotate mods
@@ -244,10 +247,10 @@ namespace GuiFunctions
         /// <param name="firstLetterOnScreen"></param>
         /// <param name="psm"></param>
         /// <param name="canvas"></param>
-        public static void DrawStationarySequence(PsmFromTsv psm, DrawnSequence stationarySequence, int yLoc)
+        public static void DrawStationarySequence(SpectrumMatchFromTsv psm, DrawnSequence stationarySequence, int yLoc)
         {
             ClearCanvas(stationarySequence.SequenceDrawingCanvas);
-            var peptide = new PeptideWithSetModifications(psm.FullSequence, GlobalVariables.AllModsKnownDictionary);
+            IBioPolymerWithSetMods peptide = psm.ToBioPolymerWithSetMods();
             string baseSequence = psm.BaseSeq.Substring(MetaDrawSettings.FirstAAonScreenIndex, MetaDrawSettings.NumberOfAAOnScreen);
             string fullSequence = baseSequence;
 
@@ -260,8 +263,8 @@ namespace GuiFunctions
                 fullSequence = fullSequence.Insert(mod.Key - 1 - MetaDrawSettings.FirstAAonScreenIndex, "[" + mod.Value.ModificationType + ":" + mod.Value.IdWithMotif + "]");
             }
 
-            List<MatchedFragmentIon> matchedIons = psm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.AminoAcidPosition > MetaDrawSettings.FirstAAonScreenIndex &&
-                                                   p.NeutralTheoreticalProduct.AminoAcidPosition < (MetaDrawSettings.FirstAAonScreenIndex + MetaDrawSettings.NumberOfAAOnScreen)).ToList();
+            List<MatchedFragmentIon> matchedIons = psm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.ResiduePosition > MetaDrawSettings.FirstAAonScreenIndex &&
+                                                   p.NeutralTheoreticalProduct.ResiduePosition < (MetaDrawSettings.FirstAAonScreenIndex + MetaDrawSettings.NumberOfAAOnScreen)).ToList();
             stationarySequence.AnnotateBaseSequence(baseSequence, fullSequence, yLoc, matchedIons, psm, true);
         }
 
@@ -270,19 +273,19 @@ namespace GuiFunctions
         /// </summary>
         /// <param name="psm"></param>
         /// <param name="sequence"></param>
-        public static void DrawSequenceAnnotation(PsmFromTsv psm, DrawnSequence sequence)
+        public static void DrawSequenceAnnotation(SpectrumMatchFromTsv psm, DrawnSequence sequence)
         {
             ClearCanvas(sequence.SequenceDrawingCanvas); 
             int segmentsPerRow = MetaDrawSettings.SequenceAnnotationSegmentPerRow;
             int residuesPerSegment = MetaDrawSettings.SequenceAnnotaitonResiduesPerSegment;
-            var peptide = new PeptideWithSetModifications(psm.FullSequence, GlobalVariables.AllModsKnownDictionary);
-            var modDictionary = peptide.AllModsOneIsNterminus.OrderByDescending(p => p.Key);
+            var bioPolymerWithSetMods = psm.ToBioPolymerWithSetMods();
+            var modDictionary = bioPolymerWithSetMods.AllModsOneIsNterminus.OrderByDescending(p => p.Key);
             int numberOfRows = (int)Math.Ceiling(((double)psm.BaseSeq.Length / residuesPerSegment) / segmentsPerRow);
             int remaining = psm.BaseSeq.Length;
 
             sequence.SequenceDrawingCanvas.Height = 42 * numberOfRows + 10;
-            // create an individual psm for each chunk to be drawn
-            List<PsmFromTsv> segments = new();
+            // create an individual match for each chunk to be drawn
+            List<SpectrumMatchFromTsv> segments = new();
             List<List<MatchedFragmentIon>> matchedIonSegments = new();
             for (int i = 0; i < psm.BaseSeq.Length; i += residuesPerSegment)
             {
@@ -292,17 +295,17 @@ namespace GuiFunctions
                 if (i + residuesPerSegment < psm.BaseSeq.Length)
                 {
                     baseSequence = psm.BaseSeq.Substring(i, residuesPerSegment);
-                    ions = psm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.AminoAcidPosition > i && p.NeutralTheoreticalProduct.AminoAcidPosition < (i + residuesPerSegment)).ToList();
-                    ions.AddRange(psm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.AminoAcidPosition == i && p.NeutralTheoreticalProduct.Annotation.Contains('y')));
-                    ions.AddRange(psm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.AminoAcidPosition == (i + residuesPerSegment) && p.NeutralTheoreticalProduct.Annotation.Contains('b')));
+                    ions = psm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.ResiduePosition > i && p.NeutralTheoreticalProduct.ResiduePosition < (i + residuesPerSegment)).ToList();
+                    ions.AddRange(psm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.ResiduePosition == i && p.NeutralTheoreticalProduct.Annotation.Contains('y')));
+                    ions.AddRange(psm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.ResiduePosition == (i + residuesPerSegment) && p.NeutralTheoreticalProduct.Annotation.Contains('b')));
                     remaining -= residuesPerSegment;
                 }
                 else
                 {
                     baseSequence = psm.BaseSeq.Substring(i, remaining);
-                    ions = psm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.AminoAcidPosition > i && p.NeutralTheoreticalProduct.AminoAcidPosition < (i + remaining)).ToList();
-                    ions.AddRange(psm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.AminoAcidPosition == i && p.NeutralTheoreticalProduct.Annotation.Contains('y')));
-                    ions.AddRange(psm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.AminoAcidPosition == (i + residuesPerSegment) && p.NeutralTheoreticalProduct.Annotation.Contains('b')));
+                    ions = psm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.ResiduePosition > i && p.NeutralTheoreticalProduct.ResiduePosition < (i + remaining)).ToList();
+                    ions.AddRange(psm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.ResiduePosition == i && p.NeutralTheoreticalProduct.Annotation.Contains('y')));
+                    ions.AddRange(psm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.ResiduePosition == (i + residuesPerSegment) && p.NeutralTheoreticalProduct.Annotation.Contains('b')));
                     remaining -= remaining;
                 }
 
@@ -322,18 +325,19 @@ namespace GuiFunctions
 
                     
                 }
-                PsmFromTsv tempPsm = new(psm, fullSequence, baseSequence: baseSequence);
+                
+                SpectrumMatchFromTsv tempPsm = psm.ReplaceFullSequence(fullSequence, baseSequence);
                 segments.Add(tempPsm);
                 matchedIonSegments.Add(ions);
             }
 
-            // draw each resulting psm
+            // draw each resulting match
             for (int i = 0; i < segments.Count; i++)
             {
                 int startPosition = i * residuesPerSegment;
                 int endPosition = (i + 1) * residuesPerSegment;
-                List<MatchedFragmentIon> matchedIons = psm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.AminoAcidPosition > startPosition &&
-                                                       p.NeutralTheoreticalProduct.AminoAcidPosition < endPosition).ToList();
+                List<MatchedFragmentIon> matchedIons = psm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.ResiduePosition > startPosition &&
+                                                       p.NeutralTheoreticalProduct.ResiduePosition < endPosition).ToList();
                 int currentRowZeroIndexed = i / segmentsPerRow;
                 int yLoc = 10 + (currentRowZeroIndexed * 42);
                 int chunkPositionInRow = (i % segmentsPerRow);
@@ -344,10 +348,14 @@ namespace GuiFunctions
 
         public void DrawCrossLinkSequence()
         {
-            this.AnnotateBaseSequence(SpectrumMatch.BetaPeptideBaseSequence, SpectrumMatch.BetaPeptideFullSequence, 100, SpectrumMatch.BetaPeptideMatchedIons, SpectrumMatch);
+            var spectrumMatch = (PsmFromTsv)this.SpectrumMatch;
+            if (spectrumMatch is null)
+                return;
+
+            this.AnnotateBaseSequence(spectrumMatch.BetaPeptideBaseSequence, spectrumMatch.BetaPeptideFullSequence, 100, spectrumMatch.BetaPeptideMatchedIons, spectrumMatch);
             // annotate crosslinker
-            int alphaSite = int.Parse(Regex.Match(SpectrumMatch.FullSequence, @"\d+").Value);
-            int betaSite = int.Parse(Regex.Match(SpectrumMatch.BetaPeptideFullSequence, @"\d+").Value);
+            int alphaSite = int.Parse(Regex.Match(spectrumMatch.FullSequence, @"\d+").Value);
+            int betaSite = int.Parse(Regex.Match(spectrumMatch.BetaPeptideFullSequence, @"\d+").Value);
 
             AnnotateCrosslinker(SequenceDrawingCanvas,
                 new Point(alphaSite * MetaDrawSettings.AnnotatedSequenceTextSpacing, 50),

--- a/MetaMorpheus/GuiFunctions/MetaDraw/DrawnSequence.cs
+++ b/MetaMorpheus/GuiFunctions/MetaDraw/DrawnSequence.cs
@@ -201,7 +201,7 @@ namespace GuiFunctions
         /// <param name="xShift"></param>
         public static void AnnotateModifications(SpectrumMatchFromTsv spectrumMatch, Canvas sequenceDrawingCanvas, string fullSequence, int yLoc, double? spacer = null, int xShift = 12, int chunkPositionInRow = 0, int annotationRow = 0, bool annotation = false)
         {
-            IBioPolymerWithSetMods peptide = spectrumMatch.ToBioPolymerWithSetMods();
+            var modDict = IBioPolymerWithSetMods.GetModificationDictionaryFromFullSequence(fullSequence, GlobalVariables.AllModsKnownDictionary);
 
             // read glycans if applicable
             List<Tuple<int, string, double>> localGlycans = null;
@@ -211,7 +211,7 @@ namespace GuiFunctions
             }
 
             // annotate mods
-            foreach (var mod in peptide.AllModsOneIsNterminus)
+            foreach (var mod in modDict)
             {
                 double xLocation = (mod.Key - 1) * (spacer ?? MetaDrawSettings.AnnotatedSequenceTextSpacing) - xShift;
                 // adjust for spacing in sequence annotation

--- a/MetaMorpheus/GuiFunctions/MetaDraw/FragmentResearching/FragmentationReanalysisViewModel.cs
+++ b/MetaMorpheus/GuiFunctions/MetaDraw/FragmentResearching/FragmentationReanalysisViewModel.cs
@@ -199,12 +199,12 @@ namespace GuiFunctions
             PossibleProducts.ForEach(product => product.Use = dissociationTypeProducts.Contains(product.ProductType));
         }
 
-        public List<MatchedFragmentIon> MatchIonsWithNewTypes(MsDataScan ms2Scan, SpectrumMatchFromTsv psmToRematch)
+        public List<MatchedFragmentIon> MatchIonsWithNewTypes(MsDataScan ms2Scan, SpectrumMatchFromTsv smToRematch)
         {
-            if (psmToRematch.FullSequence.Contains('|'))
-                return psmToRematch.MatchedIons;
+            if (smToRematch.FullSequence.Contains('|'))
+                return smToRematch.MatchedIons;
 
-            IBioPolymerWithSetMods bioPolymer = psmToRematch.ToBioPolymerWithSetMods();
+            IBioPolymerWithSetMods bioPolymer = smToRematch.ToBioPolymerWithSetMods();
 
             List<Product> terminalProducts = new List<Product>();
             Omics.Fragmentation.Peptide.DissociationTypeCollection.ProductsFromDissociationType[DissociationType.Custom] = _productsToUse.ToList(); 
@@ -223,11 +223,11 @@ namespace GuiFunctions
             if (Math.Abs(commonParams.ProductMassTolerance.Value - ProductIonMassTolerance) > 0.00001)
                 commonParams.ProductMassTolerance = new PpmTolerance(ProductIonMassTolerance);
 
-            var specificMass = new Ms2ScanWithSpecificMass(ms2Scan, psmToRematch.PrecursorMz,
-                psmToRematch.PrecursorCharge, psmToRematch.FileNameWithoutExtension, commonParams);
+            var specificMass = new Ms2ScanWithSpecificMass(ms2Scan, smToRematch.PrecursorMz,
+                smToRematch.PrecursorCharge, smToRematch.FileNameWithoutExtension, commonParams);
 
             return MetaMorpheusEngine.MatchFragmentIons(specificMass, allProducts, commonParams, false)
-                .Union(psmToRematch.MatchedIons.Where(p => _productsToUse.Contains(p.NeutralTheoreticalProduct.ProductType)))
+                .Union(smToRematch.MatchedIons.Where(p => _productsToUse.Contains(p.NeutralTheoreticalProduct.ProductType)))
                 .ToList();
         }
     }

--- a/MetaMorpheus/GuiFunctions/MetaDraw/FragmentResearching/FragmentationReanalysisViewModel.cs
+++ b/MetaMorpheus/GuiFunctions/MetaDraw/FragmentResearching/FragmentationReanalysisViewModel.cs
@@ -12,6 +12,7 @@ using MzLibUtil;
 using Omics;
 using Omics.Fragmentation;
 using Proteomics.ProteolyticDigestion;
+using Readers;
 
 namespace GuiFunctions
 {
@@ -198,14 +199,12 @@ namespace GuiFunctions
             PossibleProducts.ForEach(product => product.Use = dissociationTypeProducts.Contains(product.ProductType));
         }
 
-        public List<MatchedFragmentIon> MatchIonsWithNewTypes(MsDataScan ms2Scan, PsmFromTsv psmToRematch)
+        public List<MatchedFragmentIon> MatchIonsWithNewTypes(MsDataScan ms2Scan, SpectrumMatchFromTsv psmToRematch)
         {
             if (psmToRematch.FullSequence.Contains('|'))
                 return psmToRematch.MatchedIons;
 
-            IBioPolymerWithSetMods bioPolymer = /*_isProtein ? */
-                new PeptideWithSetModifications(psmToRematch.FullSequence, GlobalVariables.AllModsKnownDictionary);
-            /*: new OligoWithSetMods(psmToRematch.FullSequence, GlobalVariables.AllRNAModsKnownDictionary);*/
+            IBioPolymerWithSetMods bioPolymer = psmToRematch.ToBioPolymerWithSetMods();
 
             List<Product> terminalProducts = new List<Product>();
             Omics.Fragmentation.Peptide.DissociationTypeCollection.ProductsFromDissociationType[DissociationType.Custom] = _productsToUse.ToList(); 

--- a/MetaMorpheus/GuiFunctions/MetaDraw/MetaDrawSettings.cs
+++ b/MetaMorpheus/GuiFunctions/MetaDraw/MetaDrawSettings.cs
@@ -116,15 +116,15 @@ namespace GuiFunctions
             InitializeDictionaries();
         }
 
-        public static bool FilterAcceptsPsm(PsmFromTsv psm)
+        public static bool FilterAcceptsPsm(SpectrumMatchFromTsv sm)
         {
-            if (psm.QValue <= QValueFilter
-                 && (psm.QValueNotch == null || psm.QValueNotch <= QValueFilter)
-                 && (psm.DecoyContamTarget == "T" || (psm.DecoyContamTarget == "D" && ShowDecoys) || (psm.DecoyContamTarget == "C" && ShowContaminants))
-                 && (psm.GlycanLocalizationLevel == null || psm.GlycanLocalizationLevel >= LocalizationLevelStart && psm.GlycanLocalizationLevel <= LocalizationLevelEnd))
+            if (sm.QValue <= QValueFilter
+                 && (sm.QValueNotch == null || sm.QValueNotch <= QValueFilter)
+                 && (sm.DecoyContamTarget == "T" || (sm.DecoyContamTarget == "D" && ShowDecoys) || (sm.DecoyContamTarget == "C" && ShowContaminants))
+                 && (!sm.IsCrossLinkedPeptide() || (sm is PsmFromTsv { BetaPeptideBaseSequence: not null } psm && (!psm.GlycanLocalizationLevel.HasValue || psm.GlycanLocalizationLevel.Value >= LocalizationLevelStart && psm.GlycanLocalizationLevel.Value <= LocalizationLevelEnd))))
             {
                 // Ambiguity filtering conditionals, should only be hit if Ambiguity Filtering is selected
-                if (AmbiguityFilter == "No Filter" || psm.AmbiguityLevel == AmbiguityFilter)
+                if (AmbiguityFilter == "No Filter" || sm.AmbiguityLevel == AmbiguityFilter)
                 {
                     return true;
                 }
@@ -320,6 +320,15 @@ namespace GuiFunctions
             ProductTypeToColor[ProductType.zDot] = OxyColors.Orange;
             ProductTypeToColor[ProductType.D] = OxyColors.DodgerBlue;
             ProductTypeToColor[ProductType.M] = OxyColors.Firebrick;
+
+            // default color of each fragment to annotate
+            BetaProductTypeToColor = ((ProductType[])Enum.GetValues(typeof(ProductType))).ToDictionary(p => p, p => OxyColors.Aqua);
+            BetaProductTypeToColor[ProductType.b] = OxyColors.LightBlue;
+            BetaProductTypeToColor[ProductType.y] = OxyColors.OrangeRed;
+            BetaProductTypeToColor[ProductType.zDot] = OxyColors.LightGoldenrodYellow;
+            BetaProductTypeToColor[ProductType.c] = OxyColors.Orange;
+            BetaProductTypeToColor[ProductType.D] = OxyColors.AliceBlue;
+            BetaProductTypeToColor[ProductType.M] = OxyColors.LightCoral;
         }
 
         /// <summary>

--- a/MetaMorpheus/GuiFunctions/MetaDraw/PlotModelStat.cs
+++ b/MetaMorpheus/GuiFunctions/MetaDraw/PlotModelStat.cs
@@ -11,6 +11,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
 using System.Globalization;
+using Readers;
 using ThermoFisher.CommonCore.Data.Business;
 
 namespace GuiFunctions
@@ -18,8 +19,8 @@ namespace GuiFunctions
     public class PlotModelStat : INotifyPropertyChanged, IPlotModel
     {
         private PlotModel privateModel;
-        private readonly ObservableCollection<PsmFromTsv> allPsms;
-        private readonly Dictionary<string, ObservableCollection<PsmFromTsv>> psmsBySourceFile;
+        private readonly ObservableCollection<SpectrumMatchFromTsv> allPsms;
+        private readonly Dictionary<string, ObservableCollection<SpectrumMatchFromTsv>> psmsBySourceFile;
 
         public static List<string> PlotNames = new List<string> {
             "Histogram of Precursor PPM Errors (around 0 Da mass-difference notch only)",
@@ -78,7 +79,7 @@ namespace GuiFunctions
             }
         }
 
-        public PlotModelStat(string plotName, ObservableCollection<PsmFromTsv> psms, Dictionary<string, ObservableCollection<PsmFromTsv>> psmsBySourceFile)
+        public PlotModelStat(string plotName, ObservableCollection<SpectrumMatchFromTsv> psms, Dictionary<string, ObservableCollection<SpectrumMatchFromTsv>> psmsBySourceFile)
         {
             privateModel = new PlotModel { Title = plotName, DefaultFontSize = 14 };
             allPsms = psms;

--- a/MetaMorpheus/GuiFunctions/MetaDraw/PlotModelStat.cs
+++ b/MetaMorpheus/GuiFunctions/MetaDraw/PlotModelStat.cs
@@ -19,7 +19,7 @@ namespace GuiFunctions
     public class PlotModelStat : INotifyPropertyChanged, IPlotModel
     {
         private PlotModel privateModel;
-        private readonly ObservableCollection<SpectrumMatchFromTsv> allPsms;
+        private readonly ObservableCollection<SpectrumMatchFromTsv> allSpectralMatches;
         private readonly Dictionary<string, ObservableCollection<SpectrumMatchFromTsv>> psmsBySourceFile;
 
         public static List<string> PlotNames = new List<string> {
@@ -79,11 +79,11 @@ namespace GuiFunctions
             }
         }
 
-        public PlotModelStat(string plotName, ObservableCollection<SpectrumMatchFromTsv> psms, Dictionary<string, ObservableCollection<SpectrumMatchFromTsv>> psmsBySourceFile)
+        public PlotModelStat(string plotName, ObservableCollection<SpectrumMatchFromTsv> sms, Dictionary<string, ObservableCollection<SpectrumMatchFromTsv>> smsBySourceFile)
         {
             privateModel = new PlotModel { Title = plotName, DefaultFontSize = 14 };
-            allPsms = psms;
-            this.psmsBySourceFile = psmsBySourceFile;
+            allSpectralMatches = sms;
+            this.psmsBySourceFile = smsBySourceFile;
             createPlot(plotName);
             privateModel.DefaultColors = columnColors;
         }
@@ -340,8 +340,8 @@ namespace GuiFunctions
             };
             List<Tuple<double, double, string>> xy = new List<Tuple<double, double, string>>();
             List<Tuple<double, double, string>> variantxy = new List<Tuple<double, double, string>>();
-            var filteredList = allPsms.Where(p => !p.MassDiffDa.Contains("|") && Math.Round(double.Parse(p.MassDiffDa, CultureInfo.InvariantCulture), 0) == 0).ToList();
-            var test = allPsms.SelectMany(p => p.MatchedIons.Select(v => v.MassErrorPpm));
+            var filteredList = allSpectralMatches.Where(p => !p.MassDiffDa.Contains("|") && Math.Round(double.Parse(p.MassDiffDa, CultureInfo.InvariantCulture), 0) == 0).ToList();
+            var test = allSpectralMatches.SelectMany(p => p.MatchedIons.Select(v => v.MassErrorPpm));
             switch (plotType)
             {
                 case 1: // Precursor PPM Error vs. RT
@@ -363,7 +363,7 @@ namespace GuiFunctions
                     yAxisTitle = "Predicted Hydrophobicity";
                     xAxisTitle = "Observed retention time";
                     SSRCalc3 sSRCalc3 = new SSRCalc3("A100", SSRCalc3.Column.A100);
-                    foreach (var psm in allPsms)
+                    foreach (var psm in allSpectralMatches)
                     {
                         if (psm.IdentifiedSequenceVariations == null || psm.IdentifiedSequenceVariations.Equals(""))
                         {

--- a/MetaMorpheus/GuiFunctions/MetaDraw/SpectrumMatch/ChimeraSpectrumMatchPlot.cs
+++ b/MetaMorpheus/GuiFunctions/MetaDraw/SpectrumMatch/ChimeraSpectrumMatchPlot.cs
@@ -18,6 +18,7 @@ using LinearAxis = OxyPlot.Axes.LinearAxis;
 using LineSeries = OxyPlot.Series.LineSeries;
 using Plot = mzPlot.Plot;
 using TextAnnotation = OxyPlot.Annotations.TextAnnotation;
+using Readers;
 
 namespace GuiFunctions
 {
@@ -31,10 +32,10 @@ namespace GuiFunctions
             get => new Queue<OxyColor>(overflowColors.ToList());
         }
 
-        public List<PsmFromTsv> SpectrumMatches { get; private set; }
-        public Dictionary<string, List<PsmFromTsv>> PsmsByProteinDictionary { get; private set; }
+        public List<SpectrumMatchFromTsv> SpectrumMatches { get; private set; }
+        public Dictionary<string, List<SpectrumMatchFromTsv>> PsmsByProteinDictionary { get; private set; }
 
-        public ChimeraSpectrumMatchPlot(PlotView plotView, MsDataScan scan, List<PsmFromTsv> psms) : base(plotView, null, scan)
+        public ChimeraSpectrumMatchPlot(PlotView plotView, MsDataScan scan, List<SpectrumMatchFromTsv> psms) : base(plotView, null, scan)
         {
             SpectrumMatches = psms;
             PsmsByProteinDictionary = SpectrumMatches.GroupBy(p => p.BaseSeq).ToDictionary(p => p.Key, p => p.ToList());
@@ -64,7 +65,8 @@ namespace GuiFunctions
                 {
                     proteinMatchedIons.AddRange(proteinGroup[j].MatchedIons);
                     allMatchedIons.AddRange(proteinGroup[j].MatchedIons);
-                    PeptideWithSetModifications pepWithSetMods = new(proteinGroup[j].FullSequence.Split('|')[0], GlobalVariables.AllModsKnownDictionary);
+                    var bioPolymerWithSetMods = proteinGroup.First()
+                        .ToBioPolymerWithSetMods(proteinGroup[j].FullSequence.Split('|')[0]);
 
                     // more proteins than protein programmed colors
                     if (proteinIndex >= ColorByProteinDictionary.Keys.Count)

--- a/MetaMorpheus/GuiFunctions/MetaDraw/SpectrumMatch/ChimeraSpectrumMatchPlot.cs
+++ b/MetaMorpheus/GuiFunctions/MetaDraw/SpectrumMatch/ChimeraSpectrumMatchPlot.cs
@@ -35,11 +35,11 @@ namespace GuiFunctions
         public List<SpectrumMatchFromTsv> SpectrumMatches { get; private set; }
         public Dictionary<string, List<SpectrumMatchFromTsv>> PsmsByProteinDictionary { get; private set; }
 
-        public ChimeraSpectrumMatchPlot(PlotView plotView, MsDataScan scan, List<SpectrumMatchFromTsv> psms) : base(plotView, null, scan)
+        public ChimeraSpectrumMatchPlot(PlotView plotView, MsDataScan scan, List<SpectrumMatchFromTsv> sms) : base(plotView, null, scan)
         {
-            SpectrumMatches = psms;
+            SpectrumMatches = sms;
             PsmsByProteinDictionary = SpectrumMatches.GroupBy(p => p.BaseSeq).ToDictionary(p => p.Key, p => p.ToList());
-            psms.Select(p => p.MatchedIons).ForEach(p => matchedFragmentIons.AddRange(p));
+            sms.Select(p => p.MatchedIons).ForEach(p => matchedFragmentIons.AddRange(p));
             
             AnnotateMatchedIons();
             ZoomAxes();

--- a/MetaMorpheus/GuiFunctions/MetaDraw/SpectrumMatch/PeptideSpectrumMatchPlot.cs
+++ b/MetaMorpheus/GuiFunctions/MetaDraw/SpectrumMatch/PeptideSpectrumMatchPlot.cs
@@ -18,9 +18,9 @@ namespace GuiFunctions
     /// </summary>
     public class PeptideSpectrumMatchPlot : SpectrumMatchPlot
     {
-        public PeptideSpectrumMatchPlot(OxyPlot.Wpf.PlotView plotView, SpectrumMatchFromTsv psm, MsDataScan scan,
+        public PeptideSpectrumMatchPlot(OxyPlot.Wpf.PlotView plotView, SpectrumMatchFromTsv sm, MsDataScan scan,
             List<MatchedFragmentIon> matchedFragmentIons, bool annotateProperties = true, LibrarySpectrum librarySpectrum = null, bool stationarySequence = false)
-            : base(plotView, psm, scan, matchedFragmentIons)
+            : base(plotView, sm, scan, matchedFragmentIons)
         {
             if (annotateProperties)
             {

--- a/MetaMorpheus/GuiFunctions/MetaDraw/SpectrumMatch/PeptideSpectrumMatchPlot.cs
+++ b/MetaMorpheus/GuiFunctions/MetaDraw/SpectrumMatch/PeptideSpectrumMatchPlot.cs
@@ -9,6 +9,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using Omics.Fragmentation;
 using Omics.SpectrumMatch;
+using Readers;
 
 namespace GuiFunctions
 {
@@ -17,7 +18,7 @@ namespace GuiFunctions
     /// </summary>
     public class PeptideSpectrumMatchPlot : SpectrumMatchPlot
     {
-        public PeptideSpectrumMatchPlot(OxyPlot.Wpf.PlotView plotView, PsmFromTsv psm, MsDataScan scan,
+        public PeptideSpectrumMatchPlot(OxyPlot.Wpf.PlotView plotView, SpectrumMatchFromTsv psm, MsDataScan scan,
             List<MatchedFragmentIon> matchedFragmentIons, bool annotateProperties = true, LibrarySpectrum librarySpectrum = null, bool stationarySequence = false)
             : base(plotView, psm, scan, matchedFragmentIons)
         {

--- a/MetaMorpheus/GuiFunctions/MetaDraw/SpectrumMatch/SpectrumMatchPlot.cs
+++ b/MetaMorpheus/GuiFunctions/MetaDraw/SpectrumMatch/SpectrumMatchPlot.cs
@@ -441,7 +441,7 @@ namespace GuiFunctions
                     libraryIon.NeutralTheoreticalProduct.Terminus,
                     libraryIon.NeutralTheoreticalProduct.NeutralMass,
                     libraryIon.NeutralTheoreticalProduct.FragmentNumber,
-                    libraryIon.NeutralTheoreticalProduct.AminoAcidPosition,
+                    libraryIon.NeutralTheoreticalProduct.ResiduePosition,
                     libraryIon.NeutralTheoreticalProduct.NeutralLoss);
 
                 mirroredLibraryIons.Add(new MatchedFragmentIon(neutralProduct, libraryIon.Mz,

--- a/MetaMorpheus/GuiFunctions/MetaDraw/SpectrumMatch/SpectrumMatchPlot.cs
+++ b/MetaMorpheus/GuiFunctions/MetaDraw/SpectrumMatch/SpectrumMatchPlot.cs
@@ -36,10 +36,10 @@ namespace GuiFunctions
         /// Matched fragment ions should only be passed in for glyco parent/child scan
         /// </summary>
         /// <param name="plotView">Where the plot is going</param>
-        /// <param name="psm">psm to plot</param>
+        /// <param name="sm">sm to plot</param>
         /// <param name="scan">spectrum to plot</param>
         /// <param name="matchedIons">glyco ONLY child matched ions</param>
-        public SpectrumMatchPlot(OxyPlot.Wpf.PlotView plotView, SpectrumMatchFromTsv psm,
+        public SpectrumMatchPlot(OxyPlot.Wpf.PlotView plotView, SpectrumMatchFromTsv sm,
             MsDataScan scan, List<MatchedFragmentIon> matchedIons = null) : base(plotView)
         {
             Model.Title = string.Empty;
@@ -48,15 +48,15 @@ namespace GuiFunctions
             matchedFragmentIons = new();
 
             DrawSpectrum();
-            if (matchedIons is null && psm is not null)
+            if (matchedIons is null && sm is not null)
             {
-                SpectrumMatch = psm;
+                SpectrumMatch = sm;
                 matchedFragmentIons = SpectrumMatch.MatchedIons;
                 AnnotateMatchedIons(isBetaPeptide: false, matchedFragmentIons);
             }
-            else if (matchedIons is not null && psm is not null)
+            else if (matchedIons is not null && sm is not null)
             {
-                SpectrumMatch = psm;
+                SpectrumMatch = sm;
                 matchedFragmentIons = matchedIons;
                 AnnotateMatchedIons(false, matchedIons);
             }

--- a/MetaMorpheus/GuiFunctions/MetaDraw/SpectrumMatch/SpectrumMatchPlot.cs
+++ b/MetaMorpheus/GuiFunctions/MetaDraw/SpectrumMatch/SpectrumMatchPlot.cs
@@ -18,6 +18,7 @@ using OxyPlot;
 using OxyPlot.Annotations;
 using OxyPlot.Axes;
 using OxyPlot.Series;
+using Readers;
 using FontWeights = OxyPlot.FontWeights;
 using HorizontalAlignment = OxyPlot.HorizontalAlignment;
 using VerticalAlignment = OxyPlot.VerticalAlignment;
@@ -28,7 +29,7 @@ namespace GuiFunctions
     {
         protected List<MatchedFragmentIon> matchedFragmentIons;
         public MsDataScan Scan { get; protected set; }
-        public PsmFromTsv SpectrumMatch { get; set; }
+        public SpectrumMatchFromTsv SpectrumMatch { get; set; }
 
         /// <summary>
         /// Base Spectrum match constructor
@@ -38,7 +39,7 @@ namespace GuiFunctions
         /// <param name="psm">psm to plot</param>
         /// <param name="scan">spectrum to plot</param>
         /// <param name="matchedIons">glyco ONLY child matched ions</param>
-        public SpectrumMatchPlot(OxyPlot.Wpf.PlotView plotView, PsmFromTsv psm,
+        public SpectrumMatchPlot(OxyPlot.Wpf.PlotView plotView, SpectrumMatchFromTsv psm,
             MsDataScan scan, List<MatchedFragmentIon> matchedIons = null) : base(plotView)
         {
             Model.Title = string.Empty;
@@ -211,7 +212,7 @@ namespace GuiFunctions
 
             // peak annotation
             string prefix = "";
-            if (SpectrumMatch != null && SpectrumMatch.BetaPeptideBaseSequence != null)
+            if (SpectrumMatch.IsCrossLinkedPeptide())
             {
                 if (isBetaPeptide)
                 {
@@ -478,47 +479,47 @@ namespace GuiFunctions
             {
                 text.Append("Theoretical Mass: ");
                 text.Append(
-                    double.TryParse(SpectrumMatch.PeptideMonoMass, NumberStyles.Any, CultureInfo.InvariantCulture,
+                    double.TryParse(SpectrumMatch.MonoisotopicMassString, NumberStyles.Any, CultureInfo.InvariantCulture,
                         out var monoMass)
                         ? monoMass.ToString("F3")
-                        : SpectrumMatch.PeptideMonoMass);
+                        : SpectrumMatch.MonoisotopicMassString);
                 text.Append("\r\n");
             }
 
             if (MetaDrawSettings.SpectrumDescription["Protein Accession: "])
             {
                 text.Append("Protein Accession: ");
-                if (SpectrumMatch.ProteinAccession.Length > 10)
+                if (SpectrumMatch.Accession.Length > 10)
                 {
-                    text.Append("\r\n   " + SpectrumMatch.ProteinAccession);
+                    text.Append("\r\n   " + SpectrumMatch.Accession);
                 }
                 else
-                    text.Append(SpectrumMatch.ProteinAccession);
+                    text.Append(SpectrumMatch.Accession);
 
                 text.Append("\r\n");
             }
 
-            if (SpectrumMatch.ProteinName != null && MetaDrawSettings.SpectrumDescription["Protein: "])
+            if (SpectrumMatch.Name != null && MetaDrawSettings.SpectrumDescription["Protein: "])
             {
                 text.Append("Protein: ");
-                if (SpectrumMatch.ProteinName.Length > 20)
+                if (SpectrumMatch.Name.Length > 20)
                 {
-                    text.Append(SpectrumMatch.ProteinName.Substring(0, 20));
-                    int length = SpectrumMatch.ProteinName.Length;
+                    text.Append(SpectrumMatch.Name.Substring(0, 20));
+                    int length = SpectrumMatch.Name.Length;
                     int remaining = length - 20;
-                    for (int i = 20; i < SpectrumMatch.ProteinName.Length; i += 26)
+                    for (int i = 20; i < SpectrumMatch.Name.Length; i += 26)
                     {
                         if (remaining <= 26)
-                            text.Append("\r\n   " + SpectrumMatch.ProteinName.Substring(i, remaining - 1));
+                            text.Append("\r\n   " + SpectrumMatch.Name.Substring(i, remaining - 1));
                         else
                         {
-                            text.Append("\r\n   " + SpectrumMatch.ProteinName.Substring(i, 26));
+                            text.Append("\r\n   " + SpectrumMatch.Name.Substring(i, 26));
                             remaining -= 26;
                         }
                     }
                 }
                 else
-                    text.Append(SpectrumMatch.ProteinName);
+                    text.Append(SpectrumMatch.Name);
 
                 text.Append("\r\n");
             }

--- a/MetaMorpheus/GuiFunctions/MzLibExtensions.cs
+++ b/MetaMorpheus/GuiFunctions/MzLibExtensions.cs
@@ -1,11 +1,9 @@
 ﻿using System;
 using EngineLayer;
-using System.Collections.Generic;
 using MassSpectrometry;
 using Omics;
 using Proteomics.ProteolyticDigestion;
 using Readers;
-using Transcriptomics.Digestion;
 
 namespace GuiFunctions
 {
@@ -46,8 +44,8 @@ namespace GuiFunctions
 
         public static bool IsPeptide(this SpectrumMatchFromTsv sm)
         {
-            if (sm is OsmFromTsv)
-                return false;
+            //if (sm is OsmFromTsv)
+            //    return false;
             return true;
         }
 
@@ -61,19 +59,10 @@ namespace GuiFunctions
 
         public static SpectrumMatchFromTsv ReplaceFullSequence(this SpectrumMatchFromTsv sm, string fullSequence, string baseSequence = "")
         {
-            if (sm.IsPeptide())
+            //if (sm.IsPeptide())
                 return new PsmFromTsv(sm as PsmFromTsv, fullSequence, baseSequence: baseSequence);
-            else
-                return new OsmFromTsv(sm as OsmFromTsv, fullSequence, baseSequence: baseSequence);
-        }
-
-        public static IEnumerable<(int Start, int End)> GetStartAndEndPosition(this SpectrumMatchFromTsv sm)
-        {
-            foreach (var ambigSplit in sm.StartAndEndResiduesInParentSequence.Split('|'))
-            {
-                var split = ambigSplit.Replace("[", "").Replace("]", "").Split("to");
-                yield return (int.Parse(split[0]), int.Parse(split[1]));
-            }
+            //else
+            //    return new OsmFromTsv(sm as OsmFromTsv, fullSequence, baseSequence: baseSequence);
         }
     }
 }

--- a/MetaMorpheus/GuiFunctions/ViewModels/Legends/ChimeraLegendViewModel.cs
+++ b/MetaMorpheus/GuiFunctions/ViewModels/Legends/ChimeraLegendViewModel.cs
@@ -8,9 +8,11 @@ using System.Threading.Tasks;
 using System.Windows;
 using EngineLayer;
 using GuiFunctions.ViewModels.Legends;
+using Omics;
 using OxyPlot;
 using Proteomics;
 using Proteomics.ProteolyticDigestion;
+using Readers;
 
 namespace GuiFunctions
 {
@@ -43,7 +45,7 @@ namespace GuiFunctions
 
         #endregion
 
-        public ChimeraLegendViewModel(List<PsmFromTsv> chimericIDs, double offset = 0) : base()
+        public ChimeraLegendViewModel(List<SpectrumMatchFromTsv> chimericIDs, double offset = 0) : base()
         {
             TopOffset = offset;
             ChimeraLegendItems = new();
@@ -54,7 +56,7 @@ namespace GuiFunctions
         /// Populates legend items dictionary from a list of PsmTsv
         /// </summary>
         /// <param name="chimericIDs"></param>
-        public void ParseLegendItemsFromPsms(List<PsmFromTsv> chimericIDs)
+        public void ParseLegendItemsFromPsms(List<SpectrumMatchFromTsv> chimericIDs)
         {
             var groupedByProtein = chimericIDs.GroupBy(p => p.BaseSeq).OrderByDescending(p => p.Count());
 
@@ -86,10 +88,9 @@ namespace GuiFunctions
                         color = ChimeraSpectrumMatchPlot.ColorByProteinDictionary[proteinIndex][i + 1];
                     }
 
-                    PeptideWithSetModifications peptideWithSetMods =
-                        new(protein.ToList()[i].FullSequence.Split("|")[0], GlobalVariables.AllModsKnownDictionary);
+                    IBioPolymerWithSetMods bioPolymerWithSetMods = protein.ElementAt(i).ToBioPolymerWithSetMods(protein.ElementAt(i).FullSequence.Split("|")[0]);
                     var modsString = String.Join(", ",
-                        peptideWithSetMods.AllModsOneIsNterminus.Select(p => p.Key + " - " + p.Value.IdWithMotif));
+                        bioPolymerWithSetMods.AllModsOneIsNterminus.Select(p => p.Key + " - " + p.Value.IdWithMotif));
                     ChimeraLegendItems[protein.Key].Add(new(modsString, color));
                 }
                 proteinIndex++;

--- a/MetaMorpheus/GuiFunctions/ViewModels/Legends/PtmLegendViewModel.cs
+++ b/MetaMorpheus/GuiFunctions/ViewModels/Legends/PtmLegendViewModel.cs
@@ -10,6 +10,8 @@ using System.Windows;
 using EngineLayer;
 using Omics.Modifications;
 using Proteomics.ProteolyticDigestion;
+using Readers;
+using Omics;
 
 namespace GuiFunctions
 {
@@ -49,7 +51,7 @@ namespace GuiFunctions
 
         #region Constructor
 
-        public PtmLegendViewModel(PsmFromTsv psm, double offset = 0) : base()
+        public PtmLegendViewModel(SpectrumMatchFromTsv psm, double offset = 0) : base()
         {
             ParseModsFromPsmTsv(psm);
             TopOffset = offset;
@@ -100,10 +102,10 @@ namespace GuiFunctions
 
         #endregion
 
-        private void ParseModsFromPsmTsv(PsmFromTsv psm)
+        private void ParseModsFromPsmTsv(SpectrumMatchFromTsv psm)
         {
-            PeptideWithSetModifications peptide = new(psm.FullSequence, GlobalVariables.AllModsKnownDictionary);
-            List<Modification> mods = peptide.AllModsOneIsNterminus.Values.ToList();
+            IBioPolymerWithSetMods bioPolymerWithSetMods = psm.ToBioPolymerWithSetMods();
+            List<Modification> mods = bioPolymerWithSetMods.AllModsOneIsNterminus.Values.ToList();
             foreach (var mod in mods.Distinct())
             {
                 var modItem = new PtmLegendItemViewModel(mod.IdWithMotif);

--- a/MetaMorpheus/Test/MetaDraw/MetaDrawSettingsAndViewsTest.cs
+++ b/MetaMorpheus/Test/MetaDraw/MetaDrawSettingsAndViewsTest.cs
@@ -527,9 +527,9 @@ namespace Test.MetaDraw
             // object setup
             string psmsPath = Path.Combine(TestContext.CurrentContext.TestDirectory,
                 @"TopDownTestData\TDGPTMDSearchResults.psmtsv");
-            List<PsmFromTsv> psms = SpectrumMatchTsvReader.ReadPsmTsv(psmsPath, out List<string> warnings);
+            List<SpectrumMatchFromTsv> psms = SpectrumMatchTsvReader.ReadTsv(psmsPath, out List<string> warnings);
             Assert.That(warnings.Count, Is.EqualTo(0));
-            List<PsmFromTsv> filteredChimeras =
+            List<SpectrumMatchFromTsv> filteredChimeras =
                 psms.Where(p => p.QValue <= 0.01 && p.PEP <= 0.5 && p.PrecursorScanNum == 1557).ToList();
             Assert.That(filteredChimeras.Count, Is.EqualTo(3));
 
@@ -544,7 +544,7 @@ namespace Test.MetaDraw
 
             // test chimera legend overflow colors
             // more unique proteins than colored
-            List<PsmFromTsv> overflowInducingProteins = psms.DistinctBy(p => p.BaseSeq)
+            List<SpectrumMatchFromTsv> overflowInducingProteins = psms.DistinctBy(p => p.BaseSeq)
                 .Take(ChimeraSpectrumMatchPlot.ColorByProteinDictionary.Keys.Count + 1).ToList();
             chimeraLegend = new(overflowInducingProteins);
             Assert.That(chimeraLegend.ChimeraLegendItems.Values.DistinctBy(p =>
@@ -557,7 +557,7 @@ namespace Test.MetaDraw
             // more unique proteoforms than colored
             overflowInducingProteins = psms
                 .Take(ChimeraSpectrumMatchPlot.ColorByProteinDictionary.First().Value.Count)
-                .Select(p => p = new(p, overflowInducingProteins.First().FullSequence, 0,
+                .Select(p => p = new PsmFromTsv(p as PsmFromTsv, overflowInducingProteins.First().FullSequence, 0,
                     overflowInducingProteins.First().BaseSeq)).ToList();
             Assert.That(overflowInducingProteins.All(p => p.BaseSeq == overflowInducingProteins.First().BaseSeq));
             Assert.That(overflowInducingProteins.All(p =>
@@ -579,7 +579,7 @@ namespace Test.MetaDraw
             chimeraLegendItem = new(null, OxyColors.Chocolate);
             Assert.That(chimeraLegendItem.Name == "No Modifications");
 
-            chimeraLegend = new ChimeraLegendViewModel(new List<PsmFromTsv>() { psms.First() });
+            chimeraLegend = new ChimeraLegendViewModel(new List<SpectrumMatchFromTsv>() { psms.First() });
             Assert.That(chimeraLegend.DisplaySharedIonLabel == false);
         }
 

--- a/MetaMorpheus/Test/MetaDraw/MetaDrawTest.cs
+++ b/MetaMorpheus/Test/MetaDraw/MetaDrawTest.cs
@@ -174,7 +174,7 @@ namespace Test.MetaDraw
         public static void MetaDraw_TestStationarySequencePositioning()
         {
             var metadrawLogic = new MetaDrawLogic();
-            metadrawLogic.PsmResultFilePaths.Add(Path.Combine(TestContext.CurrentContext.TestDirectory, @"TopDownTestData\TDGPTMDSearchResults.psmtsv"));
+            metadrawLogic.SpectralMatchResultFilePaths.Add(Path.Combine(TestContext.CurrentContext.TestDirectory, @"TopDownTestData\TDGPTMDSearchResults.psmtsv"));
             metadrawLogic.SpectraFilePaths.Add(Path.Combine(TestContext.CurrentContext.TestDirectory, @"TopDownTestData\TDGPTMDSearchSingleSpectra.mzML"));
             var errors = metadrawLogic.LoadFiles(true, true);
             Assert.That(errors.Count == 1); // Singular error should be from not loading in the rest of the spectra that the search came from
@@ -216,7 +216,7 @@ namespace Test.MetaDraw
 
                 List<MatchedFragmentIon> matchedIons = psm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.AminoAcidPosition > MetaDrawSettings.FirstAAonScreenIndex &&
                                                        p.NeutralTheoreticalProduct.AminoAcidPosition < (MetaDrawSettings.FirstAAonScreenIndex + MetaDrawSettings.NumberOfAAOnScreen)).ToList();
-                int psmStartResidue = int.Parse(psm.StartAndEndResiduesInProtein.Split("to")[0].Replace("[", ""));
+                int psmStartResidue = int.Parse(psm.StartAndEndResiduesInParentSequence.Split("to")[0].Replace("[", ""));
                 var startAA = (MetaDrawSettings.FirstAAonScreenIndex + psmStartResidue).ToString();
                 var endAA = (MetaDrawSettings.FirstAAonScreenIndex + MetaDrawSettings.NumberOfAAOnScreen + psmStartResidue - 1).ToString();
 
@@ -244,7 +244,7 @@ namespace Test.MetaDraw
             // load results into metadraw
             var metadrawLogic = new MetaDrawLogic();
             metadrawLogic.SpectraFilePaths.Add(spectraFile);
-            metadrawLogic.PsmResultFilePaths.Add(psmFile);
+            metadrawLogic.SpectralMatchResultFilePaths.Add(psmFile);
             var errors = metadrawLogic.LoadFiles(true, true);
 
             Assert.That(!errors.Any());
@@ -393,7 +393,7 @@ namespace Test.MetaDraw
             List<MatchedFragmentIon> matchedIons = psm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.AminoAcidPosition > MetaDrawSettings.FirstAAonScreenIndex &&
                                                    p.NeutralTheoreticalProduct.AminoAcidPosition < (MetaDrawSettings.FirstAAonScreenIndex + MetaDrawSettings.NumberOfAAOnScreen)).ToList();
             Assert.That(metadrawLogic.StationarySequence.SequenceDrawingCanvas.Children.Count == modifiedBaseSeq.Length + matchedIons.Count + fullSequence.Count(p => p == '[') + 
-                psm.StartAndEndResiduesInProtein.Replace("[","").Replace("]","").Replace("to", "").Replace(" ", "").Length + 2);
+                psm.StartAndEndResiduesInParentSequence.Replace("[","").Replace("]","").Replace("to", "").Replace(" ", "").Length + 2);
 
             // write pdf
             var psmsToExport = metadrawLogic.FilteredListOfPsms.Where(p => p.FullSequence == "QIVHDSGR").Take(3).ToList();
@@ -435,7 +435,7 @@ namespace Test.MetaDraw
             matchedIons = modPsm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.AminoAcidPosition > MetaDrawSettings.FirstAAonScreenIndex &&
                                                 p.NeutralTheoreticalProduct.AminoAcidPosition < (MetaDrawSettings.FirstAAonScreenIndex + MetaDrawSettings.NumberOfAAOnScreen)).ToList();
             Assert.That(metadrawLogic.StationarySequence.SequenceDrawingCanvas.Children.Count == modifiedBaseSeq.Length + matchedIons.Count + fullSequence.Count(p => p == '[') + 
-                psm.StartAndEndResiduesInProtein.Replace("[", "").Replace("]", "").Replace("to", "").Replace(" ", "").Length + 2);
+                psm.StartAndEndResiduesInParentSequence.Replace("[", "").Replace("]", "").Replace("to", "").Replace(" ", "").Length + 2);
 
 
             // get scan from psm
@@ -446,7 +446,7 @@ namespace Test.MetaDraw
             // clean up resources
             metadrawLogic.CleanUpResources();
             Assert.That(!metadrawLogic.FilteredListOfPsms.Any());
-            Assert.That(!metadrawLogic.PsmResultFilePaths.Any());
+            Assert.That(!metadrawLogic.SpectralMatchResultFilePaths.Any());
             Assert.That(!metadrawLogic.SpectraFilePaths.Any());
 
             // delete output
@@ -474,7 +474,7 @@ namespace Test.MetaDraw
             // load results into metadraw
             var metadrawLogic = new MetaDrawLogic();
             metadrawLogic.SpectraFilePaths.Add(spectraFile);
-            metadrawLogic.PsmResultFilePaths.Add(csmFile);
+            metadrawLogic.SpectralMatchResultFilePaths.Add(csmFile);
             var errors = metadrawLogic.LoadFiles(true, true);
 
             Assert.That(!errors.Any());
@@ -562,7 +562,7 @@ namespace Test.MetaDraw
             Assert.That(childPlot.SpectrumLabel == "Scan: 3 Dissociation Type: ETD MsOrder: 2 Selected Mz: 492.02 RetentionTime: 23.9");
             Assert.That(childPlot.TheCanvas.Children.Count > 0);
             numAnnotatedResidues = csm.BaseSeq.Length;
-            numAnnotatedIons = csm.ChildScanMatchedIons[3].Concat(csm.BetaPeptideChildScanMatchedIons[3])
+            numAnnotatedIons = csm.ChildScanMatchedIons[3].Concat((csm as PsmFromTsv).BetaPeptideChildScanMatchedIons[3])
                 .Count(p => p.NeutralTheoreticalProduct.ProductType != ProductType.M);
             numAnnotatedMods = csm.FullSequence.Count(p => p == '[');
             Assert.That(childPlot.TheCanvas.Children.Count == numAnnotatedResidues + numAnnotatedIons + numAnnotatedMods);
@@ -595,7 +595,7 @@ namespace Test.MetaDraw
             // clean up resources
             metadrawLogic.CleanUpResources();
             Assert.That(!metadrawLogic.FilteredListOfPsms.Any());
-            Assert.That(!metadrawLogic.PsmResultFilePaths.Any());
+            Assert.That(!metadrawLogic.SpectralMatchResultFilePaths.Any());
             Assert.That(!metadrawLogic.SpectraFilePaths.Any());
 
             // delete output
@@ -628,7 +628,7 @@ namespace Test.MetaDraw
             // load results into metadraw
             var metadrawLogic = new MetaDrawLogic();
             metadrawLogic.SpectraFilePaths.Add(spectraFile);
-            metadrawLogic.PsmResultFilePaths.Add(psmFile);
+            metadrawLogic.SpectralMatchResultFilePaths.Add(psmFile);
             metadrawLogic.SpectralLibraryPaths.Add(library1);
             var errors = metadrawLogic.LoadFiles(true, true);
 
@@ -662,7 +662,7 @@ namespace Test.MetaDraw
             Assert.That(plotAxes.Count == 2);
 
             // write pdf
-            var psmsToExport = metadrawLogic.FilteredListOfPsms.Where(p => p.UniqueSequence == "LLDNAAADLAAISGQKPLITKAR(21)ITLNMGVGEAIADKK(14)").Take(1).ToList();
+            var psmsToExport = metadrawLogic.FilteredListOfPsms.Where(p => (p as PsmFromTsv).UniqueSequence == "LLDNAAADLAAISGQKPLITKAR(21)ITLNMGVGEAIADKK(14)").Take(1).ToList();
             metadrawLogic.ExportPlot(plotView, canvas, psmsToExport, parentChildView, outputFolder, out errors);
 
 
@@ -682,7 +682,7 @@ namespace Test.MetaDraw
             // clean up resources
             metadrawLogic.CleanUpResources();
             Assert.That(!metadrawLogic.FilteredListOfPsms.Any());
-            Assert.That(!metadrawLogic.PsmResultFilePaths.Any());
+            Assert.That(!metadrawLogic.SpectralMatchResultFilePaths.Any());
             Assert.That(!metadrawLogic.SpectraFilePaths.Any());
             Assert.That(!metadrawLogic.SpectralLibraryPaths.Any());
 
@@ -710,7 +710,7 @@ namespace Test.MetaDraw
             // load results into metadraw
             var metadrawLogic = new MetaDrawLogic();
             metadrawLogic.SpectraFilePaths.Add(spectraFile);
-            metadrawLogic.PsmResultFilePaths.Add(psmFile);
+            metadrawLogic.SpectralMatchResultFilePaths.Add(psmFile);
             var errors = metadrawLogic.LoadFiles(true, true);
 
             Assert.That(!errors.Any());
@@ -843,7 +843,7 @@ namespace Test.MetaDraw
             // clean up resources
             metadrawLogic.CleanUpResources();
             Assert.That(!metadrawLogic.FilteredListOfPsms.Any());
-            Assert.That(!metadrawLogic.PsmResultFilePaths.Any());
+            Assert.That(!metadrawLogic.SpectralMatchResultFilePaths.Any());
             Assert.That(!metadrawLogic.SpectraFilePaths.Any());
 
             // delete output
@@ -871,7 +871,7 @@ namespace Test.MetaDraw
             // load results into metadraw
             var metadrawLogic = new MetaDrawLogic();
             metadrawLogic.SpectraFilePaths.Add(spectraFile);
-            metadrawLogic.PsmResultFilePaths.Add(psmFile);
+            metadrawLogic.SpectralMatchResultFilePaths.Add(psmFile);
             var errors = metadrawLogic.LoadFiles(true, true);
             Assert.That(!errors.Any());
             Assert.That(metadrawLogic.FilteredListOfPsms.Any());
@@ -966,14 +966,14 @@ namespace Test.MetaDraw
             }
 
             // test export of singlular plot
-            List<PsmFromTsv> firstChimeraGroup = metadrawLogic.FilteredListOfPsms
+            List<SpectrumMatchFromTsv> firstChimeraGroup = metadrawLogic.FilteredListOfPsms
                 .GroupBy(p => p.Ms2ScanNumber).First().ToList();
             metadrawLogic.DisplayChimeraSpectra(plotView, firstChimeraGroup, out errors);
             Assert.That(errors == null || !errors.Any());
             foreach (var exportType in MetaDrawSettings.ExportTypes)
             {
                 MetaDrawSettings.ExportType = exportType;
-                metadrawLogic.ExportPlot(plotView, null, new List<PsmFromTsv>() { firstChimeraGroup.First() }, null, outputFolder, out errors);
+                metadrawLogic.ExportPlot(plotView, null, new List<SpectrumMatchFromTsv>() { firstChimeraGroup.First() }, null, outputFolder, out errors);
                 Assert.That(errors == null || !errors.Any());
                 string sequence = illegalInFileName.Replace(firstChimeraGroup.First().FullSequence, string.Empty);
                 string filePathWithoutDirectory = firstChimeraGroup.First().Ms2ScanNumber + "_" 
@@ -989,7 +989,7 @@ namespace Test.MetaDraw
             ptmLegend.Arrange(new Rect(legendSize));
             ptmLegend.UpdateLayout();
             Vector ptmLegendVector = new(10, 10);
-            metadrawLogic.ExportPlot(plotView, null, new List<PsmFromTsv>() { firstChimeraGroup.First() }, null,
+            metadrawLogic.ExportPlot(plotView, null, new List<SpectrumMatchFromTsv>() { firstChimeraGroup.First() }, null,
                 outputFolder, out errors, ptmLegend, ptmLegendVector);
             Assert.That(errors == null || !errors.Any());
             string sequenceSeq = illegalInFileName.Replace(firstChimeraGroup.First().FullSequence, string.Empty);
@@ -999,7 +999,7 @@ namespace Test.MetaDraw
             Assert.That(File.Exists(Path.Combine(outputFolder, fileNameWithoutDirectory)));
 
             // test export of multiple plots
-            List<PsmFromTsv> secondChimeraGroup = metadrawLogic.FilteredListOfPsms
+            List<SpectrumMatchFromTsv> secondChimeraGroup = metadrawLogic.FilteredListOfPsms
                 .GroupBy(p => p.Ms2ScanNumber).ToList()[1].ToList();
             metadrawLogic.DisplayChimeraSpectra(plotView, secondChimeraGroup, out errors);
             Assert.That(errors == null || !errors.Any());
@@ -1044,7 +1044,7 @@ namespace Test.MetaDraw
 
             // load results into metadraw (skipping spectra file, to produce an error msg)
             var metadrawLogic = new MetaDrawLogic();
-            metadrawLogic.PsmResultFilePaths.Add(psmFile);
+            metadrawLogic.SpectralMatchResultFilePaths.Add(psmFile);
 
             // this should produce an error because an expected spectra file is not present
             var errors = metadrawLogic.LoadFiles(loadSpectra: true, loadPsms: true);
@@ -1067,7 +1067,7 @@ namespace Test.MetaDraw
 
             // export to PDF should produce an error because spectra are not loaded
             MetaDrawSettings.NumberOfAAOnScreen = psmsFromTsv.First().BaseSeq.Length - 1;
-            metadrawLogic.ExportPlot(plotView, canvas, new List<PsmFromTsv> { psmsFromTsv.First() }, parentChildScanPlotsView, outputFolder, out errors);
+            metadrawLogic.ExportPlot(plotView, canvas, new List<SpectrumMatchFromTsv> { psmsFromTsv.First() }, parentChildScanPlotsView, outputFolder, out errors);
             Assert.That(errors.Any());
 
             // clean up resources
@@ -1096,7 +1096,7 @@ namespace Test.MetaDraw
 
             // load results into metadraw
             var metadrawLogic = new MetaDrawLogic();
-            metadrawLogic.PsmResultFilePaths.Add(psmFile);
+            metadrawLogic.SpectralMatchResultFilePaths.Add(psmFile);
             metadrawLogic.SpectraFilePaths.Add(spectraFile);
             var errors = metadrawLogic.LoadFiles(true, true);
             Assert.That(!errors.Any());
@@ -1118,7 +1118,7 @@ namespace Test.MetaDraw
             Assert.That(errors == null || !errors.Any());
 
             // export to PDF
-            metadrawLogic.ExportPlot(plotView, canvas, new List<PsmFromTsv> { metadrawLogic.FilteredListOfPsms.First() }, parentChildScanPlotsView, outputFolder, out errors);
+            metadrawLogic.ExportPlot(plotView, canvas, new List<SpectrumMatchFromTsv> { metadrawLogic.FilteredListOfPsms.First() }, parentChildScanPlotsView, outputFolder, out errors);
             Assert.That(!errors.Any());
 
             // clean up resources
@@ -1153,7 +1153,7 @@ namespace Test.MetaDraw
             // load results into metadraw
             var metadrawLogic = new MetaDrawLogic();
             metadrawLogic.SpectraFilePaths.Add(spectraFile);
-            metadrawLogic.PsmResultFilePaths.Add(psmFile);
+            metadrawLogic.SpectralMatchResultFilePaths.Add(psmFile);
             metadrawLogic.SpectralLibraryPaths.Add(library1);
             metadrawLogic.SpectralLibraryPaths.Add(library2);
             var errors = metadrawLogic.LoadFiles(true, true);
@@ -1195,7 +1195,7 @@ namespace Test.MetaDraw
             // clean up resources
             metadrawLogic.CleanUpResources();
             Assert.That(!metadrawLogic.FilteredListOfPsms.Any());
-            Assert.That(!metadrawLogic.PsmResultFilePaths.Any());
+            Assert.That(!metadrawLogic.SpectralMatchResultFilePaths.Any());
             Assert.That(!metadrawLogic.SpectraFilePaths.Any());
             Assert.That(!metadrawLogic.SpectralLibraryPaths.Any());
 
@@ -1226,7 +1226,7 @@ namespace Test.MetaDraw
             // load results into metadraw
             var metadrawLogic = new MetaDrawLogic();
             metadrawLogic.SpectraFilePaths.Add(spectraFile);
-            metadrawLogic.PsmResultFilePaths.Add(psmFile);
+            metadrawLogic.SpectralMatchResultFilePaths.Add(psmFile);
             var errors = metadrawLogic.LoadFiles(true, true);
 
             Assert.That(!errors.Any());
@@ -1271,7 +1271,7 @@ namespace Test.MetaDraw
             string spectraFile = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\InternalTest.mgf");
             string psmFile = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\SequenceCoverageTestPSM.psmtsv");
             metadrawLogic.SpectraFilePaths.Add(spectraFile);
-            metadrawLogic.PsmResultFilePaths.Add(psmFile);
+            metadrawLogic.SpectralMatchResultFilePaths.Add(psmFile);
             var errors = metadrawLogic.LoadFiles(true, true);
 
             Assert.That(!errors.Any());
@@ -1295,7 +1295,7 @@ namespace Test.MetaDraw
             string spectraFile = Path.Combine(TestContext.CurrentContext.TestDirectory, @"XlTestData\ms2mixed_bsa_xlink.mzML");
             string psmFile = Path.Combine(TestContext.CurrentContext.TestDirectory, @"XlTestData\XL_Intralinks_MIons.tsv");
             metadrawLogic.SpectraFilePaths.Add(spectraFile);
-            metadrawLogic.PsmResultFilePaths.Add(psmFile);
+            metadrawLogic.SpectralMatchResultFilePaths.Add(psmFile);
             var errors = metadrawLogic.LoadFiles(true, true);
 
             Assert.That(!errors.Any());
@@ -1338,7 +1338,7 @@ namespace Test.MetaDraw
             // load results into metadraw
             var metadrawLogic = new MetaDrawLogic();
             metadrawLogic.SpectraFilePaths.Add(spectraFile);
-            metadrawLogic.PsmResultFilePaths.Add(psmFile);
+            metadrawLogic.SpectralMatchResultFilePaths.Add(psmFile);
             metadrawLogic.SpectralLibraryPaths.Add(library1);
             metadrawLogic.SpectralLibraryPaths.Add(library2);
             var errors = metadrawLogic.LoadFiles(true, true);
@@ -1383,7 +1383,7 @@ namespace Test.MetaDraw
 
             metadrawLogic.CleanUpPSMFiles();
             Assert.That(!metadrawLogic.FilteredListOfPsms.Any());
-            Assert.That(!metadrawLogic.PsmResultFilePaths.Any());
+            Assert.That(!metadrawLogic.SpectralMatchResultFilePaths.Any());
 
             metadrawLogic.CleanUpSpectralLibraryFiles();
             Assert.That(!metadrawLogic.SpectralLibraryPaths.Any());
@@ -1411,7 +1411,7 @@ namespace Test.MetaDraw
             // load results into metadraw
             var metadrawLogic = new MetaDrawLogic();
             metadrawLogic.SpectraFilePaths.Add(spectraFile);
-            metadrawLogic.PsmResultFilePaths.Add(psmFile);
+            metadrawLogic.SpectralMatchResultFilePaths.Add(psmFile);
             var errors = metadrawLogic.LoadFiles(true, true);
 
             Assert.That(!errors.Any());
@@ -1433,7 +1433,7 @@ namespace Test.MetaDraw
             Assert.That(errors == null || !errors.Any());
 
             // export each file type and ensure they exist
-            var psmsToExport = new List<PsmFromTsv> { metadrawLogic.FilteredListOfPsms.Where(p => p.FullSequence == "QIVHDSGR").First() };
+            var psmsToExport = new List<SpectrumMatchFromTsv> { metadrawLogic.FilteredListOfPsms.Where(p => p.FullSequence == "QIVHDSGR").First() };
             MetaDrawSettings.NumberOfAAOnScreen = psmsToExport.First().BaseSeq.Length;
             metadrawLogic.ExportPlot(plotView, stationaryCanvas, psmsToExport, parentChildView, outputFolder, out errors);
             Assert.That(File.Exists(Path.Combine(outputFolder, @"120_QIVHDSGR.pdf")));
@@ -1485,7 +1485,7 @@ namespace Test.MetaDraw
             Assert.That(!warnings.Any());
 
             MetaDrawLogic metaDrawLogic = new();
-            metaDrawLogic.PsmResultFilePaths.Add(psmsPath);
+            metaDrawLogic.SpectralMatchResultFilePaths.Add(psmsPath);
             var errors = metaDrawLogic.LoadFiles(false, true);
             Assert.That(!errors.Any());
             Assert.That(metaDrawLogic.FilteredListOfPsms.Any());
@@ -1520,7 +1520,7 @@ namespace Test.MetaDraw
             // load results into metadraw
             var metadrawLogic = new MetaDrawLogic();
             metadrawLogic.SpectraFilePaths.Add(spectraFile);
-            metadrawLogic.PsmResultFilePaths.Add(psmFile);
+            metadrawLogic.SpectralMatchResultFilePaths.Add(psmFile);
             var errors = metadrawLogic.LoadFiles(true, true);
 
             Assert.That(!errors.Any());
@@ -1620,11 +1620,11 @@ namespace Test.MetaDraw
             searchTask.RunTask(folderPath, new List<DbForTask> { db }, new List<string> { myFile }, "metadraw");
             string psmFile = Directory.GetFiles(folderPath).First(f => f.Contains("AllPSMs.psmtsv"));
 
-            List<PsmFromTsv> parsedPsms = SpectrumMatchTsvReader.ReadPsmTsv(psmFile, out var warnings);
-            ObservableCollection<PsmFromTsv> psms = new(parsedPsms);
+            List<SpectrumMatchFromTsv> parsedPsms = SpectrumMatchTsvReader.ReadTsv(psmFile, out var warnings);
+            ObservableCollection<SpectrumMatchFromTsv> psms = new(parsedPsms);
 
             var psmDict = parsedPsms.GroupBy(p => p.FileNameWithoutExtension)
-                .ToDictionary(p => p.Key, p => new ObservableCollection<PsmFromTsv>(p));
+                .ToDictionary(p => p.Key, p => new ObservableCollection<SpectrumMatchFromTsv>(p));
 
             // check that fragment mass error was read in correctly
             Assert.That(Math.Round(-0.27631606125063707, 5), Is.EqualTo(Math.Round(psms[1].MatchedIons[1].MassErrorPpm, 5)));
@@ -1714,10 +1714,10 @@ namespace Test.MetaDraw
             List<string> warningsVariants = new List<string>();
             List<PsmFromTsv> parsedPsmsWithVariants;
             parsedPsmsWithVariants = SpectrumMatchTsvReader.ReadPsmTsv(variantFile, out warningsVariants);
-            ObservableCollection<PsmFromTsv> psmsWithVariants = new(parsedPsmsWithVariants);
+            ObservableCollection<SpectrumMatchFromTsv> psmsWithVariants = new(parsedPsmsWithVariants);
 
             var psmVariantDict = psmsWithVariants.GroupBy(p => p.FileNameWithoutExtension)
-                .ToDictionary(p => p.Key, p => new ObservableCollection<PsmFromTsv>(p));
+                .ToDictionary(p => p.Key, p => new ObservableCollection<SpectrumMatchFromTsv>(p));
 
             var variantPlot1 = new PlotModelStat("Precursor PPM Error vs. RT", psmsWithVariants, psmVariantDict);
             var variantSeries1 = variantPlot1.Model.Series.ToList()[0];

--- a/MetaMorpheus/Test/MetaDraw/MetaDrawTest.cs
+++ b/MetaMorpheus/Test/MetaDraw/MetaDrawTest.cs
@@ -214,14 +214,20 @@ namespace Test.MetaDraw
                     fullSequence = fullSequence.Insert(mod.Key - 1 - MetaDrawSettings.FirstAAonScreenIndex, "[" + mod.Value.ModificationType + ":" + mod.Value.IdWithMotif + "]");
                 }
 
-                List<MatchedFragmentIon> matchedIons = psm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.AminoAcidPosition > MetaDrawSettings.FirstAAonScreenIndex &&
-                                                       p.NeutralTheoreticalProduct.AminoAcidPosition < (MetaDrawSettings.FirstAAonScreenIndex + MetaDrawSettings.NumberOfAAOnScreen)).ToList();
+                List<MatchedFragmentIon> matchedIons = psm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.ResiduePosition > MetaDrawSettings.FirstAAonScreenIndex &&
+                                                       p.NeutralTheoreticalProduct.ResiduePosition < (MetaDrawSettings.FirstAAonScreenIndex + MetaDrawSettings.NumberOfAAOnScreen)).ToList();
                 int psmStartResidue = int.Parse(psm.StartAndEndResiduesInParentSequence.Split("to")[0].Replace("[", ""));
                 var startAA = (MetaDrawSettings.FirstAAonScreenIndex + psmStartResidue).ToString();
                 var endAA = (MetaDrawSettings.FirstAAonScreenIndex + MetaDrawSettings.NumberOfAAOnScreen + psmStartResidue - 1).ToString();
 
 
-                var expected = modifiedBaseSeq.Length + matchedIons.Count + fullSequence.Count(p => p == '[') + startAA.Length + endAA.Length + 2;
+                var expectedBaseSequence = modifiedBaseSeq.Length;
+                var expectedIonAnnotations = matchedIons.Count;
+                var expectedModCount = fullSequence.Count(p => p == '[');
+                var expectedNumberCount = startAA.Length + endAA.Length;
+                var expectedNumberLineConnectorCount = 2;
+
+                var expected = expectedBaseSequence + expectedIonAnnotations + expectedModCount + expectedNumberCount + expectedNumberLineConnectorCount;
                 Assert.That(metadrawLogic.StationarySequence.SequenceDrawingCanvas.Children.Count, Is.EqualTo(expected));
             }
         }
@@ -390,8 +396,8 @@ namespace Test.MetaDraw
                     }
                 }
             }
-            List<MatchedFragmentIon> matchedIons = psm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.AminoAcidPosition > MetaDrawSettings.FirstAAonScreenIndex &&
-                                                   p.NeutralTheoreticalProduct.AminoAcidPosition < (MetaDrawSettings.FirstAAonScreenIndex + MetaDrawSettings.NumberOfAAOnScreen)).ToList();
+            List<MatchedFragmentIon> matchedIons = psm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.ResiduePosition > MetaDrawSettings.FirstAAonScreenIndex &&
+                                                   p.NeutralTheoreticalProduct.ResiduePosition < (MetaDrawSettings.FirstAAonScreenIndex + MetaDrawSettings.NumberOfAAOnScreen)).ToList();
             Assert.That(metadrawLogic.StationarySequence.SequenceDrawingCanvas.Children.Count == modifiedBaseSeq.Length + matchedIons.Count + fullSequence.Count(p => p == '[') + 
                 psm.StartAndEndResiduesInParentSequence.Replace("[","").Replace("]","").Replace("to", "").Replace(" ", "").Length + 2);
 
@@ -432,8 +438,8 @@ namespace Test.MetaDraw
                     }
                 }
             }
-            matchedIons = modPsm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.AminoAcidPosition > MetaDrawSettings.FirstAAonScreenIndex &&
-                                                p.NeutralTheoreticalProduct.AminoAcidPosition < (MetaDrawSettings.FirstAAonScreenIndex + MetaDrawSettings.NumberOfAAOnScreen)).ToList();
+            matchedIons = modPsm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.ResiduePosition > MetaDrawSettings.FirstAAonScreenIndex &&
+                                                p.NeutralTheoreticalProduct.ResiduePosition < (MetaDrawSettings.FirstAAonScreenIndex + MetaDrawSettings.NumberOfAAOnScreen)).ToList();
             Assert.That(metadrawLogic.StationarySequence.SequenceDrawingCanvas.Children.Count == modifiedBaseSeq.Length + matchedIons.Count + fullSequence.Count(p => p == '[') + 
                 psm.StartAndEndResiduesInParentSequence.Replace("[", "").Replace("]", "").Replace("to", "").Replace(" ", "").Length + 2);
 

--- a/MetaMorpheus/Test/MetaDraw/SpectrumMatchPlotTests.cs
+++ b/MetaMorpheus/Test/MetaDraw/SpectrumMatchPlotTests.cs
@@ -52,7 +52,7 @@ namespace Test.MetaDraw
             // load results into metadraw
             metadrawLogic = new MetaDrawLogic();
             metadrawLogic.SpectraFilePaths.Add(spectraFile);
-            metadrawLogic.PsmResultFilePaths.Add(psmFile);
+            metadrawLogic.SpectralMatchResultFilePaths.Add(psmFile);
             var errors = metadrawLogic.LoadFiles(true, true);
 
             Assert.That(!errors.Any());
@@ -72,7 +72,7 @@ namespace Test.MetaDraw
         private string outputFolder;
         private MetaDrawLogic metadrawLogic;
         private OxyPlot.Wpf.PlotView plotView;
-        private PsmFromTsv psm;
+        private SpectrumMatchFromTsv psm;
         private ParentChildScanPlotsView parentChildView;
         public record PeakAnnotationTestCase(bool AnnotatePeaks, bool AnnotateCharges,
             bool AnnotateMass, bool SubAndSuper, string ExpectedAnnotation, OxyColor ExpectedColor, int FragmentIndex);
@@ -188,7 +188,7 @@ namespace Test.MetaDraw
             // load in files
             MetaDrawLogic metaDrawLogic = new MetaDrawLogic();
             metaDrawLogic.SpectraFilePaths.Add(dataFilePath);
-            metaDrawLogic.PsmResultFilePaths.Add(psmFilePath);
+            metaDrawLogic.SpectralMatchResultFilePaths.Add(psmFilePath);
 
             var errors = metaDrawLogic.LoadFiles(true, true);
 
@@ -202,7 +202,7 @@ namespace Test.MetaDraw
             var stationaryCanvas = new Canvas();
             var sequenceAnnotationCanvas = new Canvas();
             var parentChildView = new ParentChildScanPlotsView();
-            var psm = metaDrawLogic.FilteredListOfPsms.First(p => p.FullSequence == "GVTVDKMTELR(6)");
+            var psm = metaDrawLogic.FilteredListOfPsms.First(p => p.FullSequence == "GVTVDKMTELR(6)") as PsmFromTsv;
              
             // perform black magic to set the scan number of the MS2 to match the mzML file number
             var oldScanNum = psm.Ms2ScanNumber;
@@ -233,7 +233,7 @@ namespace Test.MetaDraw
             foreach (var exportType in MetaDrawSettings.ExportTypes)
             {
                 MetaDrawSettings.ExportType = exportType;
-                metaDrawLogic.ExportPlot(plotView, canvas, new List<PsmFromTsv>() { psm }, parentChildView,
+                metaDrawLogic.ExportPlot(plotView, canvas, new List<SpectrumMatchFromTsv>() { psm }, parentChildView,
                     outputFolderPath, out errors);
 
                 Assert.That(File.Exists(Path.Combine(outputFolderPath, @$"{psm.Ms2ScanNumber}_{psm.FullSequence}{psm.BetaPeptideBaseSequence}.{exportType}")));
@@ -245,7 +245,7 @@ namespace Test.MetaDraw
 
             metaDrawLogic.CleanUpPSMFiles();
             Assert.That(!metaDrawLogic.FilteredListOfPsms.Any());
-            Assert.That(!metaDrawLogic.PsmResultFilePaths.Any());
+            Assert.That(!metaDrawLogic.SpectralMatchResultFilePaths.Any());
 
             // delete output
             Directory.Delete(outputFolderPath, true);

--- a/MetaMorpheus/Test/PsvTsvTest.cs
+++ b/MetaMorpheus/Test/PsvTsvTest.cs
@@ -53,7 +53,7 @@ namespace Test
         {
             var metadrawLogic = new MetaDrawLogic();
             string psmFile = @"TestData\oglyco.psmtsv";
-            metadrawLogic.PsmResultFilePaths.Add(psmFile);
+            metadrawLogic.SpectralMatchResultFilePaths.Add(psmFile);
             var errors = metadrawLogic.LoadFiles(false, true);
 
             Assert.That(!errors.Any());
@@ -110,7 +110,7 @@ namespace Test
             foreach (var ambPsm in ambiguousPsms)
             {
                 PsmFromTsv disambiguatedPSM = new(ambPsm, ambPsm.FullSequence.Split("|")[0]);
-                Assert.That(disambiguatedPSM.StartAndEndResiduesInProtein == ambPsm.StartAndEndResiduesInProtein.Split("|")[0]);
+                Assert.That(disambiguatedPSM.StartAndEndResiduesInParentSequence == ambPsm.StartAndEndResiduesInParentSequence.Split("|")[0]);
                 Assert.That(disambiguatedPSM.BaseSeq == ambPsm.BaseSeq.Split("|")[0]);
                 Assert.That(disambiguatedPSM.EssentialSeq == ambPsm.EssentialSeq.Split("|")[0]);
                 Assert.That(disambiguatedPSM.ProteinAccession == ambPsm.ProteinAccession.Split("|")[0]);
@@ -125,12 +125,12 @@ namespace Test
                     Assert.That(disambiguatedPSM.MatchedIons[i] == ambPsm.MatchedIons[i]);
                 }
 
-                if (ambPsm.StartAndEndResiduesInProtein.Split("|").Count() > 1)
+                if (ambPsm.StartAndEndResiduesInParentSequence.Split("|").Count() > 1)
                 {
-                    for (int i = 1; i < ambPsm.StartAndEndResiduesInProtein.Split("|").Count(); i++)
+                    for (int i = 1; i < ambPsm.StartAndEndResiduesInParentSequence.Split("|").Count(); i++)
                     {
                         disambiguatedPSM = new(ambPsm, ambPsm.FullSequence.Split("|")[i], i);
-                        Assert.That(disambiguatedPSM.StartAndEndResiduesInProtein == ambPsm.StartAndEndResiduesInProtein.Split("|")[i]);
+                        Assert.That(disambiguatedPSM.StartAndEndResiduesInParentSequence == ambPsm.StartAndEndResiduesInParentSequence.Split("|")[i]);
                         Assert.That(disambiguatedPSM.BaseSeq == ambPsm.BaseSeq.Split("|")[i]);
                         Assert.That(disambiguatedPSM.EssentialSeq == ambPsm.EssentialSeq.Split("|")[i]);
                         Assert.That(disambiguatedPSM.ProteinAccession == ambPsm.ProteinAccession.Split("|")[i]);

--- a/MetaMorpheus/Test/SearchEngineTests.cs
+++ b/MetaMorpheus/Test/SearchEngineTests.cs
@@ -161,7 +161,7 @@ namespace Test
             Assert.That(0.004739, Is.EqualTo(psm.QValueNotch).Within(1E-04));
             Assert.That(psm.RetentionTime, Is.EqualTo(45.59512));
             Assert.That(psm.Score, Is.EqualTo(662.486));
-            Assert.That(psm.StartAndEndResiduesInProtein, Is.EqualTo("[2742 to 2761]"));
+            Assert.That(psm.StartAndEndResiduesInParentSequence, Is.EqualTo("[2742 to 2761]"));
             Assert.That(psm.TotalIonCurrent, Is.EqualTo(159644.25225));
             Assert.That(psm.VariantCrossingIons.Count, Is.EqualTo(0));
             property.SetValue(null, false);

--- a/MetaMorpheus/Test/SpectralRecoveryTest.cs
+++ b/MetaMorpheus/Test/SpectralRecoveryTest.cs
@@ -68,7 +68,7 @@ namespace Test
                     filePath, commonParameters);
                 Protein protein = proteinList.First(protein => protein.Accession == readPsm.ProteinAccession);
 
-                //string[] startAndEndResidues = readPsm.StartAndEndResiduesInProtein.Split(" ");
+                //string[] startAndEndResidues = readPsm.StartAndEndResiduesInParentSequence.Split(" ");
                 //int startResidue = Int32.Parse(startAndEndResidues[0].Trim('['));
                 //int endResidue = Int32.Parse(startAndEndResidues[2].Trim(']'));
 


### PR DESCRIPTION
Removed protein specific fields from MetaDraw and generalized for oligos as well. 