### PR TITLE
MetaDraw Crash with IQuantifiableRecord

### DIFF
--- a/MetaMorpheus/GUI/MetaDraw/MetaDraw.xaml.cs
+++ b/MetaMorpheus/GUI/MetaDraw/MetaDraw.xaml.cs
@@ -351,7 +351,15 @@ namespace MetaMorpheusGUI
                 }
                 else
                 {
-                    propertyView.Rows.Add(temp[i].Name, temp[i].GetValue(psm, null));
+                    // Hacky fix for some of the properties in IQuantifiableRecord that are only populated as needed by FlashLFQ
+                    try
+                    {
+                        propertyView.Rows.Add(temp[i].Name, temp[i].GetValue(psm, null));
+                    }
+                    catch
+                    {
+                        // do nothing
+                    }
                 }
             }
 


### PR DESCRIPTION
Because the quantifiable record fields are often null until ran through FlashLFQ, this lead to crashes in MetaDraw. 

This fix changes property assignment and access for the table that is usually hidden under an expander at the bottom of the fragmentation scan view. 