### PR TITLE
Fixed bug where MetaDraw couldn't open timsTof files 

### DIFF
--- a/MetaMorpheus/GUI/MetaDraw/MetaDraw.xaml.cs
+++ b/MetaMorpheus/GUI/MetaDraw/MetaDraw.xaml.cs
@@ -36,8 +36,7 @@ namespace MetaMorpheusGUI
         public PtmLegendViewModel PtmLegend;
         public ChimeraLegendViewModel ChimeraLegend;
         private ObservableCollection<ModTypeForTreeViewModel> Modifications = new ObservableCollection<ModTypeForTreeViewModel>();
-        //private static List<string> AcceptedSpectraFormats = new List<string> { ".mzml", ".raw", ".mgf" };
-        private static List<string> AcceptedSpectraFormats => Readers.SpectrumMatchFromTsvHeader.AcceptedSpectraFormats.ToList();
+        private static List<string> AcceptedSpectraFormats => Readers.SpectrumMatchFromTsvHeader.AcceptedSpectraFormats.Concat(new List<string> { ".tdf", ".tdf_bin" }).Select(format => format.ToLower()).ToList();
         private static List<string> AcceptedResultsFormats = new List<string> { ".psmtsv", ".tsv" };
         private static List<string> AcceptedSpectralLibraryFormats = new List<string> { ".msp" };
         private MetaDrawSettingsViewModel SettingsView;
@@ -105,6 +104,11 @@ namespace MetaMorpheusGUI
 
             if (AcceptedSpectraFormats.Contains(theExtension))
             {
+                // If a bruker timsTof file was selected, we actually want the parent folder
+                if(theExtension == ".tdf" || theExtension == ".tdf_bin")
+                {
+                    filePath = Path.GetDirectoryName(filePath);
+                }
                 if (!MetaDrawLogic.SpectraFilePaths.Contains(filePath))
                 {
                     MetaDrawLogic.SpectraFilePaths.Add(filePath);

--- a/MetaMorpheus/GuiFunctions/MetaDraw/MetaDrawLogic.cs
+++ b/MetaMorpheus/GuiFunctions/MetaDraw/MetaDrawLogic.cs
@@ -1054,9 +1054,7 @@ namespace GuiFunctions
             {
                 lock (ThreadLocker)
                 {
-                    var fileNameWithoutExtension = filepath.Replace(GlobalVariables.GetFileExtension(filepath), string.Empty);
-                    fileNameWithoutExtension = System.IO.Path.GetFileName(fileNameWithoutExtension);
-
+                    var fileNameWithoutExtension = System.IO.Path.GetFileName(filepath.Replace(GlobalVariables.GetFileExtension(filepath), string.Empty));
                     var spectraFile = MsDataFileReader.GetDataFile(filepath);
                     if (spectraFile is TimsTofFileReader timsTofDataFile)
                     {


### PR DESCRIPTION
If the "Select" button is used in MetaDraw to select/load spectra files, then users trying to visualize timsTof files have to select a .tdf/.tdf_bin file. Previously, this would cause a crash.

Now, metadraw finds the parent folder of a .tdf/.tdf_bin file (a folder with name ending in ".d") and sets that as the spectra file name.