### PR TITLE
Test Class implements IEquatable

### DIFF
--- a/MetaMorpheus/Test/ParameterTest.cs
+++ b/MetaMorpheus/Test/ParameterTest.cs
@@ -12,6 +12,7 @@ using Omics.Digestion;
 using Omics.Fragmentation.Peptide;
 using TaskLayer;
 using Transcriptomics.Digestion;
+using System;
 
 namespace Test
 {
@@ -335,7 +336,7 @@ namespace Test
             Assert.Throws<MetaMorpheusException>(() => new FileSpecificParameters(fileSpecificTomlBad));
         }
 
-        class BadDigestionParams : IDigestionParams
+        class BadDigestionParams : IDigestionParams, IEquatable<IDigestionParams>
         {
             public int MaxMissedCleavages { get; set; }
             public int MinLength { get; set; }
@@ -346,6 +347,32 @@ namespace Test
             public FragmentationTerminus FragmentationTerminus { get; }
             public CleavageSpecificity SearchModeType { get; }
             public IDigestionParams Clone(FragmentationTerminus? newTerminus = null) => this;
+
+            private bool Equals(BadDigestionParams other)
+            {
+                return MaxMissedCleavages == other.MaxMissedCleavages && MinLength == other.MinLength && MaxLength == other.MaxLength && MaxModificationIsoforms == other.MaxModificationIsoforms && MaxMods == other.MaxMods && DigestionAgent.Equals(other.DigestionAgent) && FragmentationTerminus == other.FragmentationTerminus && SearchModeType == other.SearchModeType;
+            }
+
+            public bool Equals(IDigestionParams other)
+            {
+                if (other is null) return false;
+                if (ReferenceEquals(this, other)) return true;
+                if (other.GetType() != GetType()) return false;
+                return Equals((BadDigestionParams)other);
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (obj is null) return false;
+                if (ReferenceEquals(this, obj)) return true;
+                if (obj.GetType() != GetType()) return false;
+                return Equals((BadDigestionParams)obj);
+            }
+
+            public override int GetHashCode()
+            {
+                return HashCode.Combine(MaxMissedCleavages, MinLength, MaxLength, MaxModificationIsoforms, MaxMods, DigestionAgent, (int)FragmentationTerminus, (int)SearchModeType);
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request enhances the `BadDigestionParams` test class by implementing proper equality and hashing logic, which is important for reliable unit testing and object comparisons. Additionally, a missing `System` namespace import was added.

This is needed to make [MzLib PR #1055](https://github.com/smith-chem-wisc/mzLib/pull/1055) pass integration tests. 

### Improvements to test class functionality

* Implemented `IEquatable<IDigestionParams>` on `BadDigestionParams` and added `Equals` and `GetHashCode` overrides to support value-based comparisons in tests. [[1]](diffhunk://#diff-b75ff0f5096d342d4cfaf0311a58c46509ea78f5d2abad2e60b7453610267ab7L338-R339) [[2]](diffhunk://#diff-b75ff0f5096d342d4cfaf0311a58c46509ea78f5d2abad2e60b7453610267ab7R350-R375)

### Code maintenance

* Added the missing `System` namespace import to `ParameterTest.cs` to support the new equality and hashing logic.