### PR TITLE
Meta draw settings to singleton

### DIFF
--- a/MetaMorpheus/GUI/MetaDraw/MetaDraw.xaml
+++ b/MetaMorpheus/GUI/MetaDraw/MetaDraw.xaml
@@ -152,15 +152,8 @@
 
                                 <Grid Grid.Row="0" Background="Gray" Opacity=".65"></Grid>
                                 <!--Settings menu-->
-                                <Button x:Name="Settings" Grid.Row="0" Grid.Column="1" Click="settings_Click" Background="White" 
-                                        BorderThickness="0" IsEnabled="{Binding SettingsView.CanOpen}">
-                                    <StackPanel Name="SettingsButton" Orientation="Horizontal">
-                                        <Image Source="Icons\icons8-settings-480.png" Margin="0,3,0,0" ></Image>
-                                        <ToolTipService.ToolTip>
-                                            <ToolTip Content="Settings" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500" />
-                                        </ToolTipService.ToolTip>
-                                    </StackPanel>
-                                </Button>
+                                <local:SettingsButtonControl x:Name="SettingsButton" Grid.Row="0" Grid.Column="1"
+                                                             RefreshAction="{Binding RedrawPlotsAction}"/>
 
                                 <!-- Scrolling Sequence and Ambiguous Textbox-->
                                 <Grid Grid.Row="0" Grid.Column="2" Grid.ColumnSpan="2" >

--- a/MetaMorpheus/GUI/MetaDraw/MetaDraw.xaml.cs
+++ b/MetaMorpheus/GUI/MetaDraw/MetaDraw.xaml.cs
@@ -40,14 +40,13 @@ namespace MetaMorpheusGUI
         private static List<string> AcceptedSpectraFormats => SpectrumMatchFromTsvHeader.AcceptedSpectraFormats.Concat(new List<string> { ".msalign", ".tdf", ".tdf_bin" }).Select(format => format.ToLower()).ToList();
         private static List<string> AcceptedResultsFormats = new List<string> { ".psmtsv", ".tsv" };
         private static List<string> AcceptedSpectralLibraryFormats = new List<string> { ".msp" };
-        private MetaDrawSettingsViewModel SettingsView;
         private FragmentationReanalysisViewModel FragmentationReanalysisViewModel;
 
         public MetaDraw()
         {
             InitializeComponent();
 
-            InitializeColorSettingsView();
+            SettingsButton.RefreshAction = RefreshPlotsAfterSettingsChange;
             MetaDrawLogic = new MetaDrawLogic();
             BindingOperations.EnableCollectionSynchronization(MetaDrawLogic.SpectralMatchResultFilePaths, MetaDrawLogic.ThreadLocker);
             BindingOperations.EnableCollectionSynchronization(MetaDrawLogic.SpectraFilePaths, MetaDrawLogic.ThreadLocker);
@@ -463,23 +462,20 @@ namespace MetaMorpheusGUI
             MetaDrawLogic.CleanUpResources();
         }
 
-        private void settings_Click(object sender, RoutedEventArgs e)
+        /// <summary>
+        /// Will be fired by settings button control if settings change. 
+        /// </summary>
+        private void RefreshPlotsAfterSettingsChange()
         {
             // save current selected PSM
             var selectedItem = dataGridScanNums.SelectedItem;
-            var settingsWindow = new MetaDrawSettingsWindow(SettingsView);
-            var result = settingsWindow.ShowDialog();
-
             exportPdfs.Content = MetaDrawSettings.ExportType;
-            // re-select selected PSM
-            if (result == true)
-            {
-                // refresh chart
-                dataGridScanNums_SelectedCellsChanged(null, null);
 
-                // filter based on new settings
-                MetaDrawLogic.FilterPsms();
-            }
+            // refresh chart
+            dataGridScanNums_SelectedCellsChanged(null, null);
+
+            // filter based on new settings
+            MetaDrawLogic.FilterPsms();
 
             if (selectedItem != null)
             {
@@ -1009,16 +1005,6 @@ namespace MetaMorpheusGUI
             }
             MetaDrawSettings.FirstAAonScreenIndex = firstLetterOnScreen;
             MetaDrawSettings.NumberOfAAOnScreen = lettersOnScreen;
-        }
-
-        /// <summary>
-        /// Allows the color settings to load asynchronously, avoiding a minor delay in MetaDraw Launch
-        /// </summary>
-        private async void InitializeColorSettingsView()
-        {
-            MetaDrawSettingsViewModel view = new MetaDrawSettingsViewModel();
-            await view.Initialization;
-            SettingsView = view;
         }
 
         /// <summary>

--- a/MetaMorpheus/GUI/MetaDraw/MetaDrawSettingsWindow.xaml.cs
+++ b/MetaMorpheus/GUI/MetaDraw/MetaDrawSettingsWindow.xaml.cs
@@ -22,17 +22,10 @@ namespace MetaMorpheusGUI
     /// </summary>
     public partial class MetaDrawSettingsWindow : Window
     {
-        private readonly ObservableCollection<ModTypeForTreeViewModel> Modifications = new ObservableCollection<ModTypeForTreeViewModel>();
-        private readonly ObservableCollection<IonTypeForTreeViewModel> IonGroups = new ObservableCollection<IonTypeForTreeViewModel>();
-        private readonly ObservableCollection<CoverageTypeForTreeViewModel> CoverageColors = new ObservableCollection<CoverageTypeForTreeViewModel>();
-
-        private MetaDrawSettingsViewModel SettingsView;
-
-        public MetaDrawSettingsWindow(MetaDrawSettingsViewModel view)
+        public MetaDrawSettingsWindow()
         {
             InitializeComponent();
-            SettingsView = view;
-            DataContext = SettingsView;
+            DataContext = MetaDrawSettingsViewModel.Instance;
             PopulateChoices();
         }
 
@@ -83,9 +76,9 @@ namespace MetaMorpheusGUI
 
             ExportFileFormatComboBox.ItemsSource = MetaDrawSettings.ExportTypes;
             ExportFileFormatComboBox.SelectedItem = MetaDrawSettings.ExportType;
-            IonColorExpander.ItemsSource = SettingsView.IonGroups;
-            PTMColorExpander.ItemsSource = SettingsView.Modifications;
-            SequenceCoverageColorExpander.ItemsSource = SettingsView.CoverageColors;
+            IonColorExpander.ItemsSource = MetaDrawSettingsViewModel.Instance.IonGroups;
+            PTMColorExpander.ItemsSource = MetaDrawSettingsViewModel.Instance.Modifications;
+            SequenceCoverageColorExpander.ItemsSource = MetaDrawSettingsViewModel.Instance.CoverageColors;
         }
 
         private void Cancel_Click(object sender, RoutedEventArgs e)
@@ -127,7 +120,7 @@ namespace MetaMorpheusGUI
             MetaDrawSettings.SpectrumDescriptionFontSize = double.TryParse(SpectrumDescriptionFontSizeBox.Text, out double spectrumDescriptionFontSize) ? spectrumDescriptionFontSize : 10;
             if (!ShowInternalIonsCheckBox.IsChecked.Value)
                 MetaDrawSettings.InternalIonColor = OxyColors.Transparent;
-            SettingsView.Save();
+            MetaDrawSettingsViewModel.Instance.Save();
 
             if (!string.IsNullOrWhiteSpace(qValueBox.Text))
             {
@@ -278,7 +271,7 @@ namespace MetaMorpheusGUI
         private void setDefaultbutton_Click(object sender, RoutedEventArgs e)
         {
             Save_Click(sender, e);
-            SettingsView.SaveAsDefault();
+            MetaDrawSettingsViewModel.Instance.SaveAsDefault();
         }
 
         /// <summary>
@@ -323,9 +316,9 @@ namespace MetaMorpheusGUI
                 if (File.Exists(MetaDrawSettingsViewModel.SettingsPath))
                     File.Delete(MetaDrawSettingsViewModel.SettingsPath);
                 MetaDrawSettings.ResetSettings();
-                MetaDrawSettingsViewModel settingsViewModel = new MetaDrawSettingsViewModel();
-                SettingsView = settingsViewModel;
-                DataContext = SettingsView;
+                MetaDrawSettingsViewModel settingsViewModel = MetaDrawSettingsViewModel.Instance;
+                settingsViewModel.LoadSettings();
+                DataContext = settingsViewModel;
                 PopulateChoices();
                 DialogResult = true;
             }

--- a/MetaMorpheus/GUI/MetaDraw/SettingsButtonControl.xaml
+++ b/MetaMorpheus/GUI/MetaDraw/SettingsButtonControl.xaml
@@ -1,0 +1,21 @@
+﻿<UserControl x:Class="MetaMorpheusGUI.SettingsButtonControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
+             xmlns:local="clr-namespace:MetaMorpheusGUI"
+             mc:Ignorable="d" 
+             d:DesignHeight="32" d:DesignWidth="32">
+    <Button x:Name="SettingsButton"
+            Background="White"
+            BorderThickness="0"
+            Click="SettingsButton_Click"
+            IsEnabled="{Binding SettingsViewModel.CanOpen, RelativeSource={RelativeSource AncestorType=UserControl}}">
+        <StackPanel Orientation="Horizontal">
+            <Image Source="Icons/icons8-settings-480.png" Margin="0,3,0,0"/>
+            <ToolTipService.ToolTip>
+                <ToolTip Content="Settings" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500"/>
+            </ToolTipService.ToolTip>
+        </StackPanel>
+    </Button>
+</UserControl>

--- a/MetaMorpheus/GUI/MetaDraw/SettingsButtonControl.xaml.cs
+++ b/MetaMorpheus/GUI/MetaDraw/SettingsButtonControl.xaml.cs
@@ -1,0 +1,56 @@
+﻿using GuiFunctions;
+using System;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace MetaMorpheusGUI;
+
+/// <summary>
+/// Interaction logic for SettingsButtonControl.xaml
+/// </summary>
+public partial class SettingsButtonControl : UserControl
+{
+    public SettingsButtonControl()
+    {
+        InitializeComponent();
+        var vm = MetaDrawSettingsViewModel.Instance; 
+        SettingsViewModel = vm; // Assign the view model to the control's property
+    }
+
+    // DependencyProperty for the settings view model
+    public static readonly DependencyProperty SettingsViewModelProperty =
+        DependencyProperty.Register(nameof(SettingsViewModel), typeof(MetaDrawSettingsViewModel), typeof(SettingsButtonControl));
+
+    public MetaDrawSettingsViewModel SettingsViewModel
+    {
+        get => GetValue(SettingsViewModelProperty) as MetaDrawSettingsViewModel;
+        set => SetValue(SettingsViewModelProperty, value);
+    }
+
+    // DependencyProperty for the refresh action
+    public static readonly DependencyProperty RefreshActionProperty =
+        DependencyProperty.Register(nameof(RefreshAction), typeof(Action), typeof(SettingsButtonControl));
+
+    public Action RefreshAction
+    {
+        get => GetValue(RefreshActionProperty) as Action;
+        set => SetValue(RefreshActionProperty, value);
+    }
+
+    private void SettingsButton_Click(object sender, RoutedEventArgs e)
+    {
+        // Open the settings window
+        var settingsWindow = new MetaDrawSettingsWindow(SettingsViewModel as MetaDrawSettingsViewModel)
+        {
+            Owner = Window.GetWindow(this)
+        };
+
+        var result = settingsWindow.ShowDialog();
+
+        // If settings were changed, call the refresh action
+        if (result == true)
+        {
+            RefreshAction?.Invoke();
+        }
+    }
+}

--- a/MetaMorpheus/GUI/MetaDraw/SettingsButtonControl.xaml.cs
+++ b/MetaMorpheus/GUI/MetaDraw/SettingsButtonControl.xaml.cs
@@ -40,7 +40,7 @@ public partial class SettingsButtonControl : UserControl
     private void SettingsButton_Click(object sender, RoutedEventArgs e)
     {
         // Open the settings window
-        var settingsWindow = new MetaDrawSettingsWindow(SettingsViewModel as MetaDrawSettingsViewModel)
+        var settingsWindow = new MetaDrawSettingsWindow()
         {
             Owner = Window.GetWindow(this)
         };

--- a/MetaMorpheus/GuiFunctions/ViewModels/MetaDrawSettingsViewModel.cs
+++ b/MetaMorpheus/GuiFunctions/ViewModels/MetaDrawSettingsViewModel.cs
@@ -21,6 +21,12 @@ namespace GuiFunctions
     /// </summary>
     public class MetaDrawSettingsViewModel : BaseViewModel, IAsyncInitialization
     {
+        private static readonly Lazy<MetaDrawSettingsViewModel> _instance =
+            new(() => new MetaDrawSettingsViewModel());
+
+        // Singleton to ensure only one instance of MetaDrawSettingsViewModel exists
+        public static MetaDrawSettingsViewModel Instance => _instance.Value;
+
         #region Private Properties
 
         private ObservableCollection<ModTypeForTreeViewModel> _Modifications = new ObservableCollection<ModTypeForTreeViewModel>();
@@ -93,6 +99,7 @@ namespace GuiFunctions
                 LoadPTMs();
                 LoadIonTypes();
                 LoadSequenceCoverage();
+                Initialization = Task.CompletedTask;
             }
         }
 


### PR DESCRIPTION
MetaDrawSettings view models take a bit of time to load as it must process all of the color information stored in the MetaDrawSettings static class into visualizable objects. 

This PR ensure this time-consuming operation only ever occurs once. This is done by converting MetaDrawSettings into a singleton, or a class which only ever has one instance at run-time. 

This PR also breaks out the settings window button into a distinct control which can be dropped anywhere else in the MetaDraw GUI