### PR TITLE
Updates MetaMorpheus to consume mzLib 1.0.578

### DIFF
--- a/MetaMorpheus/CMD/CMD.csproj
+++ b/MetaMorpheus/CMD/CMD.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.577" />
+    <PackageReference Include="mzLib" Version="1.0.578" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.118" />

--- a/MetaMorpheus/CMD/Properties/launchSettings.json
+++ b/MetaMorpheus/CMD/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "profiles": {
+    "CMD": {
+      "commandName": "Project"
+    },
+    "WSL": {
+      "commandName": "WSL2",
+      "distributionName": ""
+    }
+  }
+}

--- a/MetaMorpheus/EngineLayer/EngineLayer.csproj
+++ b/MetaMorpheus/EngineLayer/EngineLayer.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.577" />
+    <PackageReference Include="mzLib" Version="1.0.578" />
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/MetaMorpheus/EngineLayer/FdrAnalysis/PEPAnalysisEngine.cs
+++ b/MetaMorpheus/EngineLayer/FdrAnalysis/PEPAnalysisEngine.cs
@@ -712,7 +712,7 @@ namespace EngineLayer
                         }
                         fullSequences.Add(bestMatch.SpecificBioPolymer.FullSequence);
 
-                        double predictedHydrophobicity = bestMatch.SpecificBioPolymer is PeptideWithSetModifications pep ? predictor.PredictRetentionTime(pep, out _) ?? 0 : 0;
+                        double predictedHydrophobicity = bestMatch.SpecificBioPolymer is PeptideWithSetModifications pep ? predictor.PredictRetentionTimeEquivalent(pep, out _) ?? 0 : 0;
 
                         //here i'm grouping this in 2 minute increments becuase there are cases where you get too few data points to get a good standard deviation an average. This is for stability.
                         int possibleKey = (int)(2 * Math.Round(psm.ScanRetentionTime / 2d, 0));
@@ -911,7 +911,7 @@ namespace EngineLayer
                 int time = (int)(2 * Math.Round(psm.ScanRetentionTime / 2d, 0));
                 if (d[Path.GetFileName(psm.FullFilePath)].Keys.Contains(time))
                 {
-                    double predictedHydrophobicity = Peptide is PeptideWithSetModifications pep ? predictor.PredictRetentionTime(pep, out _) ?? 0 : 0;
+                    double predictedHydrophobicity = Peptide is PeptideWithSetModifications pep ? predictor.PredictRetentionTimeEquivalent(pep, out _) ?? 0 : 0;
 
                     hydrophobicityZscore = Math.Abs(d[Path.GetFileName(psm.FullFilePath)][time].Item1 - predictedHydrophobicity) / d[Path.GetFileName(psm.FullFilePath)][time].Item2;
                 }

--- a/MetaMorpheus/EngineLayer/GlobalVariables.cs
+++ b/MetaMorpheus/EngineLayer/GlobalVariables.cs
@@ -428,8 +428,8 @@ namespace EngineLayer
                 // no error thrown if multiple mods with this ID are present - just pick one
             }
             ProteaseMods = ModificationLoader.ReadModsFromFile(Path.Combine(DataDir, @"Mods", @"ProteaseMods.txt"), out var errors).ToList();
-            ProteaseDictionary.Dictionary = ProteaseDictionary.LoadProteaseDictionary(Path.Combine(DataDir, @"ProteolyticDigestion", @"proteases.tsv"), ProteaseMods);
-            RnaseDictionary.Dictionary = RnaseDictionary.LoadRnaseDictionary(Path.Combine(DataDir, @"Digestion", @"rnases.tsv"));
+            ProteaseDictionary.LoadAndMergeCustomProteases(Path.Combine(DataDir, @"ProteolyticDigestion", @"proteases.tsv"), ProteaseMods);
+            RnaseDictionary.LoadAndMergeCustomRnases(Path.Combine(DataDir, @"Digestion", @"rnases.tsv"));
         }
 
         private static void LoadRnaModifications()

--- a/MetaMorpheus/GUI/GUI.csproj
+++ b/MetaMorpheus/GUI/GUI.csproj
@@ -63,7 +63,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.577" />
+    <PackageReference Include="mzLib" Version="1.0.578" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0" />

--- a/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
+++ b/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="itext7" Version="8.0.5" />
     <PackageReference Include="itext7.bouncy-castle-adapter" Version="8.0.5" />
-    <PackageReference Include="mzLib" Version="1.0.577" />
+    <PackageReference Include="mzLib" Version="1.0.578" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.0.0" />
     <PackageReference Include="Svg" Version="3.4.7" />
   </ItemGroup>

--- a/MetaMorpheus/TaskLayer/TaskLayer.csproj
+++ b/MetaMorpheus/TaskLayer/TaskLayer.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.577" />
+    <PackageReference Include="mzLib" Version="1.0.578" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />

--- a/MetaMorpheus/Test/AddCompIonsTest.cs
+++ b/MetaMorpheus/Test/AddCompIonsTest.cs
@@ -39,7 +39,7 @@ namespace Test
 
             List<DigestionMotif> motifs = new List<DigestionMotif> { new DigestionMotif("K", null, 1, null) };
             Protease protease = new Protease("Custom Protease3", CleavageSpecificity.Full, null, null, motifs);
-            ProteaseDictionary.Dictionary.Add(protease.Name, protease);
+            ProteaseDictionary.Dictionary[protease.Name] = protease;
 
             CommonParameters CommonParameters = new CommonParameters(
                 digestionParams: new DigestionParams(protease: protease.Name, maxMissedCleavages: 0, minPeptideLength: 1),

--- a/MetaMorpheus/Test/MatchIonsOfAllCharges.cs
+++ b/MetaMorpheus/Test/MatchIonsOfAllCharges.cs
@@ -106,7 +106,7 @@ namespace Test
 
             List<DigestionMotif> motifs = new List<DigestionMotif> { new DigestionMotif("K", null, 1, null) };
             Protease protease = new Protease("Custom Protease3", CleavageSpecificity.Full, null, null, motifs);
-            ProteaseDictionary.Dictionary.Add(protease.Name, protease);
+            ProteaseDictionary.Dictionary[protease.Name] = protease;
 
             CommonParameters CommonParameters1 = new CommonParameters(
                 digestionParams: new DigestionParams(protease: protease.Name, maxMissedCleavages: 0, minPeptideLength: 1),

--- a/MetaMorpheus/Test/Test.csproj
+++ b/MetaMorpheus/Test/Test.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.577" />
+    <PackageReference Include="mzLib" Version="1.0.578" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />


### PR DESCRIPTION
  Updates MetaMorpheus to consume mzLib 1.0.578. Two upstream API surfaces shifted and broke compilation in
  `EngineLayer`; one test had to be made order-independent because the new dictionary-loading API no longer resets
  between fixtures.

  ### Production code

  **`EngineLayer/GlobalVariables.cs`** — `ProteaseDictionary.Dictionary` and `RnaseDictionary.Dictionary` became
  read-only (`{ get; private set; }`) in mzLib 1.0.578. The dictionaries are now seeded from an embedded resource at
  startup and extended via merge calls instead of full replacement. Migrated:

  - `ProteaseDictionary.Dictionary = LoadProteaseDictionary(path, mods)` →
  `ProteaseDictionary.LoadAndMergeCustomProteases(path, mods)`
  - `RnaseDictionary.Dictionary = LoadRnaseDictionary(path)` → `RnaseDictionary.LoadAndMergeCustomRnases(path)`

  Both new methods return a `CustomDigestionAgentLoadResult` describing what was added/collided. We discard it for now
  since the startup flow doesn't surface that info today; worth capturing later if startup logging of custom-agent
  merges is desired.

  **`EngineLayer/FdrAnalysis/PEPAnalysisEngine.cs`** — `IRetentionTimePredictor.PredictRetentionTime` was renamed
  `PredictRetentionTimeEquivalent` as part of the unified predictor interface from mzLib PR #1046. Two call sites
  (`ComputeHydrophobicities`, `GetRetentionTimeEquivalentZscore`) updated. Signature is otherwise identical; behavior
  unchanged.

  ### Test code

  **`Test/MatchIonsOfAllCharges.cs`** and **`Test/AddCompIonsTest.cs`** — both files register a protease named `"Custom
  Protease3"` via `ProteaseDictionary.Dictionary.Add(...)`. With the new merge-based loader the global dictionary
  persists across fixtures, so whichever test runs second hits `ArgumentException: An item with the same key has already
   been added`. Switched both to indexer-set (`Dictionary[name] = protease`) so the registration is idempotent and
  order-independent. Other `.Add(...)` call sites in the suite use unique custom-protease names and are not actively
  broken; left as-is to keep this commit surgical.

  ### Package references

  - `mzLib` package reference bumped to `1.0.578` across `CMD`, `EngineLayer`, `GUI`, `GuiFunctions`, `TaskLayer`,
  `Test`.

  ## Test plan

  - [x] `dotnet build MetaMorpheus.sln -c Release` → 0 errors
  - [x] `dotnet test Test/Test.csproj -c Release --filter
  "FullyQualifiedName~TestMatchIonsOfAllChargesBottomUp|FullyQualifiedName~AddCompIonsTest"` → 8 passed
  - [x] Full suite via discovery script: 1438 tests, 0 failed
  - [x] Pre-merge: rerun the full suite one more time without `--no-restore` to confirm a fresh restore + build still
  succeeds end-to-end

  ## Notes

  - The `LoadAndMergeCustom*` API merges custom entries into the embedded-resource-seeded dictionary atomically and
  reports collisions via the returned `CustomDigestionAgentLoadResult`. If any downstream caller wants to know which
  custom proteases/rnases were added vs. collided at startup, capture that result and surface it through the existing
  logging pipeline.
  - This PR parallels the prior `chronologerInPep` upgrade for mzLib 9.9.4 — same migration patterns, same test failure,
   same fix shape. The only new piece is the predictor-method rename, which `chronologerInPep` didn't touch.