### PR TITLE
Refactor ModSitePair: convert from tuple type to a individual class

### DIFF
--- a/MetaMorpheus/EngineLayer/GlycoSearch/GlycoPeptides.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/GlycoPeptides.cs
@@ -306,10 +306,10 @@ namespace EngineLayer.GlycoSearch
         /// <returns> A modfiied peptide </returns>
         public static PeptideWithSetModifications OGlyGetTheoreticalPeptide(Route theModPositions, PeptideWithSetModifications peptide)
         {
-            Modification[] modifications = new Modification[theModPositions.Mods.Count];
-            for (int i = 0; i < theModPositions.Mods.Count; i++)
+            Modification[] modifications = new Modification[theModPositions.ModSitePairs.Count];
+            for (int i = 0; i < theModPositions.ModSitePairs.Count; i++)
             {
-                modifications[i] = GlycanBox.GlobalOGlycans[theModPositions.Mods[i].Item2];
+                modifications[i] = GlycanBox.GlobalOGlycans[theModPositions.ModSitePairs[i].ModId];
             }
 
             Dictionary<int, Modification> testMods = new Dictionary<int, Modification>();
@@ -318,9 +318,9 @@ namespace EngineLayer.GlycoSearch
                 testMods.Add(mod.Key, mod.Value);
             }
 
-            for (int i = 0; i < theModPositions.Mods.Count; i++)
+            for (int i = 0; i < theModPositions.ModSitePairs.Count; i++)
             {
-                testMods.Add(theModPositions.Mods[i].Item1, modifications[i]);
+                testMods.Add(theModPositions.ModSitePairs[i].SiteIndex, modifications[i]);
             }
 
             var testPeptide = new PeptideWithSetModifications(peptide.Protein, peptide.DigestionParams, peptide.OneBasedStartResidue,

--- a/MetaMorpheus/EngineLayer/GlycoSearch/GlycoSpectralMatch.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/GlycoSpectralMatch.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using EngineLayer.ModSearch;
 using Omics.Modifications;
 using Readers;
 
@@ -38,7 +39,7 @@ namespace EngineLayer.GlycoSearch
         public double DiagnosticIonScore { get; set; } //Since every glycopeptide generate DiagnosticIon, it is important to seperate the score. 
 
         public double R138vs144 { get; set; } // The intensity ratio of this 138 and 144 could be a signature for O-glycan or N-glycan.
-        public List<Tuple<int, int, bool>> LocalizedGlycan { get; set; } //<mod site, glycanID, isLocalized> All seen glycans identified.
+        public List<ModSitePair> LocalizedGlycan { get; set; } //<mod site, glycanID, isLocalized> All seen glycans identified.
         public LocalizationLevel LocalizationLevel { get; set; }
 
         /// <summary>
@@ -381,27 +382,29 @@ namespace EngineLayer.GlycoSearch
         /// <param name="OGlycanBoxLocalization"> all case of the pair </param>
         /// <param name="localizationLevel"> level 1 to level 3 </param>
         /// <returns> A tuple, represent the pair and its confidience ex. [3,5,ture] means glycan 5 located on glycosite 3, and very confidience </returns>
-        public static List<Tuple<int, int, bool>> GetLocalizedGlycan(List<Route> OGlycanBoxLocalization, out LocalizationLevel localizationLevel)
+        public static List<ModSitePair> GetLocalizedGlycan(List<Route> OGlycanBoxLocalization, out LocalizationLevel localizationLevel)
         {
-            List<Tuple<int, int, bool>> localizedGlycan = new List<Tuple<int, int, bool>>();
+            List<ModSitePair> localizedMod = new List<ModSitePair>();
 
-            Dictionary<string, int> modSiteSeenCount = new Dictionary<string, int>(); // all possible glycan-sites pair, Dictionary<string, int>: site-glycan pair, count
+            //Dictionary<string, int> modSiteSeenCount = new Dictionary<string, int>(); // all possible glycan-sites pair, Dictionary<string, int>: site-glycan pair, count
 
-            foreach (var ogl in OGlycanBoxLocalization) // ogl means one case, there are three glycan located on the same peptide: (5,1,False),(9,8,Flase),(10,9,Ture)
-            {
-                foreach (var og in ogl.Mods)            // og means one glycan locaization, like (5,1,False) -> glycan 1 attached on postion5.
-                {
-                    var k = og.Item1.ToString() + "-" + og.Item2.ToString(); // k = 5-1(glycosite-glycan) means the glycan-site pair
-                    if (modSiteSeenCount.ContainsKey(k)) // accout the number of the same glycan-site pair
-                    {
-                        modSiteSeenCount[k] += 1;   // this pair cpunt +1
-                    }
-                    else
-                    {
-                        modSiteSeenCount.Add(k, 1); // If the pair is first time to seen, add it to the dictionary.
-                    }
-                }
-            }
+            //foreach (var route in OGlycanBoxLocalization) // ogl means one case, there are three glycan located on the same peptide: (5,1,False),(9,8,Flase),(10,9,Ture)
+            //{
+            //    foreach (var modSite in route.ModSitePairs)            // og means one glycan locaization, like (5,1,False) -> glycan 1 attached on postion5.
+            //    {
+            //        var k = modSite.SiteIndex.ToString() + "-" + modSite.ModId.ToString(); // k = 5-1(glycosite-glycan) means the glycan-site pair
+            //        if (modSiteSeenCount.ContainsKey(k)) // accout the number of the same glycan-site pair
+            //        {
+            //            modSiteSeenCount[k] += 1;   // this pair cpunt +1
+            //        }
+            //        else
+            //        {
+            //            modSiteSeenCount.Add(k, 1); // If the pair is first time to seen, add it to the dictionary.
+            //        }
+            //    }
+            //}
+
+            var modSiteSeenCount = OGlycanBoxLocalization.SelectMany(p => p.ModSitePairs).GroupBy(p => p).ToDictionary(g => g.Key, g => g.Count()); //This is a more efficient way to count the glycan-site pair.
 
             localizationLevel = LocalizationLevel.Level3;
             if (OGlycanBoxLocalization.Count == 1) // we just have one situation(route), no other possibility
@@ -410,7 +413,7 @@ namespace EngineLayer.GlycoSearch
             }
             else if (OGlycanBoxLocalization.Count > 1)
             {
-                if (modSiteSeenCount.Values.Where(p => p == OGlycanBoxLocalization.Count).Count() > 0) //If anyone of the glycan-site pair is localized in all the cases, then the localization level is 2.
+                if (modSiteSeenCount.Values.Any(p => p == OGlycanBoxLocalization.Count)) //If anyone of the glycan-site pair is localized in all the cases, then the localization level is 2.
                 {
                     localizationLevel = LocalizationLevel.Level2;
                 }
@@ -424,15 +427,12 @@ namespace EngineLayer.GlycoSearch
             {
                 if (seenMod.Value == OGlycanBoxLocalization.Count) // Try to fine the glycan-site pair that always localized in all the cases.
                 {
-                    localizedGlycan.Add(new Tuple<int, int, bool>(int.Parse(seenMod.Key.Split('-')[0]), int.Parse(seenMod.Key.Split('-')[1]), true));
+                    seenMod.Key.Confident = true;
                 }
-                else
-                {
-                    localizedGlycan.Add(new Tuple<int, int, bool>(int.Parse(seenMod.Key.Split('-')[0]), int.Parse(seenMod.Key.Split('-')[1]), false));
-                }
+                localizedMod.Add(seenMod.Key);
             }
 
-            return localizedGlycan;
+            return localizedMod;
         }
 
         /// <summary>
@@ -460,7 +460,7 @@ namespace EngineLayer.GlycoSearch
             {
                 var ogl = OGlycanBoxLocalization[i];
                 local += "{@" + ogl.ModBoxId.ToString() + "[";
-                var g = string.Join(",", ogl.Mods.Select(p => (p.Item1 - 1).ToString() + "-" + p.Item2.ToString())); //why we have to -1 here?
+                var g = string.Join(",", ogl.ModSitePairs.Select(p => (p.SiteIndex - 1).ToString() + "-" + p.ModId.ToString())); //why we have to -1 here?
                 local += g + "]}";
                 i++;
             }
@@ -482,7 +482,7 @@ namespace EngineLayer.GlycoSearch
         /// <param name="localizedGlycan"></param>
         /// <param name="localizationLevel"></param>
         /// <returns> level 1 or level 1b</returns>
-        public static LocalizationLevel CorrectLocalizationLevel(Dictionary<int, List<Tuple<int, double>>> siteSpeciLocalProb, LocalizationGraph localizationGraph, Route route, List<Tuple<int, int, bool>> localizedGlycan, LocalizationLevel localizationLevel)
+        public static LocalizationLevel CorrectLocalizationLevel(Dictionary<int, List<Tuple<int, double>>> siteSpeciLocalProb, LocalizationGraph localizationGraph, Route route, List<ModSitePair> localizedGlycan, LocalizationLevel localizationLevel)
         {
             if (siteSpeciLocalProb == null || localizationLevel!=LocalizationLevel.Level1)
             {
@@ -497,13 +497,13 @@ namespace EngineLayer.GlycoSearch
 
             for (int i = 0; i < localizedGlycan.Count; i++)
             {
-                var g = localizedGlycan[i];
-                if (siteSpeciLocalProb[g.Item1].Where(p => p.Item1 == g.Item2).First().Item2 < 0.75)
+                var modSitePair = localizedGlycan[i];
+                if (siteSpeciLocalProb[modSitePair.SiteIndex].Where(p => p.Item1 == modSitePair.ModId).First().Item2 < 0.75)
                 {
                     return LocalizationLevel.Level1b;
                 }
 
-                if (!route.Mods[i].Item3) // if the peak is not exist.
+                if (!route.ModSitePairs[i].HasMs2Spectrum) // if the peak is not exist.
                 {
                     return LocalizationLevel.Level1b;
                 }
@@ -521,21 +521,21 @@ namespace EngineLayer.GlycoSearch
         /// <param name="OneBasedStartResidueInProtein"></param>
         /// <param name="local"></param>
         /// <param name="local_protein"></param>
-        public static void LocalizedSiteSpeciLocalInfo(Dictionary<int, List<Tuple<int, double>>> siteSpeciLocalProb, List<Tuple<int, int, bool>> localizedGlycan, int? OneBasedStartResidueInProtein, ref string local_peptide, ref string local_protein)
+        public static void LocalizedSiteSpeciLocalInfo(Dictionary<int, List<Tuple<int, double>>> siteSpeciLocalProb, List<ModSitePair> localizedGlycan, int? OneBasedStartResidueInProtein, ref string local_peptide, ref string local_protein)
         {
             if (siteSpeciLocalProb == null)
             {
                 return;
             }
 
-            foreach (var glycositePair in localizedGlycan.Where(p => p.Item3)) // get the most confidient glycosite-glycan pair, loc is a pair of glycosite and glycan. Item 1 is glycosite, Item 2 is glycanId.
+            foreach (var glycositePair in localizedGlycan.Where(p => p.Confident)) // get the most confidient glycosite-glycan pair, loc is a pair of glycosite and glycan. Item 1 is glycosite, Item 2 is glycanId.
             {
-                var site_glycanProb = siteSpeciLocalProb[glycositePair.Item1].Where(p => p.Item1 == glycositePair.Item2).First().Item2; // get the probability of the specfic glycan on the specific site.
-                var peptide_site = glycositePair.Item1 - 1;
-                local_peptide += "[" + peptide_site + "," + GlycanBox.GlobalOGlycans[glycositePair.Item2].Composition + "," + site_glycanProb.ToString("0.000") + "]";
+                var site_glycanProb = siteSpeciLocalProb[glycositePair.SiteIndex].Where(p => p.Item1 == glycositePair.ModId).First().Item2; // get the probability of the specfic glycan on the specific site.
+                var peptide_site = glycositePair.SiteIndex - 1;
+                local_peptide += "[" + peptide_site + "," + GlycanBox.GlobalOGlycans[glycositePair.ModId].Composition + "," + site_glycanProb.ToString("0.000") + "]";
 
-                var protein_site = OneBasedStartResidueInProtein.HasValue ? OneBasedStartResidueInProtein.Value + glycositePair.Item1 - 2 : -1;
-                local_protein += "[" + protein_site + "," + GlycanBox.GlobalOGlycans[glycositePair.Item2].Composition + "," + site_glycanProb.ToString("0.000") + "]";
+                var protein_site = OneBasedStartResidueInProtein.HasValue ? OneBasedStartResidueInProtein.Value + glycositePair.SiteIndex - 2 : -1;
+                local_protein += "[" + protein_site + "," + GlycanBox.GlobalOGlycans[glycositePair.ModId].Composition + "," + site_glycanProb.ToString("0.000") + "]";
             }
 
         }

--- a/MetaMorpheus/EngineLayer/GlycoSearch/LocalizationGraph.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/LocalizationGraph.cs
@@ -400,11 +400,11 @@ namespace EngineLayer.GlycoSearch
                 matrix[i] = new Tuple<int, int, double>[routes.Count];
                 for (int j = 0; j < routes.Count; j++)
                 {
-                    foreach (var m in routes[j].Mods)
+                    foreach (var modSitePair in routes[j].ModSitePairs)
                     {
-                        if (m.Item1 == modPos[i])
+                        if (modSitePair.SiteIndex == modPos[i])
                         {
-                            matrix[i][j] = new Tuple<int, int, double>(m.Item1, m.Item2, routes[j].ReversePScore);
+                            matrix[i][j] = new Tuple<int, int, double>(modSitePair.SiteIndex, modSitePair.ModId, routes[j].ReversePScore);
                         }
                     }
                 }

--- a/MetaMorpheus/EngineLayer/GlycoSearch/Route.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/Route.cs
@@ -1,9 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using EngineLayer.ModSearch;
+using Omics;
 
 namespace EngineLayer.GlycoSearch
 {
+    /// <summary>
+    /// Presents a possible hypothesis in the glycan localization graph, which contains a set of modification site pairs and their associated scores.
+    /// </summary>
     public class Route
     { 
 
@@ -11,7 +16,7 @@ namespace EngineLayer.GlycoSearch
 
         //Tuple<int, int, double> mod pos, glycan id, local peak exist
         //For the local peak exist, the idea is that, in the localization graph matrix, if the node is detected as a mod, then the node score and the previous node has a current score >0.
-        public List<Tuple<int, int, bool>> Mods { get; private set; } = new List<Tuple<int, int, bool>>();
+        public List<ModSitePair> ModSitePairs { get; private set; } = new List<ModSitePair>();
 
         public double Score { get; set; }
 
@@ -19,7 +24,7 @@ namespace EngineLayer.GlycoSearch
 
         public void AddPos(int pos, int id, bool localPeakExist)
         {
-            Mods.Add(new Tuple<int, int, bool>(pos, id, localPeakExist));
+            ModSitePairs.Add(new ModSitePair(pos, id, localPeakExist));
         }
 
     }

--- a/MetaMorpheus/EngineLayer/ModSearch/ModSitePair.cs
+++ b/MetaMorpheus/EngineLayer/ModSearch/ModSitePair.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EngineLayer.ModSearch
+{
+    /// <summary>
+    /// Represent a hypothesis of the pair of modification and site. Include the modification Id, motif index and existece of the MS2 spectrum.
+    /// </summary>
+    public class ModSitePair(int siteIndex, int modId, bool hasMs2Spectrum)
+    {
+        public int SiteIndex { get; } = siteIndex; // The index of the site in the peptide sequence
+        public int ModId { get; } = modId; // The ID of the modification, which corresponds to its index in the modBox
+        public bool HasMs2Spectrum { get; } = hasMs2Spectrum; // Indicates whether the MS2 spectrum exists for this modification at the site
+        public bool Confident { get; set; } = false; // Indicates whether the modification is confidently localized at the site, if this pair occurs within of all hypothesis, then it is confident localized.
+
+        public override bool Equals(object obj)
+        {
+            if (obj is ModSitePair other)
+            {
+                return SiteIndex == other.SiteIndex && ModId == other.ModId;
+            }
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(SiteIndex, ModId);
+        }
+
+    }
+}

--- a/MetaMorpheus/TaskLayer/GlycoSearchTask/GlycoProteinParsimony.cs
+++ b/MetaMorpheus/TaskLayer/GlycoSearchTask/GlycoProteinParsimony.cs
@@ -58,25 +58,25 @@ namespace TaskLayer
                 {
                     foreach (var local in gsm.LocalizedGlycan)
                     {
-                        int proteinPos = local.Item1 + gsm.OneBasedStartResidue.Value - 2;
+                        int proteinPos = local.SiteIndex + gsm.OneBasedStartResidue.Value - 2;
 
-                        (string,string,int) proPosId = new (gsm.Accession, proteinPos.ToString(), local.Item2);
+                        (string,string,int) proPosId = new (gsm.Accession, proteinPos.ToString(), local.ModId);
 
                         double prob = -1;
-                        if (gsm.SiteSpeciLocalProb != null && gsm.SiteSpeciLocalProb.ContainsKey(local.Item1))
+                        if (gsm.SiteSpeciLocalProb != null && gsm.SiteSpeciLocalProb.ContainsKey(local.SiteIndex))
                         {
-                            prob = gsm.SiteSpeciLocalProb[local.Item1].Where(p => p.Item1 == local.Item2).FirstOrDefault().Item2;
+                            prob = gsm.SiteSpeciLocalProb[local.SiteIndex].Where(p => p.Item1 == local.ModId).FirstOrDefault().Item2;
                         }
 
 
                         if (!localizedGlycan.ContainsKey(proPosId))
                         {
-                            GlycoProteinParsimony gpp = new GlycoProteinParsimony(gsm.Accession, proteinPos, gsm.BaseSequence[local.Item1-2], local.Item3, gsm.FdrInfo.QValue, gsm.LocalizationLevel, prob);
+                            GlycoProteinParsimony gpp = new GlycoProteinParsimony(gsm.Accession, proteinPos, gsm.BaseSequence[local.SiteIndex -2], local.Confident, gsm.FdrInfo.QValue, gsm.LocalizationLevel, prob);
                             localizedGlycan.Add(proPosId, gpp);
                         }
                         else
                         {
-                            bool islocalized = (local.Item3 || localizedGlycan[proPosId].IsLocalized);
+                            bool islocalized = (local.Confident || localizedGlycan[proPosId].IsLocalized);
                             double minQValue = localizedGlycan[proPosId].MinQValue > gsm.FdrInfo.QValue ? gsm.FdrInfo.QValue : localizedGlycan[proPosId].MinQValue;
                             double maxProb = localizedGlycan[proPosId].MaxProbability > prob ? localizedGlycan[proPosId].MaxProbability : prob;
                             var localLevel = localizedGlycan[proPosId].BestLocalizeLevel < gsm.LocalizationLevel ? localizedGlycan[proPosId].BestLocalizeLevel : gsm.LocalizationLevel;

--- a/MetaMorpheus/Test/TestOGlyco.cs
+++ b/MetaMorpheus/Test/TestOGlyco.cs
@@ -483,8 +483,8 @@ namespace Test
 
             //Get localized Route
             var local = LocalizationGraph.GetLocalizedPath(localizationGraph, allPaths.First());
-            Assert.That(Enumerable.SequenceEqual(local.Mods.Select(v=>v.Item1), new List<int>{ 2, 3, 10}));
-            Assert.That(Enumerable.SequenceEqual(local.Mods.Select(v => v.Item2), new List<int> { 3, 3, 0 }));
+            Assert.That(Enumerable.SequenceEqual(local.ModSitePairs.Select(v=>v.SiteIndex), new List<int>{ 2, 3, 10}));
+            Assert.That(Enumerable.SequenceEqual(local.ModSitePairs.Select(v => v.ModId), new List<int> { 3, 3, 0 }));
 
 
             //Get all paths, calculate PScore and calculate position probability. 
@@ -569,8 +569,8 @@ namespace Test
             var local = LocalizationGraph.GetLocalizedPath(localizationGraph, allPaths.First());
             //There is only one path, [4,1] means in position 4 with glycan 1
 
-            Assert.That(Enumerable.SequenceEqual(local.Mods.Select(p=>p.Item1), new List<int> { 4}));
-            Assert.That(Enumerable.SequenceEqual(local.Mods.Select(p => p.Item2), new List<int> { 1 }));
+            Assert.That(Enumerable.SequenceEqual(local.ModSitePairs.Select(p=>p.SiteIndex), new List<int> { 4}));
+            Assert.That(Enumerable.SequenceEqual(local.ModSitePairs.Select(p => p.ModId), new List<int> { 1 }));
         }
 
         [Test]
@@ -1088,7 +1088,7 @@ namespace Test
 
             var route = LocalizationGraph.GetLocalizedPath(localizationGraph, allPaths.First());
 
-            Assert.That(route.Mods.First().Item3);
+            Assert.That(route.ModSitePairs.First().HasMs2Spectrum);
         }
 
         [Test]


### PR DESCRIPTION
In the past, glycoSearch used the tuple <int, int, bool> to represent the Mod-Site pair; however, that is not readable for the reviewer.
In this PR, I created a new class to store the information, which can be friendly for future maintenance.


**Mods (Mod-SitePair)**: Tuple<int, int, bool> index of modification in ModBox, amino acid index in the peptide, and has MS2 peaks for this pair.
**LocalizedGlycan**: Tuple<int, int, bool>index of modification in ModBox, amino acid index in the peptide, and confidence for this pair hypothesis.

-----------------------------------------------------------------------------------------------------------------------------------------------updated

**ModSitePair**
- SiteIndex: The index of the site in the peptide sequence
- ModId: The ID of the modification, which corresponds to its index in the modBox
- HasMs2Spectrum: Indicates whether the MS2 spectrum exists for this modification at the site
- Confident: Indicates whether the modification is confidently localized at the site.
<img width="1816" height="1129" alt="Route" src="https://github.com/user-attachments/assets/c7c79151-06a4-4b70-9d90-42a0446bbfdd" />

