### PR TITLE
Fix Glyco Crash on ProteinParsimony

### DIFF
--- a/MetaMorpheus/EngineLayer/ProteinParsimony/ProteinParsimonyEngine.cs
+++ b/MetaMorpheus/EngineLayer/ProteinParsimony/ProteinParsimonyEngine.cs
@@ -183,7 +183,7 @@ namespace EngineLayer
                                     }
 
                                     // create any new associations that need to be made
-                                    foreach (PeptideSpectralMatch psm in baseSequence.Value)
+                                    foreach (SpectralMatch psm in baseSequence.Value)
                                     {
                                         var tentativeMatch = psm.BestMatchingBioPolymersWithSetMods.First();
                                         IBioPolymerWithSetMods originalPeptide = tentativeMatch.SpecificBioPolymer;


### PR DESCRIPTION
GlycoSpectralMatch inherits from SpectralMatch and not PeptideSpectralMatch. This caused a crash during protein parsimony and is fixed in this PR. 