### PR TITLE
MetaDraw Bug Fix: Newt Loss fragment ion annotations no longer duplicated in sub/superscript mode

### DIFF
--- a/MetaMorpheus/GuiFunctions/MetaDraw/SpectrumMatch/SpectrumMatchPlot.cs
+++ b/MetaMorpheus/GuiFunctions/MetaDraw/SpectrumMatch/SpectrumMatchPlot.cs
@@ -250,12 +250,15 @@ namespace GuiFunctions
                         }
                     }
                 else
-                    peakAnnotationText += matchedIon.NeutralTheoreticalProduct.Annotation;
-                
-                if (matchedIon.NeutralTheoreticalProduct.NeutralLoss != 0 &&
-                    !peakAnnotationText.Contains("-" + matchedIon.NeutralTheoreticalProduct.NeutralLoss.ToString("F2")))
                 {
-                    peakAnnotationText += "-" + matchedIon.NeutralTheoreticalProduct.NeutralLoss.ToString("F2");
+                    peakAnnotationText += matchedIon.NeutralTheoreticalProduct.Annotation;
+
+                    if (matchedIon.NeutralTheoreticalProduct.NeutralLoss != 0 &&
+                        !peakAnnotationText.Contains("-" +
+                                                     matchedIon.NeutralTheoreticalProduct.NeutralLoss.ToString("F2")))
+                    {
+                        peakAnnotationText += "-" + matchedIon.NeutralTheoreticalProduct.NeutralLoss.ToString("F2");
+                    }
                 }
 
                 if (MetaDrawSettings.AnnotateCharges)


### PR DESCRIPTION
Title says it all