### PR TITLE
MetaDraw Update: Refragment persists to output and right click for clipboard 

### DIFF
--- a/MetaMorpheus/GUI/MetaDraw/MetaDraw.xaml
+++ b/MetaMorpheus/GUI/MetaDraw/MetaDraw.xaml
@@ -217,7 +217,15 @@
                                             <Grid.RowDefinitions>
                                                 <RowDefinition Height = "0.75*" />
                                             </Grid.RowDefinitions>
-                                            <oxy:PlotView Grid.Row="0" x:Name="plotView" FontSize="16" FontStretch="Expanded" Margin="0 0 0 0"/>
+                                            <oxy:PlotView Grid.Row="0" x:Name="plotView" FontSize="16" FontStretch="Expanded" Margin="0 0 0 0">
+                                                <oxy:PlotView.ContextMenu>
+                                                    <ContextMenu>
+                                                        <MenuItem Header="Copy m/z Spectrum (All)" Click="CopyMzSpectrum_Click"/>
+                                                        <MenuItem Header="Copy m/z Spectrum (Annotated)" Click="CopyAnnotatedMzSpectrum_Click"/>
+                                                        <MenuItem Header="Copy Matched Ions" Click="CopyMatchedIons_Click"/>
+                                                    </ContextMenu>
+                                                </oxy:PlotView.ContextMenu>
+                                            </oxy:PlotView>
                                         </Grid>
 
                                         <!--Canvas for drawing stationary sequence annotation-->

--- a/MetaMorpheus/GUI/MetaDraw/MetaDraw.xaml.cs
+++ b/MetaMorpheus/GUI/MetaDraw/MetaDraw.xaml.cs
@@ -623,7 +623,7 @@ namespace MetaMorpheusGUI
                     ptmLegendLocationVector.X = PsmAnnotationGrid.ActualWidth - ChildScanPtmLegendControl.ActualWidth;
                 }
                 MetaDrawLogic.ExportPlot(plotView, stationarySequenceCanvas, items, itemsControlSampleViewModel,
-                    directoryPath, out errors, legendCanvas, ptmLegendLocationVector);
+                    directoryPath, out errors, legendCanvas, ptmLegendLocationVector, FragmentationReanalysisViewModel);
             }
 
             if (errors != null && errors.Any())

--- a/MetaMorpheus/GuiFunctions/MetaDraw/MetaDrawLogic.cs
+++ b/MetaMorpheus/GuiFunctions/MetaDraw/MetaDrawLogic.cs
@@ -503,7 +503,7 @@ namespace GuiFunctions
 
         public void ExportPlot(PlotView plotView, Canvas stationaryCanvas, List<SpectrumMatchFromTsv> spectrumMatches,
             ParentChildScanPlotsView parentChildScanPlotsView, string directory, out List<string> errors,
-            Canvas legendCanvas = null, Vector ptmLegendLocationVector = new())
+            Canvas legendCanvas = null, Vector ptmLegendLocationVector = new(), FragmentationReanalysisViewModel? reFragment = null)
         {
             errors = new List<string>();
 
@@ -519,6 +519,16 @@ namespace GuiFunctions
                 {
                     errors.Add("The spectra file could not be found for this PSM: " + psm.FileNameWithoutExtension);
                     return;
+                }
+
+                // if we have ions that were not originally search for, cache original, find new ions, plot, replace original
+                List<MatchedFragmentIon> oldMatchedIons = null;
+                if (reFragment is not null && reFragment.Persist)
+                {
+                    oldMatchedIons = psm.MatchedIons;
+                    var scan = GetMs2ScanFromPsm(psm);
+                    var newIons = reFragment.MatchIonsWithNewTypes(scan, psm);
+                    psm.MatchedIons = newIons;
                 }
 
                 if (plotView.Name == "plotView")
@@ -583,12 +593,30 @@ namespace GuiFunctions
                             break;
                     }
                 }
+                // put the original ions back in place if they were altered
+                if (oldMatchedIons != null && !psm.MatchedIons.SequenceEqual(oldMatchedIons))
+                    psm.MatchedIons = oldMatchedIons;
             }
 
             if (plotView.Name == "plotView")
             {
-                DisplaySequences(stationaryCanvas, null, null, spectrumMatches.First());
-                DisplaySpectrumMatch(plotView, spectrumMatches.First(), parentChildScanPlotsView, out errors);
+                var psm = spectrumMatches.First();
+
+                // if we have ions that were not originally search for, cache original, find new ions, plot, replace original
+                List<MatchedFragmentIon> oldMatchedIons = null;
+                if (reFragment is not null && reFragment.Persist)
+                {
+                    oldMatchedIons = psm.MatchedIons;
+                    var scan = GetMs2ScanFromPsm(psm);
+                    var newIons = reFragment.MatchIonsWithNewTypes(scan, psm);
+                    psm.MatchedIons = newIons;
+                }
+                DisplaySequences(stationaryCanvas, null, null, psm);
+                DisplaySpectrumMatch(plotView, psm, parentChildScanPlotsView, out errors);
+
+                // put the original ions back in place if they were altered
+                if (oldMatchedIons != null && !psm.MatchedIons.SequenceEqual(oldMatchedIons))
+                    psm.MatchedIons = oldMatchedIons;
             }
             else if (plotView.Name == "chimeraPlot")
             {
@@ -598,7 +626,6 @@ namespace GuiFunctions
                     .ToList();
                 DisplayChimeraSpectra(plotView, chimericPsms, out errors);
             }
-
         }
 
         public MsDataScan GetMs2ScanFromPsm(SpectrumMatchFromTsv spectralMatch)


### PR DESCRIPTION
This PR does 2 things in MetaDraw. 

## Bug Fix: Re-fragment in Export
Previously refragmentation analysis would not put the new peaks in the exported image. This has been fixed. 

## Right Click copy to clipboard for fragmentation annotation
You can now copy out 
1. The entire spectrum
2. The annotated spectrum
3. The matched ions