### PR TITLE
Update mz lib

### DIFF
--- a/MetaMorpheus/CMD/CMD.csproj
+++ b/MetaMorpheus/CMD/CMD.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.562" />
+    <PackageReference Include="mzLib" Version="1.0.563" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>
 

--- a/MetaMorpheus/EngineLayer/EngineLayer.csproj
+++ b/MetaMorpheus/EngineLayer/EngineLayer.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.562" />
+    <PackageReference Include="mzLib" Version="1.0.563" />
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/MetaMorpheus/EngineLayer/MetaMorpheusException.cs
+++ b/MetaMorpheus/EngineLayer/MetaMorpheusException.cs
@@ -5,7 +5,7 @@ namespace EngineLayer
     [Serializable]
     public class MetaMorpheusException : Exception
     {
-        public MetaMorpheusException(string message) : base(message)
+        public MetaMorpheusException(string message, Exception innerException = null) : base(message, innerException)
         {
         }
     }

--- a/MetaMorpheus/GUI/GUI.csproj
+++ b/MetaMorpheus/GUI/GUI.csproj
@@ -55,7 +55,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.562" />
+    <PackageReference Include="mzLib" Version="1.0.563" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0" />

--- a/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
+++ b/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="itext7" Version="8.0.5" />
     <PackageReference Include="itext7.bouncy-castle-adapter" Version="8.0.5" />
-    <PackageReference Include="mzLib" Version="1.0.562" />
+    <PackageReference Include="mzLib" Version="1.0.563" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.0.0" />
     <PackageReference Include="Svg" Version="3.4.7" />
   </ItemGroup>

--- a/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
+++ b/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
@@ -93,7 +93,7 @@ namespace TaskLayer
                     {
                         "ClassicDeconvolution" => tmlTable.Get<ClassicDeconvolutionParameters>(),
                         "IsoDecDeconvolution" => tmlTable.Get<IsoDecDeconvolutionParameters>(),
-                        _ => throw new MetaMorpheusException($"Toml Parsing Failure - Unknown DeconvolutionType: {tmlTable.Get<string>("DeconvolutionType")}")
+                        _ => throw new MetaMorpheusException($"Toml Parsing Failure - Unknown Deconvolution Type: {tmlTable.Get<string>("DeconvolutionType")}")
                     })))
             // Ignore all properties that are not user settable, instantiate with defaults. If the toml differs, defaults will be overridden. 
             .ConfigureType<ClassicDeconvolutionParameters>(type => type
@@ -127,11 +127,9 @@ namespace TaskLayer
                         }
                     )))
             .ConfigureType<Averagine>(type => type
-                .CreateInstance(() => new Averagine())
                 .WithConversionFor<TomlString>(convert => convert
                     .ToToml(custom => custom.GetType().Name)))
             .ConfigureType<OxyriboAveragine>(type => type
-                .CreateInstance(() => new OxyriboAveragine())
                 .WithConversionFor<TomlString>(convert => convert
                     .ToToml(custom => custom.GetType().Name)))
         );

--- a/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
+++ b/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
@@ -113,7 +113,16 @@ namespace TaskLayer
                 .IgnoreProperty(p => p.MinusOneAreasZero)
                 .IgnoreProperty(p => p.IsotopeThreshold)
                 .IgnoreProperty(p => p.ZScoreThreshold))
-            );
+            // Convert average residue models to simple strings instead of tables, Nett makes all objects tables by default
+            .ConfigureType<Averagine>(type => type
+                .WithConversionFor<TomlString>(convert => convert
+                    .ToToml(custom => custom.GetType().Name)
+                    .FromToml(_ => new Averagine())))
+            .ConfigureType<OxyriboAveragine>(type => type
+                .WithConversionFor<TomlString>(convert => convert
+                    .ToToml(custom => custom.GetType().Name)
+                    .FromToml(_ => new OxyriboAveragine())))
+        );
        
 
         protected readonly StringBuilder ProseCreatedWhileRunning = new StringBuilder();

--- a/MetaMorpheus/TaskLayer/TaskLayer.csproj
+++ b/MetaMorpheus/TaskLayer/TaskLayer.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.562" />
+    <PackageReference Include="mzLib" Version="1.0.563" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>

--- a/MetaMorpheus/Test/Test.csproj
+++ b/MetaMorpheus/Test/Test.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.562" />
+    <PackageReference Include="mzLib" Version="1.0.563" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />

--- a/MetaMorpheus/Test/TestToml.cs
+++ b/MetaMorpheus/Test/TestToml.cs
@@ -415,6 +415,33 @@ namespace Test
             var searchTaskLoaded = Toml.ReadFile<SearchTask>(tomlPath, MetaMorpheusTask.tomlConfig);
             var loadedModel = searchTaskLoaded.CommonParameters.PrecursorDeconvolutionParameters.AverageResidueModel;
             Assert.That(loadedModel.GetType(), Is.EqualTo(model.GetType()));
+            File.Delete(tomlPath);
+        }
+
+        [Test]
+        public static void TestToml_IsoDecWithOxyRiboAverageResidueModel()
+        {
+            var model = (AverageResidue)new OxyriboAveragine();
+            var searchTask = new SearchTask()
+            {
+                CommonParameters = new CommonParameters(precursorDeconParams: new IsoDecDeconvolutionParameters(Polarity.Negative, 4))
+            };
+            searchTask.CommonParameters.PrecursorDeconvolutionParameters.AverageResidueModel = model;
+
+            var tomlPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "testIsodec.toml");
+            Toml.WriteFile(searchTask, tomlPath, MetaMorpheusTask.tomlConfig);
+
+            var searchTaskLoaded = Toml.ReadFile<SearchTask>(tomlPath, MetaMorpheusTask.tomlConfig);
+            var loadedModel = searchTaskLoaded.CommonParameters.PrecursorDeconvolutionParameters.AverageResidueModel;
+            Assert.That(loadedModel.GetType(), Is.EqualTo(model.GetType()));
+            var loadedDeconParams = searchTaskLoaded.CommonParameters.PrecursorDeconvolutionParameters;
+            Assert.That(loadedDeconParams, Is.TypeOf<IsoDecDeconvolutionParameters>());
+            var isoDecParams = (IsoDecDeconvolutionParameters)loadedDeconParams;
+            Assert.That(isoDecParams.Polarity, Is.EqualTo(Polarity.Negative));
+            Assert.That(isoDecParams.AverageResidueModel.GetType(), Is.EqualTo(model.GetType()));
+            Assert.That(isoDecParams.PhaseRes, Is.EqualTo(4));
+
+            File.Delete(tomlPath);
         }
 
         [Test]
@@ -498,7 +525,7 @@ namespace Test
                 var inner2 = inner!.InnerException;
                 Assert.That(inner2, Is.TypeOf<MetaMorpheusException>());
                 Assert.That(inner2!.Message, Does.Contain("Toml Parsing Failure"));
-                Assert.That(inner2.Message, Does.Contain("Unknown DeconvolutionType: BadDecon"));
+                Assert.That(inner2.Message, Does.Contain("Unknown Deconvolution Type: BadDecon"));
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Updated mzlib and added new toml handling for average residue models. Not the best way to handle it as you need to add a new line to the toml parser for each now model created, but it is good enough for now. A more robust approach would require a factory in MzLib. 