### PR TITLE
Bump mzLib to 1.0.579

### DIFF
--- a/MetaMorpheus/CMD/CMD.csproj
+++ b/MetaMorpheus/CMD/CMD.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.578" />
+    <PackageReference Include="mzLib" Version="1.0.579" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.118" />

--- a/MetaMorpheus/EngineLayer/EngineLayer.csproj
+++ b/MetaMorpheus/EngineLayer/EngineLayer.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.578" />
+    <PackageReference Include="mzLib" Version="1.0.579" />
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/MetaMorpheus/GUI/GUI.csproj
+++ b/MetaMorpheus/GUI/GUI.csproj
@@ -63,7 +63,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.578" />
+    <PackageReference Include="mzLib" Version="1.0.579" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0" />

--- a/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
+++ b/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="itext7" Version="8.0.5" />
     <PackageReference Include="itext7.bouncy-castle-adapter" Version="8.0.5" />
-    <PackageReference Include="mzLib" Version="1.0.578" />
+    <PackageReference Include="mzLib" Version="1.0.579" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.0.0" />
     <PackageReference Include="Svg" Version="3.4.7" />
   </ItemGroup>

--- a/MetaMorpheus/TaskLayer/TaskLayer.csproj
+++ b/MetaMorpheus/TaskLayer/TaskLayer.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.578" />
+    <PackageReference Include="mzLib" Version="1.0.579" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />

--- a/MetaMorpheus/Test/Test.csproj
+++ b/MetaMorpheus/Test/Test.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.578" />
+    <PackageReference Include="mzLib" Version="1.0.579" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />


### PR DESCRIPTION
Bumps mzLib `PackageReference` from **1.0.578** to **1.0.579** across `CMD`, `EngineLayer`, `GUI`, `GuiFunctions`, `TaskLayer`, and `Test`. The full mzLib 1.0.579 release notes are reproduced below ([source](https://github.com/smith-chem-wisc/mzLib/releases/tag/1.0.579)).

---

# mzLib 1.0.579 — Release Notes

**Release date:** May 2026
**Source range:** `1.0.578`..`1.0.579` (10 merged PRs)
**Contributors:** @nbollis, @trishorts, @pcarvalho75, @dependabot

---

## New Features

### Generic Deconvolution Scoring for IsotopicEnvelope (#1054)

Adds a method-agnostic quality score in [0, 1] for deconvoluted isotopic envelopes. The score is computed from four features — cosine similarity, ppm error, peak completeness, and intensity-ratio consistency — using only the envelope's peak list and an Averagine model, making it comparable across Classic, IsoDec, and future deconvolution algorithms by construction.

New API surface: `EnvelopeScoreFeatures` struct, `DeconvolutionScorer` static class, `Deconvoluter.DeconvoluteWithGenericScoring` overloads, and `IsotopicEnvelopeExtensions.GetOrComputeGenericScore`. Existing `Score` semantics unchanged; `GenericScore` is purely additive. Logistic weights are flagged as provisional and recommend recalibration against labelled data.

### Spectrum-Aware Generic Deconvolution Scoring (#1056)

Extends the generic scorer with two spectrum-aware features — local signal-to-noise ratio and competing-peak ratio — available when the original `MzSpectrum` is still in hand. The envelope-only path is preserved verbatim; the two scoring philosophies are not directly comparable and should not share a threshold.

`EnvelopeScoreFeatures` gains `LocalSignalToNoise`, `CompetingPeakRatio`, and `HasSpectrumFeatures`. `DeconvolutionScorer` gains `ComputeFeatures(env, model, spectrum)`, `ComputeScoreWithSpectrumContext`, and `ScoreEnvelope(env, model, spectrum)`. `DeconvoluteWithGenericScoring(MzSpectrum, …)` automatically upgrades to the spectrum-aware path. 15 new tests.

### Per-peak charge array support in mzML I/O (#1060)

Adds optional per-peak charge state arrays to `MsDataScan`, encoded as PSI-MS `MS:1000516` "charge array" in a third `<binaryDataArray>` per spectrum (32-bit float, no compression). The constructor parameter defaults to `null`; existing callers and files without charge arrays are unaffected. Contributed by @pcarvalho75 — motivated by YADA 3.1 deisotoping output.

### Protease: subtilisin (#1061)

Adds `subtilisin|p` to the protease dictionary: cleaves after N, S, L, K, I, D, Y, V, G, F, T, E, Q, A, R, except when followed by proline. Includes unit test coverage.

### FromFile deconvolution algorithm (#1064)

New `FromFileDeconvolutionAlgorithm` that loads external feature files (FlashDeconv/TopFD `.ms1.feature`, Dinosaur `.feature.tsv`) and yields synthetic `IsotopicEnvelope` objects filtered by m/z + RT + charge range. Plugs into the existing `Deconvoluter` factory via a virtual `DeconvolutionParameters.CreateAlgorithm()` hook. Features are sorted by m/z with binary-search lookup (O(log N + k) per query). `ISingleChargeMs1Feature` moves to `MassSpectrometry` (no external consumers affected). 40 new tests.

### Multiple Decon (#1068)

Wraps multiple deconvolution algorithms for combined use. Provides infrastructure for running Classic and IsoDec (or others) together on the same spectrum, with room for a future `ConsensusDecon` that filters and reconciles between algorithms.

---

## Enhancements

### Spectral Library & Similarity Quality of Life (#1059)

`LibrarySpectrum` now implements `IEquatable`. New overloads in `SpectralSimilarity` allow running similarity directly from a `LibrarySpectrum`. A similarity metric enum and batch metric methods are added. No functional behavior changes — purely API ergonomics.

### PSM Reading robustness (#1066)

Fixes a crash when reading custom PSM files where name or gene fields are empty during ambiguous PSM splitting. The parser handles missing values gracefully.

### TopFD column name compatibility (#1067)

`Ms1Feature` now accepts both older FlashDeconv/TopFD-v1.6.2 column schemas and newer TopFD column names, via `[Name]` aliases and `[Optional]` fields. The writer continues to emit canonical older column names. `GetSingleChargeFeatures()` works identically across both schemas.

---

## Bug Fixes

- **PSM Reading crash on empty fields** — The PSM parser no longer throws when name or gene fields are blank during ambiguous PSM splitting (#1066).

---

## Dependencies

- **OpenMcdf 2.3.1 → 3.1.3** — Major version upgrade bringing a rewritten .NET-conventional API, 16 TB file support, transactions, consolidation, nullable attributes, multi-targeting (netstandard2.0 + net8.0+), and extensive validation/robustness fixes (#1052). ⚠️ Breaking API change from 2.x.

---

### Unified IRetentionTimePredictor with batch method (#1046)

Adds a default `PredictRetentionTimes` batch method to `IRetentionTimePredictor` that predicts retention times for multiple peptides in a single call. `RetentionTimeModel` (Koina/Prosit abstract base) now implements `IRetentionTimePredictor`, consolidating both local predictors (Chronologer) and remote predictors (Koina/Prosit) under a single interface. MetaMorpheus can consume `IRetentionTimePredictor` directly without an adapter layer. Chronologer inherits the default batch method; Koina overrides it with its own batch implementation via `RunInferenceAsync`. No existing method signatures were modified — purely additive. 10 new interface-contract tests.

## Thanks

Thanks to @pcarvalho75 for the charge array contribution (#1060)!

---

## Test plan

- [x] `dotnet restore MetaMorpheus.sln` — succeeds
- [x] `dotnet build MetaMorpheus.sln` — succeeds, 0 errors (93 pre-existing warnings)
- [x] `dotnet test Test/Test.csproj` — **1446 passed, 0 failed, 1 skipped** (1447 total, 16.4 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
