### PR TITLE
Chimera count now is set in PEP

### DIFF
--- a/MetaMorpheus/EngineLayer/FdrAnalysis/PEPAnalysisEngine.cs
+++ b/MetaMorpheus/EngineLayer/FdrAnalysis/PEPAnalysisEngine.cs
@@ -195,6 +195,10 @@ namespace EngineLayer
                 FileSpecificTimeDependantHydrophobicityAverageAndDeviation_modified = ComputeHydrophobicityValues(trainingData,  true);
                 FileSpecificTimeDependantHydrophobicityAverageAndDeviation_CZE = ComputeMobilityValues(trainingData);
             }
+            if (trainingVariables.Contains("ChimeraCount"))
+            {
+                chimeraCountDictionary = trainingData.GroupBy(p => p.ChimeraIdString).ToDictionary(g => g.Key, g => g.Count());
+            }
         }
 
         public static List<int>[] GetPeptideGroupIndices(List<SpectralMatchGroup> peptides, int numGroups)

--- a/MetaMorpheus/EngineLayer/SpectralMatch.cs
+++ b/MetaMorpheus/EngineLayer/SpectralMatch.cs
@@ -531,21 +531,13 @@ namespace EngineLayer
         {
             if (matchedFragments != null && matchedFragments.Count != 0)
             {
-                List<int> nIons = matchedFragments.Where(f => f.NeutralTheoreticalProduct.Terminus is FragmentationTerminus.N or FragmentationTerminus.FivePrime).Select(f => f.NeutralTheoreticalProduct.FragmentNumber).ToList();
-                List<int> cIons = matchedFragments.Where(f => f.NeutralTheoreticalProduct.Terminus is FragmentationTerminus.C or FragmentationTerminus.ThreePrime).Select(f => (peptide.BaseSequence.Length - f.NeutralTheoreticalProduct.FragmentNumber)).ToList();
-                if (nIons.Any() && cIons.Any())
-                {
-                    return nIons.Intersect(cIons).Count();
-                }
-                else
-                {
-                    return 0;
-                }
+                var nIons = matchedFragments.Where(f => f.NeutralTheoreticalProduct.Terminus is FragmentationTerminus.N or FragmentationTerminus.FivePrime).Select(f => f.NeutralTheoreticalProduct.ResiduePosition);
+                var cIons = matchedFragments.Where(f => f.NeutralTheoreticalProduct.Terminus is FragmentationTerminus.C or FragmentationTerminus.ThreePrime).Select(f => peptide.BaseSequence.Length - f.NeutralTheoreticalProduct.ResiduePosition);
+
+                return nIons.Intersect(cIons).Count();
             }
-            else
-            {
-                return 0;
-            }
+
+            return 0;
         }
 
         /// <summary>


### PR DESCRIPTION
The count of chimeras per scan is a useful PEP feature for top down. We never populated the dictionary which was used to set this field, now we do. 