### PR TITLE
Enable user-supplied custom glycan databases and monosaccharides

### DIFF
--- a/MetaMorpheus/EngineLayer/EngineLayer.csproj
+++ b/MetaMorpheus/EngineLayer/EngineLayer.csproj
@@ -73,7 +73,13 @@
     <None Update="Glycan_Mods\NGlycan\NGlycan.gdb">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Glycan_Mods\NGlycan\NGlycan_Custom.gdb">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Glycan_Mods\OGlycan\OGlycan.gdb">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Glycan_Mods\OGlycan\OGlycan_Custom.gdb">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Glycan_Mods\OGlycan\OGlycan_withIsobaric.gdb">

--- a/MetaMorpheus/EngineLayer/EngineLayer.csproj
+++ b/MetaMorpheus/EngineLayer/EngineLayer.csproj
@@ -70,6 +70,9 @@
     <None Update="Data\unimod.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Glycan_Mods\MonosaccharidesCustom.tsv">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Glycan_Mods\NGlycan\NGlycan.gdb">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/MetaMorpheus/EngineLayer/GlobalVariables.cs
+++ b/MetaMorpheus/EngineLayer/GlobalVariables.cs
@@ -467,6 +467,12 @@ namespace EngineLayer
 
         private static void LoadGlycans()
         {
+            // Custom monosaccharides must be registered FIRST so any custom tokens are recognized
+            // by the glycan-database parsers below. The file is optional; if it does not exist,
+            // LoadCustomMonosaccharides is a no-op.
+            string customMonosaccharidePath = Path.Combine(DataDir, @"Glycan_Mods", "MonosaccharidesCustom.tsv");
+            GlycanDatabase.LoadCustomMonosaccharides(customMonosaccharidePath);
+
             OGlycanDatabasePaths = new List<string>();
             NGlycanDatabasePaths = new List<string>();
 

--- a/MetaMorpheus/EngineLayer/Glycan_Mods/MonosaccharidesCustom.tsv
+++ b/MetaMorpheus/EngineLayer/Glycan_Mods/MonosaccharidesCustom.tsv
@@ -1,0 +1,85 @@
+# ============================================================================
+# CUSTOM MONOSACCHARIDE DICTIONARY
+# ============================================================================
+# This file lets you add monosaccharides that MetaMorpheus does not ship with,
+# so they can be used inside custom glycan database entries
+# (NGlycan_Custom.gdb / OGlycan_Custom.gdb, or any user-supplied .gdb file).
+#
+# Definitions added here are shared across BOTH O-glycan and N-glycan searches.
+# They are loaded once at startup, BEFORE any glycan database is parsed.
+#
+# Lines starting with '#' are comments and are ignored by the parser.
+# Blank lines are also ignored. Indentation before '#' is allowed.
+#
+# ============================================================================
+# FILE FORMAT (tab-separated)
+# ============================================================================
+# Each data line defines ONE custom monosaccharide. Columns:
+#
+#   1. Name                Required. Unique. Must not collide with a built-in
+#                          (Hex, HexNAc, NeuAc, NeuGc, Fuc, dHex, Phospho,
+#                          Sulfo, Na, Ac, Xylose, Kdn) or with another entry.
+#                          Use this name in composition-format glycan files,
+#                          e.g.  HexNAc(2)Hex(5)HexA(1)
+#
+#   2. SingleCharCode      Required. Exactly one ASCII letter (A-Z or a-z).
+#                          Unique. Must not collide with a built-in code
+#                          (H, N, A, G, F, P, S, Y, C, X, K) or with another
+#                          custom entry. Use this code in structure-format
+#                          glycan files, e.g.  (N(H)(U))
+#
+#   3. MonoisotopicMass    Required. The monoisotopic mass in Daltons of the
+#                          monosaccharide RESIDUE (the form integrated into
+#                          the glycan chain after water loss). Decimal, e.g.
+#                          176.03209
+#
+#   4. DiagnosticIonMasses Optional. Zero or more diagnostic-ion m/z values
+#                          (in Daltons) that should be added to MetaMorpheus's
+#                          diagnostic-ion set whenever a glycan contains at
+#                          least one of this monosaccharide. Comma-separated,
+#                          no spaces required:
+#                              175.02482,157.01425
+#                          Provide the m/z you would EXPECT TO OBSERVE in the
+#                          spectrum (no hydrogen-mass offset is applied).
+#                          Leave blank or omit the column for no extra
+#                          diagnostic ions.
+#
+#   5. Description         Optional. Free text for human readers. Ignored by
+#                          the parser. Use it to record source, formula, or
+#                          a note about the residue.
+#
+# A column-header row beginning with "Name" followed by a tab is recognized
+# and skipped, so the template line below the next banner is safe to keep.
+#
+# ============================================================================
+# BUILT-IN MONOSACCHARIDES (do NOT redefine these)
+# ============================================================================
+#   Name      Code   Monoisotopic mass (Da)   Notes
+#   --------  ----   ----------------------   -----------------------------
+#   Hex       H      162.05282                Hexose (Gal, Glc, Man, ...)
+#   HexNAc    N      203.07937                N-Acetylhexosamine (GlcNAc, GalNAc)
+#   NeuAc     A      291.09542                N-Acetylneuraminate (Neu5Ac)
+#   NeuGc     G      307.09033                N-Glycolylneuraminate (Neu5Gc)
+#   Fuc       F      146.05791                Fucose / dHex
+#   Phospho   P       79.96633                Phosphate
+#   Sulfo     S       79.95681                Sulfate
+#   Na        Y       22.98977                Sodium adduct
+#   Ac        C       42.01056                Acetyl
+#   Xylose    X      150.05282                Xylose
+#   Kdn       K      250.06897                KDN (deaminoneuraminate)
+#
+# Attempting to register a custom entry whose Name OR SingleCharCode collides
+# with any built-in (or any earlier line in this file) is an error and the
+# file will fail to load.
+#
+# ============================================================================
+# EXAMPLES (remove the leading '#' to enable any of these)
+# ============================================================================
+# HexA	U	176.03209	175.02482,157.01425	Hexuronic acid (GlcA, GalA)
+# Pent	T	132.04226		Generic pentose (e.g. Ara, Rib not covered by Xylose)
+# Me	M	14.01565		Methyl group as a residue contribution
+#
+# ============================================================================
+# CUSTOM DEFINITIONS (add your monosaccharides below this line)
+# ============================================================================
+Name	SingleCharCode	MonoisotopicMass	DiagnosticIonMasses	Description

--- a/MetaMorpheus/EngineLayer/Glycan_Mods/NGlycan/NGlycan.gdb
+++ b/MetaMorpheus/EngineLayer/Glycan_Mods/NGlycan/NGlycan.gdb
@@ -1,3 +1,85 @@
+# ============================================================================
+# GLYCAN DATABASE FILE (composition format)
+# ============================================================================
+# Lines starting with '#' are comments and are ignored by the parser.
+# Blank lines are also ignored. Indentation before '#' is allowed.
+#
+# DISCOVERY
+# ----------------------------------------------------------------------------
+# MetaMorpheus scans the Glycan_Mods/NGlycan/ folder (inside the install
+# directory) at startup. Every file in that folder is offered in the
+# Glyco Search task's "N-Glycan Database" dropdown by its filename. Pick
+# this file there to search against it.
+#
+# ============================================================================
+# LINE FORMAT (composition)
+# ============================================================================
+# One glycan per data line. Only the text before the first TAB is parsed,
+# so additional tab-separated columns (e.g. a short name or a mass) are
+# tolerated and ignored.
+#
+# Syntax:
+#     <Monosaccharide>(<count>)<Monosaccharide>(<count>)...
+#
+# Order does not matter. Monosaccharides with zero count are omitted.
+#
+# Examples:
+#     HexNAc(2)Hex(5)                       core mannose-5
+#     HexNAc(2)Hex(5)NeuAc(1)               sialylated
+#     HexNAc(4)Hex(5)NeuAc(2)Fuc(1)         biantennary, fucosylated
+#
+# An alternative STRUCTURE format (example: (N(H(A))(N(H(A))(F))) ) is
+# also accepted in glycan files, but EVERY line of a single file must use
+# the SAME format. The parser auto-detects format from the first
+# non-comment, non-blank line. Do not mix formats within one file.
+#
+# ============================================================================
+# RECOGNIZED MONOSACCHARIDE TOKENS
+# ============================================================================
+#   Composition name    Single-char code (used in structure format)
+#   ------------------  -------------------------------------------
+#   Hex                 H
+#   HexNAc              N
+#   NeuAc               A
+#   NeuGc               G
+#   Fuc (or dHex)       F
+#   Phospho             P
+#   Sulfo               S
+#   Na                  Y
+#   Ac                  C
+#   Xylose              X
+#   Kdn                 K
+#
+# Any token outside this set will cause a load error.
+#
+# ============================================================================
+# AUTOMATIC EXPANSION (you do not write these out yourself)
+# ============================================================================
+# For each composition listed below, MetaMorpheus automatically:
+#   - Generates ONE entry targeting motif Asn-X-Ser (Nxs) and a SECOND
+#     entry targeting Asn-X-Thr (Nxt). Do not duplicate rows for the two
+#     motifs.
+#   - Generates neutral-loss masses, Y-ions, and diagnostic oxonium ions
+#     from the composition. You do NOT need to enumerate fragments.
+#
+# ============================================================================
+# ADDING YOUR OWN CUSTOM GLYCANS
+# ============================================================================
+# Two options:
+#
+#  (a) Append new composition lines below this header. They will be loaded
+#      the next time MetaMorpheus starts.
+#
+#  (b) Create a new file with any name and a .gdb (or .txt) extension in
+#      this same Glycan_Mods/NGlycan/ folder, then restart MetaMorpheus.
+#      It will appear in the Glyco Search task dropdown alongside this
+#      one. Copy this header into your new file so readers know the format.
+#
+# You can use '#' on any line to comment your additions.
+#
+# ============================================================================
+# GLYCAN DEFINITIONS
+# ============================================================================
 HexNAc(1)
 HexNAc(1)Fuc(1)
 HexNAc(2)

--- a/MetaMorpheus/EngineLayer/Glycan_Mods/NGlycan/NGlycan_Custom.gdb
+++ b/MetaMorpheus/EngineLayer/Glycan_Mods/NGlycan/NGlycan_Custom.gdb
@@ -1,0 +1,61 @@
+# ============================================================================
+# CUSTOM N-GLYCAN DATABASE (composition format)
+# ============================================================================
+# This file is a TEMPLATE for users to add their own N-glycan compositions
+# without modifying the built-in NGlycan.gdb. It ships with no glycan rows
+# of its own; only the example rows below (commented out) demonstrate the
+# format.
+#
+# Lines starting with '#' are comments and are ignored by the parser.
+# Blank lines are also ignored. Indentation before '#' is allowed.
+#
+# DISCOVERY
+# ----------------------------------------------------------------------------
+# MetaMorpheus scans the Glycan_Mods/NGlycan/ folder (inside the install
+# directory) at startup. Every file in that folder appears in the Glyco
+# Search task's "N-Glycan Database" dropdown by its filename. Select
+# "NGlycan_Custom.gdb" there to search against the entries you add below.
+#
+# As long as this file has no uncommented data rows it is harmless to
+# leave it selected: the search will simply find no glycans in it.
+#
+# ============================================================================
+# HOW TO ADD A GLYCAN
+# ============================================================================
+# Add one composition per line, below the GLYCAN DEFINITIONS banner.
+#
+# Syntax:
+#     <Monosaccharide>(<count>)<Monosaccharide>(<count>)...
+#
+# Order does not matter. Monosaccharides with zero count are omitted.
+#
+# Recognized monosaccharide names:
+#     Hex, HexNAc, NeuAc, NeuGc, Fuc (or dHex), Phospho, Sulfo,
+#     Na, Ac, Xylose, Kdn
+#
+# Any name outside this set will cause a load error.
+#
+# An alternative STRUCTURE format (example: (N(H(A))(N(H(A))(F))) ) is
+# also accepted, but EVERY line of a single file must use the SAME format.
+# Do not mix formats within one file.
+#
+# ============================================================================
+# AUTOMATIC EXPANSION (you do not write these out yourself)
+# ============================================================================
+# For each composition listed below, MetaMorpheus automatically:
+#   - Generates ONE entry targeting motif Asn-X-Ser (Nxs) and a SECOND
+#     entry targeting Asn-X-Thr (Nxt). Do not duplicate rows for the two
+#     motifs.
+#   - Generates neutral-loss masses, Y-ions, and diagnostic oxonium ions
+#     from the composition. You do NOT need to enumerate fragments.
+#
+# ============================================================================
+# EXAMPLES (remove the leading '#' to enable any of these)
+# ============================================================================
+# HexNAc(2)Hex(5)                       core mannose-5
+# HexNAc(2)Hex(5)NeuAc(1)               sialylated
+# HexNAc(4)Hex(5)NeuAc(2)Fuc(1)         biantennary, fucosylated
+#
+# ============================================================================
+# GLYCAN DEFINITIONS (add your compositions below this line)
+# ============================================================================

--- a/MetaMorpheus/EngineLayer/Glycan_Mods/OGlycan/OGlycan.gdb
+++ b/MetaMorpheus/EngineLayer/Glycan_Mods/OGlycan/OGlycan.gdb
@@ -1,3 +1,85 @@
+# ============================================================================
+# GLYCAN DATABASE FILE (structure format)
+# ============================================================================
+# Lines starting with '#' are comments and are ignored by the parser.
+# Blank lines are also ignored. Indentation before '#' is allowed.
+#
+# DISCOVERY
+# ----------------------------------------------------------------------------
+# MetaMorpheus scans the Glycan_Mods/OGlycan/ folder (inside the install
+# directory) at startup. Every file in that folder is offered in the
+# Glyco Search task's "O-Glycan Database" dropdown by its filename. Pick
+# this file there to search against it.
+#
+# ============================================================================
+# LINE FORMAT (structure)
+# ============================================================================
+# One glycan per data line. The glycan is encoded as a parenthesized
+# linkage tree: each single-character code is a monosaccharide, and
+# parenthesized groups attached to it are its branches.
+#
+# Syntax:
+#     (<root>(<branch>)(<branch>)...)
+#
+# Examples:
+#     (N)                              single GlcNAc
+#     (N(H))                           GlcNAc-Hex linear
+#     (N(H)(N))                        GlcNAc branching to Hex and GlcNAc
+#     (N(H(A)))                        GlcNAc-Hex-NeuAc linear
+#     (N(H(A))(N(H(A))(F)))            biantennary, sialylated, fucosylated
+#
+# An alternative COMPOSITION format (example: HexNAc(2)Hex(5)NeuAc(1) ) is
+# also accepted in glycan files, but EVERY line of a single file must use
+# the SAME format. The parser auto-detects format from the first
+# non-comment, non-blank line. Do not mix formats within one file.
+#
+# ============================================================================
+# RECOGNIZED MONOSACCHARIDE CODES (structure format uses single chars)
+# ============================================================================
+#   Code    Monosaccharide      Composition-format name
+#   ----    -----------------   -----------------------
+#   H       Hexose              Hex
+#   N       N-Acetylhexosamine  HexNAc
+#   A       N-Acetylneuraminate NeuAc
+#   G       N-Glycolylneuraminate NeuGc
+#   F       Fucose              Fuc (or dHex)
+#   P       Phosphate           Phospho
+#   S       Sulfate             Sulfo
+#   Y       Sodium              Na
+#   C       Acetyl              Ac
+#   X       Xylose              Xylose
+#   K       Kdn                 Kdn
+#
+# Any character outside this set will cause a load error or a wrong mass.
+#
+# ============================================================================
+# AUTOMATIC EXPANSION (you do not write these out yourself)
+# ============================================================================
+# For each structure listed below, MetaMorpheus automatically:
+#   - Generates ONE entry targeting Ser (S) and a SECOND entry targeting
+#     Thr (T). Do not duplicate rows for the two motifs.
+#   - Enumerates all sub-tree fragments to produce Y-ion neutral losses,
+#     plus diagnostic oxonium ions from the composition. You do NOT need
+#     to enumerate fragments.
+#
+# ============================================================================
+# ADDING YOUR OWN CUSTOM GLYCANS
+# ============================================================================
+# Two options:
+#
+#  (a) Append new structure lines below this header. They will be loaded
+#      the next time MetaMorpheus starts.
+#
+#  (b) Create a new file with any name and a .gdb (or .txt) extension in
+#      this same Glycan_Mods/OGlycan/ folder, then restart MetaMorpheus.
+#      It will appear in the Glyco Search task dropdown alongside this
+#      one. Copy this header into your new file so readers know the format.
+#
+# You can use '#' on any line to comment your additions.
+#
+# ============================================================================
+# GLYCAN DEFINITIONS
+# ============================================================================
 (N)
 (N(H))
 (N(A))

--- a/MetaMorpheus/EngineLayer/Glycan_Mods/OGlycan/OGlycan_Custom.gdb
+++ b/MetaMorpheus/EngineLayer/Glycan_Mods/OGlycan/OGlycan_Custom.gdb
@@ -1,0 +1,63 @@
+# ============================================================================
+# CUSTOM O-GLYCAN DATABASE (composition format)
+# ============================================================================
+# This file is a TEMPLATE for users to add their own O-glycan compositions
+# without modifying the built-in OGlycan.gdb. It ships with no glycan rows
+# of its own; only the example rows below (commented out) demonstrate the
+# format.
+#
+# Lines starting with '#' are comments and are ignored by the parser.
+# Blank lines are also ignored. Indentation before '#' is allowed.
+#
+# DISCOVERY
+# ----------------------------------------------------------------------------
+# MetaMorpheus scans the Glycan_Mods/OGlycan/ folder (inside the install
+# directory) at startup. Every file in that folder appears in the Glyco
+# Search task's "O-Glycan Database" dropdown by its filename. Select
+# "OGlycan_Custom.gdb" there to search against the entries you add below.
+#
+# As long as this file has no uncommented data rows it is harmless to
+# leave it selected: the search will simply find no glycans in it.
+#
+# ============================================================================
+# HOW TO ADD A GLYCAN
+# ============================================================================
+# Add one composition per line, below the GLYCAN DEFINITIONS banner.
+#
+# Syntax:
+#     <Monosaccharide>(<count>)<Monosaccharide>(<count>)...
+#
+# Order does not matter. Monosaccharides with zero count are omitted.
+#
+# Recognized monosaccharide names:
+#     Hex, HexNAc, NeuAc, NeuGc, Fuc (or dHex), Phospho, Sulfo,
+#     Na, Ac, Xylose, Kdn
+#
+# Any name outside this set will cause a load error.
+#
+# An alternative STRUCTURE format (example: (N(H(A))(N(H(A))(F))) ) is
+# also accepted, but EVERY line of a single file must use the SAME format.
+# Do not mix formats within one file. The built-in OGlycan.gdb is in
+# structure format; this template uses composition because it is easier
+# for non-experts to write.
+#
+# ============================================================================
+# AUTOMATIC EXPANSION (you do not write these out yourself)
+# ============================================================================
+# For each composition listed below, MetaMorpheus automatically:
+#   - Generates ONE entry targeting Ser (S) and a SECOND entry targeting
+#     Thr (T). Do not duplicate rows for the two motifs.
+#   - Generates neutral-loss masses, Y-ions, and diagnostic oxonium ions
+#     from the composition. You do NOT need to enumerate fragments.
+#
+# ============================================================================
+# EXAMPLES (remove the leading '#' to enable any of these)
+# ============================================================================
+# HexNAc(1)                             single GalNAc (Tn antigen)
+# HexNAc(1)Hex(1)                       core-1 (T antigen)
+# HexNAc(1)Hex(1)NeuAc(1)               sialyl-core-1
+# HexNAc(2)Hex(1)                       core-2
+#
+# ============================================================================
+# GLYCAN DEFINITIONS (add your compositions below this line)
+# ============================================================================

--- a/MetaMorpheus/EngineLayer/Glycan_Mods/OGlycan/OGlycan_withIsobaric.gdb
+++ b/MetaMorpheus/EngineLayer/Glycan_Mods/OGlycan/OGlycan_withIsobaric.gdb
@@ -1,3 +1,88 @@
+# ============================================================================
+# GLYCAN DATABASE FILE (structure format, includes Kdn isobaric examples)
+# ============================================================================
+# Lines starting with '#' are comments and are ignored by the parser.
+# Blank lines are also ignored. Indentation before '#' is allowed.
+#
+# DISCOVERY
+# ----------------------------------------------------------------------------
+# MetaMorpheus scans the Glycan_Mods/OGlycan/ folder (inside the install
+# directory) at startup. Every file in that folder is offered in the
+# Glyco Search task's "O-Glycan Database" dropdown by its filename. Pick
+# this file there to search against it.
+#
+# This database differs from OGlycan.gdb by including glycans with Kdn (K)
+# residues that are isobaric with other compositions, useful for testing
+# how the search distinguishes them.
+#
+# ============================================================================
+# LINE FORMAT (structure)
+# ============================================================================
+# One glycan per data line. The glycan is encoded as a parenthesized
+# linkage tree: each single-character code is a monosaccharide, and
+# parenthesized groups attached to it are its branches.
+#
+# Syntax:
+#     (<root>(<branch>)(<branch>)...)
+#
+# Examples:
+#     (N)                              single GlcNAc
+#     (N(H))                           GlcNAc-Hex linear
+#     (N(N(K)))                        GlcNAc-GlcNAc-Kdn
+#     (N(H(A))(N(H(A))(F)))            biantennary, sialylated, fucosylated
+#
+# An alternative COMPOSITION format (example: HexNAc(2)Hex(5)NeuAc(1) ) is
+# also accepted in glycan files, but EVERY line of a single file must use
+# the SAME format. The parser auto-detects format from the first
+# non-comment, non-blank line. Do not mix formats within one file.
+#
+# ============================================================================
+# RECOGNIZED MONOSACCHARIDE CODES (structure format uses single chars)
+# ============================================================================
+#   Code    Monosaccharide      Composition-format name
+#   ----    -----------------   -----------------------
+#   H       Hexose              Hex
+#   N       N-Acetylhexosamine  HexNAc
+#   A       N-Acetylneuraminate NeuAc
+#   G       N-Glycolylneuraminate NeuGc
+#   F       Fucose              Fuc (or dHex)
+#   P       Phosphate           Phospho
+#   S       Sulfate             Sulfo
+#   Y       Sodium              Na
+#   C       Acetyl              Ac
+#   X       Xylose              Xylose
+#   K       Kdn                 Kdn
+#
+# Any character outside this set will cause a load error or a wrong mass.
+#
+# ============================================================================
+# AUTOMATIC EXPANSION (you do not write these out yourself)
+# ============================================================================
+# For each structure listed below, MetaMorpheus automatically:
+#   - Generates ONE entry targeting Ser (S) and a SECOND entry targeting
+#     Thr (T). Do not duplicate rows for the two motifs.
+#   - Enumerates all sub-tree fragments to produce Y-ion neutral losses,
+#     plus diagnostic oxonium ions from the composition. You do NOT need
+#     to enumerate fragments.
+#
+# ============================================================================
+# ADDING YOUR OWN CUSTOM GLYCANS
+# ============================================================================
+# Two options:
+#
+#  (a) Append new structure lines below this header. They will be loaded
+#      the next time MetaMorpheus starts.
+#
+#  (b) Create a new file with any name and a .gdb (or .txt) extension in
+#      this same Glycan_Mods/OGlycan/ folder, then restart MetaMorpheus.
+#      It will appear in the Glyco Search task dropdown alongside this
+#      one. Copy this header into your new file so readers know the format.
+#
+# You can use '#' on any line to comment your additions.
+#
+# ============================================================================
+# GLYCAN DEFINITIONS
+# ============================================================================
 (N)
 (N(H))
 (N(A))

--- a/MetaMorpheus/EngineLayer/GlycoSearch/Glycan.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/Glycan.cs
@@ -178,6 +178,19 @@ namespace EngineLayer
                     diagnosticIons.Add(29008759 - hydrogenAtomMonoisotopicMass);
                     diagnosticIons.Add(30809816 - hydrogenAtomMonoisotopicMass);
                 }
+                // Custom-monosaccharide diagnostic ions: emitted at the value supplied by the user
+                // in MonosaccharidesCustom.tsv (no hydrogen-mass offset is applied; users provide
+                // observed m/z directly).
+                foreach (var kv in _customDiagnosticIonsByIndex)
+                {
+                    if (kv.Key < Kind.Length && Kind[kv.Key] >= 1)
+                    {
+                        foreach (int ion in kv.Value)
+                        {
+                            diagnosticIons.Add(ion);
+                        }
+                    }
+                }
                 return diagnosticIons;
             }
         }
@@ -187,45 +200,121 @@ namespace EngineLayer
         private static readonly int hydrogenAtomMonoisotopicMass =  Convert.ToInt32(PeriodicTable.GetElement("H").PrincipalIsotope.AtomicMass * 1E5);
 
 
-        //Glycan mass dictionary
+        // Master ordered list of monosaccharide slots. Position in this list IS the Kind[] index.
+        // The 11 built-in entries are seeded here; LoadCustomMonosaccharides appends additional
+        // entries at indices 11+. Built-in indices (0..10) are referenced by name in places like
+        // GlycanDiagnosticIons and OGlycanCompositionCombinationChildIons filter rules, so existing
+        // built-in semantics are unchanged by adding customs.
+        //
+        // H: C6O5H10 Hexose, N: C8O5NH13 HexNAc, A: C11O8NH17 Neu5Ac, G: C11H17NO9 Neu5Gc,
+        // F: C6O4H10 Fucose, P: PO3H Phosphate, S: SO3H Sulfo, Y: Na Sodium, C: Acetyl for Neu5Ac,
+        // X: C5H10O5 Xylose, K: Kdn
+        private static readonly List<(string CanonicalName, char Code, int MassScaled)> _builtInKindEntries =
+            new List<(string, char, int)>
+        {
+            ("Hex",     'H', 16205282),
+            ("HexNAc",  'N', 20307937),
+            ("NeuAc",   'A', 29109542),
+            ("NeuGc",   'G', 30709033),
+            ("Fuc",     'F', 14605791),
+            ("Phospho", 'P',  7996633),
+            ("Sulfo",   'S',  7995681),
+            ("Na",      'Y',  2298977),
+            ("Ac",      'C',  4201056),
+            ("Xylose",  'X', 15005282),
+            ("Kdn",     'K', 25006897),
+        };
+
+        // Active list (built-ins + any loaded customs). Length defines Kind[] capacity.
+        private static List<(string CanonicalName, char Code, int MassScaled)> _kindEntries =
+            new List<(string, char, int)>(_builtInKindEntries);
+
+        // Custom monosaccharides' diagnostic ions (int, scaled by 1e5), keyed by Kind[] index.
+        // Emitted by GlycanDiagnosticIons whenever the glycan has count >= 1 at the custom index.
+        private static Dictionary<int, int[]> _customDiagnosticIonsByIndex = new Dictionary<int, int[]>();
+
+        /// <summary>
+        /// Number of monosaccharide slots in the Kind[] array (built-ins + any registered customs).
+        /// </summary>
+        public static int KindCapacity => _kindEntries.Count;
+
         /// <summary>
         /// Dictionary mapping monosaccharide character codes to their integer mass (scaled by 1e5).
+        /// Rebuilt whenever a custom monosaccharide is registered.
         /// </summary>
-        //H: C6O5H10 Hexose, N: C8O5NH13 HexNAc, A: C11O8NH17 Neu5Ac, G: C11H17NO9 Neu5Gc, F: C6O4H10 Fucose, 
-        //P: PO3H Phosphate, S: SO3H Sulfo, Y: Na Sodium, C:Acetyl for Neu5Ac
-        //X: C5H10O5 Xylose
-        private readonly static Dictionary<char, int> CharMassDic = new Dictionary<char, int> {
-            { 'H', 16205282 },
-            { 'N', 20307937 },
-            { 'A', 29109542 },
-            { 'G', 30709033 },
-            { 'F', 14605791 },
-            { 'P', 7996633 },
-            { 'S', 7995681 },
-            { 'Y', 2298977 },
-            { 'C',  4201056 },
-            { 'X', 15005282 },
-            { 'K', 25006897 },
-        };
+        public static Dictionary<char, int> CharMassDic { get; private set; } = BuildCharMassDic();
 
         /// <summary>
         /// Dictionary mapping monosaccharide names to their character code and index in the Kind array.
+        /// Rebuilt whenever a custom monosaccharide is registered. "dHex" is permanently aliased to "Fuc".
         /// </summary>
-        public readonly static Dictionary<string, Tuple<char, int>> NameCharDic = new Dictionary<string, Tuple<char, int>>
+        public static Dictionary<string, Tuple<char, int>> NameCharDic { get; private set; } = BuildNameCharDic();
+
+        private static Dictionary<char, int> BuildCharMassDic()
         {
-            {"Hex", new Tuple<char, int>('H', 0) },
-            {"HexNAc", new Tuple<char, int>('N', 1) },
-            {"NeuAc", new Tuple<char, int>('A', 2) },
-            {"NeuGc", new Tuple<char, int>('G', 3) },
-            {"Fuc",  new Tuple<char, int>('F', 4)},
-            {"dHex", new Tuple<char, int>('F', 4)}, // Treat dHex as Fuc
-            {"Phospho", new Tuple<char, int>('P', 5)},
-            {"Sulfo", new Tuple<char, int>('S', 6) },
-            {"Na", new Tuple<char, int>('Y', 7) },
-            {"Ac", new Tuple<char, int>('C', 8) },
-            {"Xylose", new Tuple<char, int>('X', 9) },
-            {"Kdn", new Tuple<char,int>('K',10)}
-        };
+            var dic = new Dictionary<char, int>(_kindEntries.Count);
+            foreach (var e in _kindEntries)
+            {
+                dic[e.Code] = e.MassScaled;
+            }
+            return dic;
+        }
+
+        private static Dictionary<string, Tuple<char, int>> BuildNameCharDic()
+        {
+            var dic = new Dictionary<string, Tuple<char, int>>(_kindEntries.Count + 1);
+            for (int i = 0; i < _kindEntries.Count; i++)
+            {
+                var e = _kindEntries[i];
+                dic[e.CanonicalName] = Tuple.Create(e.Code, i);
+            }
+            // Preserved built-in alias: dHex -> Fuc (same slot, same code).
+            if (dic.ContainsKey("Fuc"))
+            {
+                dic["dHex"] = dic["Fuc"];
+            }
+            return dic;
+        }
+
+        /// <summary>
+        /// Register a custom monosaccharide. Called by GlycanDatabase.LoadCustomMonosaccharides
+        /// at startup. Appends a new slot at the end of Kind[] (index = KindCapacity-after-add - 1).
+        /// </summary>
+        /// <param name="name">Unique name, must not collide with a built-in or already-registered name.</param>
+        /// <param name="code">Unique single ASCII letter, must not collide with a built-in or already-registered code.</param>
+        /// <param name="massScaled">Monoisotopic mass in Da multiplied by 1e5 (e.g. 176.03209 Da -> 17603209).</param>
+        /// <param name="diagnosticIonsScaled">Optional diagnostic ion m/z values (scaled by 1e5); null or empty for none.</param>
+        public static void RegisterCustomMonosaccharide(string name, char code, int massScaled, int[] diagnosticIonsScaled)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("Monosaccharide name must be non-empty.", nameof(name));
+            if (NameCharDic.ContainsKey(name))
+                throw new ArgumentException($"Monosaccharide name '{name}' already exists (built-in or previously-registered).", nameof(name));
+            if (CharMassDic.ContainsKey(code))
+                throw new ArgumentException($"Single-char code '{code}' already exists (built-in or previously-registered).", nameof(code));
+            if (!((code >= 'A' && code <= 'Z') || (code >= 'a' && code <= 'z')))
+                throw new ArgumentException($"Single-char code '{code}' must be an ASCII letter.", nameof(code));
+
+            int newIndex = _kindEntries.Count;
+            _kindEntries.Add((name, code, massScaled));
+            if (diagnosticIonsScaled != null && diagnosticIonsScaled.Length > 0)
+            {
+                _customDiagnosticIonsByIndex[newIndex] = diagnosticIonsScaled;
+            }
+            CharMassDic = BuildCharMassDic();
+            NameCharDic = BuildNameCharDic();
+        }
+
+        /// <summary>
+        /// Removes all registered custom monosaccharides, restoring the built-in 11. Intended for tests.
+        /// </summary>
+        public static void ResetCustomMonosaccharides()
+        {
+            _kindEntries = new List<(string, char, int)>(_builtInKindEntries);
+            _customDiagnosticIonsByIndex = new Dictionary<int, int[]>();
+            CharMassDic = BuildCharMassDic();
+            NameCharDic = BuildNameCharDic();
+        }
 
         /// <summary>
         /// Set of common oxonium ion masses (int, scaled by 1e5) used for initial glycopeptide peak filtering.
@@ -293,7 +382,7 @@ namespace EngineLayer
             }
             if (!isOglycan)
             {
-                glycanIons.Add(new GlycanIon(null, 8303819, new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, mass - 8303819)); //Cross-ring mass
+                glycanIons.Add(new GlycanIon(null, 8303819, new byte[KindCapacity], mass - 8303819)); //Cross-ring mass
             }
             glycanIons.Add(new GlycanIon(null, 0, kind, mass)); //That is Y0 ion. The whole glycan dropped from the glycopeptide. Like a netural loss.
 
@@ -542,43 +631,29 @@ namespace EngineLayer
         /// </summary>
         /// <param name="structure"> ex.(N(H(A))(N(H(A))(F))) </param>
         /// <returns> The glycan Mass </returns>
-        private static int GetMass(string structure) 
+        private static int GetMass(string structure)
         {
-            int y = CharMassDic['H'] * structure.Count(p => p == 'H') +
-                CharMassDic['N'] * structure.Count(p => p == 'N') +
-                CharMassDic['A'] * structure.Count(p => p == 'A') +
-                CharMassDic['G'] * structure.Count(p => p == 'G') +
-                CharMassDic['F'] * structure.Count(p => p == 'F') +
-                CharMassDic['P'] * structure.Count(p => p == 'P') +
-                CharMassDic['S'] * structure.Count(p => p == 'S') +
-                CharMassDic['Y'] * structure.Count(p => p == 'Y') +
-                CharMassDic['C'] * structure.Count(p => p == 'C') +
-                CharMassDic['X'] * structure.Count(p => p == 'X') +
-                CharMassDic['K'] * structure.Count(p => p == 'K')
-                ;
+            int y = 0;
+            foreach (var entry in _kindEntries)
+            {
+                y += entry.MassScaled * structure.Count(p => p == entry.Code);
+            }
             return y;
         }
 
         /// <summary>
         /// Get glycan mass by glycan composition
         /// </summary>
-        /// <param name="kind"> [2, 2, 2, 0, 1, 0, 0, 0, 0, 0] </param>
+        /// <param name="kind"> [2, 2, 2, 0, 1, 0, 0, 0, 0, 0, 0, ...] </param>
         /// <returns> The glycan mass </returns>
-        public static int GetMass(byte[] kind) 
+        public static int GetMass(byte[] kind)
         {
-            int mass = CharMassDic['H'] * kind[0] +
-            CharMassDic['N'] * kind[1] +
-            CharMassDic['A'] * kind[2] +
-            CharMassDic['G'] * kind[3] +
-            CharMassDic['F'] * kind[4] +
-            CharMassDic['P'] * kind[5] +
-            CharMassDic['S'] * kind[6] +
-            CharMassDic['Y'] * kind[7] +
-            CharMassDic['C'] * kind[8] +
-            CharMassDic['X'] * kind[9] +
-            CharMassDic['K'] * kind[10]
-            ;
-
+            int mass = 0;
+            int upper = Math.Min(kind.Length, _kindEntries.Count);
+            for (int i = 0; i < upper; i++)
+            {
+                mass += _kindEntries[i].MassScaled * kind[i];
+            }
             return mass;
         }
 
@@ -587,46 +662,35 @@ namespace EngineLayer
         /// Get glycan composition by the structure string
         /// </summary>
         /// <param name="structure"> structure format : (N(H(A))(N(H(A))(F))) </param>
-        /// <returns> The kind List ex [2, 2, 2, 0, 1, 0, 0, 0, 0, 0].</returns>
-        public static byte[] GetKind(string structure) 
+        /// <returns> The kind array, length == KindCapacity. </returns>
+        public static byte[] GetKind(string structure)
         {
-            var kind = new byte[] 
-            { Convert.ToByte(structure.Count(p => p == 'H')),
-                Convert.ToByte(structure.Count(p => p == 'N')),
-                Convert.ToByte(structure.Count(p => p == 'A')),
-                Convert.ToByte(structure.Count(p => p == 'G')),
-                Convert.ToByte(structure.Count(p => p == 'F')),
-                Convert.ToByte(structure.Count(p => p == 'P')),
-                Convert.ToByte(structure.Count(p => p == 'S')),
-                Convert.ToByte(structure.Count(p => p == 'Y')),
-                Convert.ToByte(structure.Count(p => p == 'C')),
-                Convert.ToByte(structure.Count(p => p == 'X')),
-                Convert.ToByte(structure.Count(p => p == 'K'))
-            };
+            var kind = new byte[_kindEntries.Count];
+            for (int i = 0; i < _kindEntries.Count; i++)
+            {
+                kind[i] = Convert.ToByte(structure.Count(p => p == _kindEntries[i].Code));
+            }
             return kind;
         }
 
 
         /// <summary>
-        /// Get glycan composition text from the glycan kind[].
+        /// Get glycan composition text from the glycan kind[]. Slots with zero count are omitted.
         /// </summary>
-        /// <param name="Kind"> ex. [2, 2, 2, 0, 1, 0, 0, 0, 0, 0] </param>
+        /// <param name="Kind"> ex. [2, 2, 2, 0, 1, 0, 0, 0, 0, 0, 0, ...] </param>
         /// <returns> The composition text ex. H2N2A2F1 </returns>
         public static string GetKindString(byte[] Kind)
         {
-            string H = Kind[0]==0 ? "" : "H" + Kind[0].ToString();
-            string N = Kind[1] == 0 ? "" : "N" + Kind[1].ToString();
-            string A = Kind[2] == 0 ? "" : "A" + Kind[2].ToString();
-            string G = Kind[3] == 0 ? "" : "G" + Kind[3].ToString();
-            string F = Kind[4] == 0 ? "" : "F" + Kind[4].ToString();
-            string P = Kind[5] == 0 ? "" : "P" + Kind[5].ToString();
-            string S = Kind[6] == 0 ? "" : "S" + Kind[6].ToString();
-            string Y = Kind[7] == 0 ? "" : "Y" + Kind[7].ToString();
-            string C = Kind[8] == 0 ? "" : "C" + Kind[8].ToString();
-            string X = Kind[9] == 0 ? "" : "X" + Kind[9].ToString();
-            string K = Kind[10] == 0 ? "" : "K" + Kind[10].ToString();
-            string kindString = H + N + A + G + F + P + S + Y + C + X + K;
-            return kindString;
+            var sb = new System.Text.StringBuilder();
+            int upper = Math.Min(Kind.Length, _kindEntries.Count);
+            for (int i = 0; i < upper; i++)
+            {
+                if (Kind[i] != 0)
+                {
+                    sb.Append(_kindEntries[i].Code).Append(Kind[i]);
+                }
+            }
+            return sb.ToString();
         }
 
         #endregion

--- a/MetaMorpheus/EngineLayer/GlycoSearch/GlycanBox.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/GlycanBox.cs
@@ -223,7 +223,7 @@ namespace EngineLayer
         /// <param name="targetDecoy"></param>
         public GlycanBox(int[] ids, bool Istarget = true):base(ids)
         {
-            byte[] kind = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+            byte[] kind = new byte[Glycan.KindCapacity];
             foreach (var id in ModIds) //ModIds is the same as ids.
             {
                 for (int i = 0; i < kind.Length; i++)   
@@ -249,7 +249,7 @@ namespace EngineLayer
         {
             OGlycanIds = oGlycanIds;
             NGlycanId = nGlycanIds;
-            byte[] kind = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+            byte[] kind = new byte[Glycan.KindCapacity];
 
             if (!oGlycanIds.IsNullOrEmpty())
             {

--- a/MetaMorpheus/EngineLayer/GlycoSearch/GlycanDatabase.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/GlycanDatabase.cs
@@ -24,10 +24,14 @@ namespace EngineLayer
             bool isKind = true;
             using (StreamReader lines = new StreamReader(filePath))
             {
-                while(lines.Peek() != -1)
+                while (lines.Peek() != -1)
                 {
                     string line = lines.ReadLine();
-                    if (!line.Contains("HexNAc"))  // use the first line to determine the format (kind / structure) of glycan database.
+                    if (IsCommentOrBlank(line)) // Skip comment (#) and blank lines so they don't drive format detection.
+                    {
+                        continue;
+                    }
+                    if (!line.Contains("HexNAc")) // Use the first content line to determine the format (kind / structure) of glycan database.
                     {
                         isKind = false;
                     }
@@ -58,16 +62,33 @@ namespace EngineLayer
             using (StreamReader lines = new StreamReader(filePath))
             {
                 int id = 1;
+                int lineNumber = 0;
                 while (lines.Peek() != -1)
                 {
-                    string line = lines.ReadLine().Split('\t').First();
+                    string rawLine = lines.ReadLine();
+                    lineNumber++;
+                    if (IsCommentOrBlank(rawLine)) // Skip header/comment (#) and blank lines.
+                    {
+                        continue;
+                    }
+                    string line = rawLine.Split('\t').First();
 
                     if (!(line.Contains("HexNAc") || line.Contains("Hex"))) // Make sure the line is a glycan line. The line should contain HexNAc or Hex.
                     {
                         continue;
                     }
 
-                    var kind = String2Kind(line);  // Convert the database string to kind[] format (byte array).
+                    byte[] kind;
+                    try
+                    {
+                        kind = String2Kind(line);  // Convert the database string to kind[] format (byte array).
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new MetaMorpheusException(
+                            $"Could not parse glycan composition in '{Path.GetFileName(filePath)}' at line {lineNumber}: \"{rawLine}\". {ex.Message}",
+                            ex);
+                    }
 
                     if (IsOGlycan) // Load the oGlycan with two different motifs : S and T
                     {
@@ -144,18 +165,66 @@ namespace EngineLayer
             using (StreamReader glycans = new StreamReader(filePath))
             {
                 int id = 1;
+                int lineNumber = 0;
                 while (glycans.Peek() != -1)
                 {
                     string line = glycans.ReadLine();   // Read the line from the database file. Ex. (N(H(A))(A))
+                    lineNumber++;
+
+                    if (IsCommentOrBlank(line)) // Skip header/comment (#) and blank lines so they don't get fed to Struct2Glycan.
+                    {
+                        continue;
+                    }
 
                     // For each glycan, two versions will be generated:
                     // For O-glycan, one modified on serine (S), and the other on threonine (T).
                     // For N-glycan, one modified on N-glycosylation on motif Asn-X-Ser(Nxs), and the other on Asn-X-Thr(Nxt).
-                    foreach (var glycan in Glycan.Struct2Glycan(line, id, IsOGlycan)) // Modify the line to handle multiple Glycan objects returned by Struct2Glycan.  
+                    // Parse inside try/catch so a malformed line is reported with file + line number;
+                    // yield after the try (C# disallows yield inside a try with a catch).
+                    List<Glycan> parsed;
+                    try
+                    {
+                        string trimmed = line.Trim();
+                        ValidateStructureLine(trimmed);
+                        parsed = Glycan.Struct2Glycan(trimmed, id, IsOGlycan).ToList();
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new MetaMorpheusException(
+                            $"Could not parse glycan structure in '{Path.GetFileName(filePath)}' at line {lineNumber}: \"{line}\". {ex.Message}",
+                            ex);
+                    }
+
+                    foreach (var glycan in parsed)
                     {
                         yield return glycan;
                     }
                     id = id + 2; // Each line will generate two glycan objects
+                }
+            }
+        }
+
+        // A line is treated as a comment if its first non-whitespace character is '#'.
+        // Blank/whitespace-only lines are also skipped so users can space out their database files.
+        private static bool IsCommentOrBlank(string line)
+        {
+            return string.IsNullOrWhiteSpace(line) || line.TrimStart().StartsWith("#");
+        }
+
+        // Valid characters in structure-format lines: parens plus the 11 single-char monosaccharide codes.
+        // Struct2Glycan silently miscounts unknown chars (no entry in CharMassDic), so we pre-validate
+        // to give the user a clear error instead of a silently wrong glycan mass.
+        private static readonly HashSet<char> ValidStructureChars = new HashSet<char>
+            { '(', ')', 'H', 'N', 'A', 'G', 'F', 'P', 'S', 'Y', 'C', 'X', 'K' };
+
+        private static void ValidateStructureLine(string trimmedLine)
+        {
+            foreach (char c in trimmedLine)
+            {
+                if (!ValidStructureChars.Contains(c))
+                {
+                    throw new FormatException(
+                        $"Unrecognized character '{c}' in glycan structure. Allowed: parentheses and one of HNAGFPSYCXK.");
                 }
             }
         }

--- a/MetaMorpheus/EngineLayer/GlycoSearch/GlycanDatabase.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/GlycanDatabase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 using System.IO;
 using System.Linq;
@@ -46,6 +47,105 @@ namespace EngineLayer
             else
             {
                 return LoadStructureGlycan(filePath, IsOGlycan);            // open the file of the structure format, example: (N(H(A))(A))
+            }
+        }
+
+        /// <summary>
+        /// Load custom monosaccharide definitions from a tab-separated file and register them with
+        /// Glycan so they are recognized by both glycan-database formats and the structure validator.
+        ///
+        /// File format (tab-separated, one entry per line, header optional):
+        ///   Name  SingleCharCode  MonoisotopicMass  DiagnosticIonMasses  Description
+        ///
+        /// Lines starting with '#' and blank lines are skipped. The header row (a line beginning
+        /// with "Name" followed by a tab) is also skipped if present. Description column is
+        /// optional and ignored. DiagnosticIonMasses is optional and may contain zero or more
+        /// comma-separated decimal m/z values.
+        ///
+        /// Mass values are decimal Daltons (e.g. "176.03209") and are internally scaled by 1e5 to
+        /// match the integer-mass representation used throughout the glycan code. Diagnostic ion
+        /// m/z values are stored as supplied (no hydrogen-mass offset).
+        ///
+        /// A malformed line throws MetaMorpheusException with the file name, line number, raw line
+        /// content, and the specific problem (collision with built-in, bad char, non-numeric mass).
+        /// </summary>
+        public static void LoadCustomMonosaccharides(string filePath)
+        {
+            if (!File.Exists(filePath))
+            {
+                return; // file is optional
+            }
+
+            int lineNumber = 0;
+            using (var reader = new StreamReader(filePath))
+            {
+                while (reader.Peek() != -1)
+                {
+                    string line = reader.ReadLine();
+                    lineNumber++;
+                    if (IsCommentOrBlank(line))
+                    {
+                        continue;
+                    }
+                    // Skip the optional column-header row.
+                    if (line.TrimStart().StartsWith("Name\t", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    string[] cols = line.Split('\t');
+                    if (cols.Length < 3)
+                    {
+                        throw new MetaMorpheusException(
+                            $"Could not parse custom monosaccharide in '{Path.GetFileName(filePath)}' at line {lineNumber}: \"{line}\". Expected at least 3 tab-separated columns (Name, SingleCharCode, MonoisotopicMass).");
+                    }
+
+                    string name = cols[0].Trim();
+                    string codeStr = cols[1].Trim();
+                    string massStr = cols[2].Trim();
+                    string ionsStr = cols.Length > 3 ? cols[3].Trim() : string.Empty;
+
+                    if (codeStr.Length != 1)
+                    {
+                        throw new MetaMorpheusException(
+                            $"Could not parse custom monosaccharide in '{Path.GetFileName(filePath)}' at line {lineNumber}: SingleCharCode must be exactly one character, got \"{codeStr}\".");
+                    }
+                    char code = codeStr[0];
+
+                    if (!double.TryParse(massStr, NumberStyles.Float, CultureInfo.InvariantCulture, out double massDa))
+                    {
+                        throw new MetaMorpheusException(
+                            $"Could not parse custom monosaccharide in '{Path.GetFileName(filePath)}' at line {lineNumber}: MonoisotopicMass \"{massStr}\" is not a valid decimal number.");
+                    }
+                    int massScaled = (int)Math.Round(massDa * 1E5);
+
+                    int[] ionsScaled = null;
+                    if (!string.IsNullOrWhiteSpace(ionsStr))
+                    {
+                        var parts = ionsStr.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                        ionsScaled = new int[parts.Length];
+                        for (int i = 0; i < parts.Length; i++)
+                        {
+                            if (!double.TryParse(parts[i].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out double ionDa))
+                            {
+                                throw new MetaMorpheusException(
+                                    $"Could not parse custom monosaccharide in '{Path.GetFileName(filePath)}' at line {lineNumber}: DiagnosticIonMasses entry \"{parts[i]}\" is not a valid decimal number.");
+                            }
+                            ionsScaled[i] = (int)Math.Round(ionDa * 1E5);
+                        }
+                    }
+
+                    try
+                    {
+                        Glycan.RegisterCustomMonosaccharide(name, code, massScaled, ionsScaled);
+                    }
+                    catch (ArgumentException ex)
+                    {
+                        throw new MetaMorpheusException(
+                            $"Could not register custom monosaccharide in '{Path.GetFileName(filePath)}' at line {lineNumber}: \"{line}\". {ex.Message}",
+                            ex);
+                    }
+                }
             }
         }
 
@@ -142,7 +242,7 @@ namespace EngineLayer
         /// <returns> The glycan Kind List ex. [2, 5, 0, 0, 1, 0, 0, 0, 0, 1] </returns>
         public static byte[] String2Kind(string line) 
         {
-            byte[] kind = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+            byte[] kind = new byte[Glycan.KindCapacity];
             var x = line.Split(new char[] { '(', ')' });
             int i = 0;
             while (i < x.Length - 1)
@@ -211,20 +311,21 @@ namespace EngineLayer
             return string.IsNullOrWhiteSpace(line) || line.TrimStart().StartsWith("#");
         }
 
-        // Valid characters in structure-format lines: parens plus the 11 single-char monosaccharide codes.
-        // Struct2Glycan silently miscounts unknown chars (no entry in CharMassDic), so we pre-validate
-        // to give the user a clear error instead of a silently wrong glycan mass.
-        private static readonly HashSet<char> ValidStructureChars = new HashSet<char>
-            { '(', ')', 'H', 'N', 'A', 'G', 'F', 'P', 'S', 'Y', 'C', 'X', 'K' };
-
+        // Valid characters in structure-format lines: parens plus any single-char monosaccharide
+        // code currently registered with Glycan (built-ins + customs loaded from
+        // MonosaccharidesCustom.tsv). Struct2Glycan silently miscounts unknown chars (no entry in
+        // CharMassDic), so we pre-validate to give the user a clear error instead of a silently
+        // wrong glycan mass.
         private static void ValidateStructureLine(string trimmedLine)
         {
             foreach (char c in trimmedLine)
             {
-                if (!ValidStructureChars.Contains(c))
+                if (c == '(' || c == ')') continue;
+                if (!Glycan.CharMassDic.ContainsKey(c))
                 {
+                    string allowed = string.Concat(Glycan.CharMassDic.Keys);
                     throw new FormatException(
-                        $"Unrecognized character '{c}' in glycan structure. Allowed: parentheses and one of HNAGFPSYCXK.");
+                        $"Unrecognized character '{c}' in glycan structure. Allowed: parentheses and one of {allowed}.");
                 }
             }
         }
@@ -256,7 +357,8 @@ namespace EngineLayer
             {
                 if (hexnac_count == 0)
                 {
-                    byte[] startKind = new byte[] { 0, (byte)hexnac_count, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+                    byte[] startKind = new byte[Glycan.KindCapacity];
+                    startKind[1] = (byte)hexnac_count;
                     string glycanName = Glycan.GetKindString(startKind);
                     GlycanIon glycanIon = new GlycanIon(glycanName, 8303819, startKind, glycan_mass - 8303819);
                     glycanIons.Add(glycanIon);
@@ -475,7 +577,11 @@ namespace EngineLayer
 
         private static GlycanIon GenerateGlycanIon(byte hexose_count, byte hexnac_count, byte fuc_count, byte xyl_count, int glycan_mass)
         {
-            byte[] ionKind = new byte[] { hexose_count, hexnac_count, 0, 0, fuc_count, 0, 0, 0, 0, xyl_count,0 };
+            byte[] ionKind = new byte[Glycan.KindCapacity];
+            ionKind[0] = hexose_count;
+            ionKind[1] = hexnac_count;
+            ionKind[4] = fuc_count;
+            ionKind[9] = xyl_count;
 
             int ionMass = Glycan.GetMass(ionKind);
 

--- a/MetaMorpheus/MetaMorpheusSetup/Product.wxs
+++ b/MetaMorpheus/MetaMorpheusSetup/Product.wxs
@@ -564,9 +564,14 @@
         <RegistryValue Root="HKCU" Key="Software\SmithGroup\MetaMorpheus" Name="installed" Type="integer" Value="1" KeyPath="yes" />
       </Component>
       <Component Id="Appsrc_Data_NGlycan.gdb" Guid="1AE1B223-9C67-4378-BA07-ABA31BCE4EAB" Condition="OVERWRITEAPPDATA">
-        
+
         <RegistryValue Root="HKCU" Key="Software\SmithGroup\MetaMorpheus" Name="installed" Type="integer" Value="1" KeyPath="yes" />
         <File ReadOnly="no" Id="Appsrc_NGlycan.gdb" Name="NGlycan.gdb" Source="$(var.GUI_TargetDir)Glycan_Mods\NGlycan\NGlycan.gdb" />
+      </Component>
+      <Component Id="Appsrc_Data_NGlycan_Custom.gdb" Guid="0A9175E9-2755-4703-8751-DE57480117E9" Condition="OVERWRITEAPPDATA">
+
+        <RegistryValue Root="HKCU" Key="Software\SmithGroup\MetaMorpheus" Name="installed" Type="integer" Value="1" KeyPath="yes" />
+        <File ReadOnly="no" Id="Appsrc_NGlycan_Custom.gdb" Name="NGlycan_Custom.gdb" Source="$(var.GUI_TargetDir)Glycan_Mods\NGlycan\NGlycan_Custom.gdb" />
       </Component>
     </ComponentGroup>
   </Fragment>
@@ -580,9 +585,14 @@
         <RegistryValue Root="HKCU" Key="Software\SmithGroup\MetaMorpheus" Name="installed" Type="integer" Value="1" KeyPath="yes" />
       </Component>
       <Component Id="Appsrc_Data_OGlycan.gdb" Guid="08054759-2D7E-4760-A174-A53E5A77507F" Condition="OVERWRITEAPPDATA">
-        
+
         <RegistryValue Root="HKCU" Key="Software\SmithGroup\MetaMorpheus" Name="installed" Type="integer" Value="1" KeyPath="yes" />
         <File ReadOnly="no" Id="Appsrc_OGlycan.gdb" Name="OGlycan.gdb" Source="$(var.GUI_TargetDir)Glycan_Mods\OGlycan\OGlycan.gdb" />
+      </Component>
+      <Component Id="Appsrc_Data_OGlycan_Custom.gdb" Guid="50DFF7F1-5816-49E2-B33A-236FFCA266D3" Condition="OVERWRITEAPPDATA">
+
+        <RegistryValue Root="HKCU" Key="Software\SmithGroup\MetaMorpheus" Name="installed" Type="integer" Value="1" KeyPath="yes" />
+        <File ReadOnly="no" Id="Appsrc_OGlycan_Custom.gdb" Name="OGlycan_Custom.gdb" Source="$(var.GUI_TargetDir)Glycan_Mods\OGlycan\OGlycan_Custom.gdb" />
       </Component>
       <Component Id="Appsrc_OlgycanDatabase28glycansplusSodium56total.txt" Guid="BCA7AE90-98BA-4F94-9A6A-0BB8486F5532" Condition="OVERWRITEAPPDATA">
         

--- a/MetaMorpheus/MetaMorpheusSetup/Product.wxs
+++ b/MetaMorpheus/MetaMorpheusSetup/Product.wxs
@@ -626,10 +626,15 @@
   <Fragment>
     <ComponentGroup Id="Appsrc_Glycan_Mods_files" Directory="MetaAppGlycan_ModsFolder">
       <Component Id="RemoveGlycanModsData" Guid="40090707-AEFF-4C5C-9693-F9A11F9D0402" Condition="OVERWRITEAPPDATA">
-        
+
         <RemoveFolder Id="MetaAppGlycan_ModsFolder" On="both" />
         <RegistryValue Root="HKCU" Key="Software\SmithGroup\MetaMorpheus" Name="installed" Type="integer" Value="1" KeyPath="yes" />
-      </Component>      
+      </Component>
+      <Component Id="Appsrc_Data_MonosaccharidesCustom.tsv" Guid="82338312-33BC-4426-A6D5-E78E35034A50" Condition="OVERWRITEAPPDATA">
+
+        <RegistryValue Root="HKCU" Key="Software\SmithGroup\MetaMorpheus" Name="installed" Type="integer" Value="1" KeyPath="yes" />
+        <File ReadOnly="no" Id="Appsrc_MonosaccharidesCustom.tsv" Name="MonosaccharidesCustom.tsv" Source="$(var.GUI_TargetDir)Glycan_Mods\MonosaccharidesCustom.tsv" />
+      </Component>
     </ComponentGroup>
   </Fragment>
 

--- a/MetaMorpheus/Test/TestNGlyco.cs
+++ b/MetaMorpheus/Test/TestNGlyco.cs
@@ -523,6 +523,224 @@ namespace Test
         }
 
         [Test]
+        public static void LoadCustomMonosaccharides_RoundTripsThroughCompositionAndMass()
+        {
+            // Register HexA (hexuronic acid, residue mass 176.03209 Da). Verify the loader
+            // makes it parseable in composition-format glycan files, that Kind[] gets the right
+            // count at the custom slot, that GetMass uses the custom mass, and that
+            // GetKindString round-trips the custom code.
+
+            string tsv = string.Join(Environment.NewLine, new[]
+            {
+                "# comment line ignored",
+                "Name\tSingleCharCode\tMonoisotopicMass\tDiagnosticIonMasses\tDescription",
+                "",
+                "HexA\tU\t176.03209\t\tHexuronic acid"
+            });
+            string path = Path.GetTempFileName();
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.WriteAllText(path, tsv);
+                GlycanDatabase.LoadCustomMonosaccharides(path);
+
+                Assert.That(Glycan.KindCapacity, Is.EqualTo(12)); // 11 built-ins + 1 custom
+                Assert.That(Glycan.NameCharDic.ContainsKey("HexA"));
+                Assert.That(Glycan.NameCharDic["HexA"].Item1, Is.EqualTo('U'));
+                Assert.That(Glycan.NameCharDic["HexA"].Item2, Is.EqualTo(11));
+                Assert.That(Glycan.CharMassDic['U'], Is.EqualTo(17603209));
+
+                byte[] kind = GlycanDatabase.String2Kind("HexNAc(2)Hex(5)HexA(1)");
+                Assert.That(kind.Length, Is.EqualTo(12));
+                Assert.That(kind[0], Is.EqualTo(5));   // Hex
+                Assert.That(kind[1], Is.EqualTo(2));   // HexNAc
+                Assert.That(kind[11], Is.EqualTo(1));  // HexA
+
+                int expectedMass = 2 * 20307937 + 5 * 16205282 + 1 * 17603209;
+                Assert.That(Glycan.GetMass(kind), Is.EqualTo(expectedMass));
+
+                // GetKindString writes built-ins first (H..K) then customs at their slot order.
+                Assert.That(Glycan.GetKindString(kind), Is.EqualTo("H5N2U1"));
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.Delete(path);
+            }
+        }
+
+        [Test]
+        public static void LoadCustomMonosaccharides_CommentsBlanksAndHeaderRowAreSkipped()
+        {
+            string tsv = string.Join(Environment.NewLine, new[]
+            {
+                "# only one real entry should be registered",
+                "",
+                "Name\tSingleCharCode\tMonoisotopicMass\tDiagnosticIonMasses\tDescription",
+                "# another comment",
+                "Pent\tT\t132.04226\t\tGeneric pentose",
+                ""
+            });
+            string path = Path.GetTempFileName();
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.WriteAllText(path, tsv);
+                GlycanDatabase.LoadCustomMonosaccharides(path);
+
+                Assert.That(Glycan.KindCapacity, Is.EqualTo(12));
+                Assert.That(Glycan.NameCharDic.ContainsKey("Pent"));
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.Delete(path);
+            }
+        }
+
+        [Test]
+        public static void LoadCustomMonosaccharides_NameCollisionThrowsWithFileAndLineNumber()
+        {
+            // "HexNAc" is a built-in; redefining it must fail.
+            string tsv = "HexNAc\tU\t999.99999\t\tWill collide";
+            string path = Path.GetTempFileName();
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.WriteAllText(path, tsv);
+                var ex = Assert.Throws<MetaMorpheusException>(
+                    () => GlycanDatabase.LoadCustomMonosaccharides(path));
+                Assert.That(ex.Message, Does.Contain(Path.GetFileName(path)));
+                Assert.That(ex.Message, Does.Contain("line 1"));
+                Assert.That(ex.Message, Does.Contain("HexNAc"));
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.Delete(path);
+            }
+        }
+
+        [Test]
+        public static void LoadCustomMonosaccharides_CharCollisionThrows()
+        {
+            // 'N' is the built-in single-char code for HexNAc; reusing it must fail.
+            string tsv = "Foo\tN\t100.0\t\tCollides with HexNAc";
+            string path = Path.GetTempFileName();
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.WriteAllText(path, tsv);
+                var ex = Assert.Throws<MetaMorpheusException>(
+                    () => GlycanDatabase.LoadCustomMonosaccharides(path));
+                Assert.That(ex.Message, Does.Contain("'N'"));
+                Assert.That(ex.Message, Does.Contain("line 1"));
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.Delete(path);
+            }
+        }
+
+        [Test]
+        public static void LoadCustomMonosaccharides_NonLetterCodeRejected()
+        {
+            string tsv = "Foo\t1\t100.0\t\tDigit is not a letter";
+            string path = Path.GetTempFileName();
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.WriteAllText(path, tsv);
+                var ex = Assert.Throws<MetaMorpheusException>(
+                    () => GlycanDatabase.LoadCustomMonosaccharides(path));
+                Assert.That(ex.Message, Does.Contain("ASCII letter"));
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.Delete(path);
+            }
+        }
+
+        [Test]
+        public static void LoadCustomMonosaccharides_NonNumericMassThrows()
+        {
+            string tsv = "Foo\tU\tnot-a-number\t\tBad mass";
+            string path = Path.GetTempFileName();
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.WriteAllText(path, tsv);
+                var ex = Assert.Throws<MetaMorpheusException>(
+                    () => GlycanDatabase.LoadCustomMonosaccharides(path));
+                Assert.That(ex.Message, Does.Contain("MonoisotopicMass"));
+                Assert.That(ex.Message, Does.Contain("not-a-number"));
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.Delete(path);
+            }
+        }
+
+        [Test]
+        public static void LoadCustomMonosaccharides_DiagnosticIonsEmittedWhenPresent()
+        {
+            string tsv = "HexA\tU\t176.03209\t175.02482,157.01425\tHexuronic acid";
+            string path = Path.GetTempFileName();
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.WriteAllText(path, tsv);
+                GlycanDatabase.LoadCustomMonosaccharides(path);
+
+                byte[] kind = GlycanDatabase.String2Kind("HexNAc(2)HexA(1)");
+                var glycan = new Glycan(null, Glycan.GetMass(kind), kind, null, false, "Nxs", GlycanType.N_glycan);
+
+                int expectedIon1 = (int)Math.Round(175.02482 * 1E5);
+                int expectedIon2 = (int)Math.Round(157.01425 * 1E5);
+                Assert.That(glycan.GlycanDiagnosticIons.Contains(expectedIon1));
+                Assert.That(glycan.GlycanDiagnosticIons.Contains(expectedIon2));
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.Delete(path);
+            }
+        }
+
+        [Test]
+        public static void LoadCustomMonosaccharides_CustomCodeAcceptedInStructureFormat()
+        {
+            // Register HexA. A structure-format glycan file using 'U' must now parse without the
+            // "Unrecognized character" validator error (which would have fired before registration).
+
+            string monoTsv = "HexA\tU\t176.03209\t\tHexuronic acid";
+            string monoPath = Path.GetTempFileName();
+            string glycanPath = Path.GetTempFileName();
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.WriteAllText(monoPath, monoTsv);
+                GlycanDatabase.LoadCustomMonosaccharides(monoPath);
+
+                File.WriteAllText(glycanPath, "(N(H)(U))" + Environment.NewLine);
+                var glycans = GlycanDatabase.LoadGlycan(glycanPath, false, false).ToList();
+
+                Assert.That(glycans.Count, Is.EqualTo(2)); // Nxs + Nxt motif duplication
+                int expectedMass = 1 * 20307937 + 1 * 16205282 + 1 * 17603209;
+                Assert.That(glycans[0].Mass, Is.EqualTo(expectedMass));
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.Delete(monoPath);
+                File.Delete(glycanPath);
+            }
+        }
+
+        [Test]
         public static void LoadStructureGlycan_UnknownCharThrowsWithFileAndLineNumber()
         {
             string[] lines =

--- a/MetaMorpheus/Test/TestNGlyco.cs
+++ b/MetaMorpheus/Test/TestNGlyco.cs
@@ -311,7 +311,245 @@ namespace Test
             var overlap = glycanIonmass.Intersect(ionMass).Count();
 
             Assert.That(overlap == 15);
-     
+
+        }
+
+        [Test]
+        public static void LoadKindGlycan_SkipsCommentsAndBlankLines()
+        {
+            string[] body =
+            {
+                "HexNAc(2)Hex(5)NeuAc(1)Fuc(1)",
+                "HexNAc(2)Hex(3)",
+                "HexNAc(4)Hex(5)NeuAc(2)"
+            };
+
+            string[] decorated =
+            {
+                "# Composition-format custom glycan database",
+                "# Lines starting with '#' are comments. Blank lines are also ignored.",
+                "",
+                body[0],
+                "   # indented comment should also be skipped",
+                "",
+                body[1],
+                "\t",
+                body[2],
+                "# trailing comment"
+            };
+
+            string plainPath = Path.GetTempFileName();
+            string decoratedPath = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllLines(plainPath, body);
+                File.WriteAllLines(decoratedPath, decorated);
+
+                var plain = GlycanDatabase.LoadGlycan(plainPath, false, false).ToList();
+                var fromDecorated = GlycanDatabase.LoadGlycan(decoratedPath, false, false).ToList();
+
+                Assert.That(fromDecorated.Count, Is.EqualTo(plain.Count));
+                CollectionAssert.AreEqual(
+                    plain.Select(g => g.Composition).ToList(),
+                    fromDecorated.Select(g => g.Composition).ToList());
+                CollectionAssert.AreEqual(
+                    plain.Select(g => g.Mass).ToList(),
+                    fromDecorated.Select(g => g.Mass).ToList());
+            }
+            finally
+            {
+                File.Delete(plainPath);
+                File.Delete(decoratedPath);
+            }
+        }
+
+        [Test]
+        public static void LoadStructureGlycan_SkipsCommentsAndBlankLines()
+        {
+            string[] body =
+            {
+                "(N(H(A))(N(H(A))(F)))",
+                "(N(H)(N(H)))",
+                "(N(H(A)))"
+            };
+
+            string[] decorated =
+            {
+                "# Structure-format custom glycan database",
+                "# Lines starting with '#' are comments.",
+                "",
+                body[0],
+                "  # indented comment",
+                body[1],
+                "",
+                body[2]
+            };
+
+            string plainPath = Path.GetTempFileName();
+            string decoratedPath = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllLines(plainPath, body);
+                File.WriteAllLines(decoratedPath, decorated);
+
+                // N-glycan (isOGlycan = false): each line produces two glycans (Nxs, Nxt).
+                var plain = GlycanDatabase.LoadGlycan(plainPath, false, false).ToList();
+                var fromDecorated = GlycanDatabase.LoadGlycan(decoratedPath, false, false).ToList();
+
+                Assert.That(fromDecorated.Count, Is.EqualTo(plain.Count));
+                Assert.That(fromDecorated.Count, Is.EqualTo(body.Length * 2));
+                CollectionAssert.AreEqual(
+                    plain.Select(g => g.IdWithMotif).ToList(),
+                    fromDecorated.Select(g => g.IdWithMotif).ToList());
+            }
+            finally
+            {
+                File.Delete(plainPath);
+                File.Delete(decoratedPath);
+            }
+        }
+
+        [Test]
+        public static void LoadGlycan_CommentOnlyFileYieldsNoGlycans()
+        {
+            string[] lines =
+            {
+                "# This file has no glycan rows.",
+                "",
+                "# Just comments."
+            };
+
+            string path = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllLines(path, lines);
+                var loaded = GlycanDatabase.LoadGlycan(path, false, true).ToList();
+                Assert.That(loaded, Is.Empty);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Test]
+        public static void LoadKindGlycan_UnknownTokenThrowsWithFileAndLineNumber()
+        {
+            string[] lines =
+            {
+                "# Custom glycan file with a bad row",
+                "HexNAc(2)Hex(5)",
+                "HexNAc(1)Wibble(2)" // line 3 -- Wibble is not a recognized monosaccharide
+            };
+
+            string path = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllLines(path, lines);
+                var ex = Assert.Throws<MetaMorpheusException>(
+                    () => GlycanDatabase.LoadGlycan(path, false, false).ToList());
+
+                Assert.That(ex.Message, Does.Contain(Path.GetFileName(path)));
+                Assert.That(ex.Message, Does.Contain("line 3"));
+                Assert.That(ex.Message, Does.Contain("HexNAc(1)Wibble(2)"));
+                Assert.That(ex.InnerException, Is.Not.Null);
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Test]
+        public static void LoadGlycan_CustomFileRoundTripsThroughEngineSelectionAndIonGeneration()
+        {
+            // Mirror the way GlycoSearchEngine selects and loads a custom database:
+            //   GlobalVariables.OGlycanDatabasePaths.Where(p => Path.GetFileName(p) == _oglycanDatabase).First()
+            //   GlycanDatabase.LoadGlycan(path, ToGenerateIons: true, IsOGlycan: true)
+            // and verify a commented custom file flows end-to-end through that pipeline.
+
+            string tempDir = Path.Combine(Path.GetTempPath(), "GlycoRoundTrip_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(tempDir);
+            string customFileName = "RoundTrip_OGlycan_Custom.gdb";
+            string customPath = Path.Combine(tempDir, customFileName);
+
+            string[] lines =
+            {
+                "# round-trip custom glycan template",
+                "",
+                "HexNAc(1)",        // single GalNAc -> 2 entries (S, T)
+                "HexNAc(1)Hex(1)",  // core-1        -> 2 entries (S, T)
+                "# trailing comment ignored"
+            };
+            File.WriteAllLines(customPath, lines);
+
+            bool addedToGlobals = false;
+            try
+            {
+                if (!GlobalVariables.OGlycanDatabasePaths.Contains(customPath))
+                {
+                    GlobalVariables.OGlycanDatabasePaths.Add(customPath);
+                    addedToGlobals = true;
+                }
+
+                string selectedPath = GlobalVariables.OGlycanDatabasePaths
+                    .Where(p => Path.GetFileName(p) == customFileName).First();
+                var glycans = GlycanDatabase.LoadGlycan(selectedPath, true, true).ToArray();
+
+                // 2 source rows x 2 motifs (S, T) = 4 yielded glycans, in row-then-motif order.
+                Assert.That(glycans.Length, Is.EqualTo(4));
+                Assert.That(glycans.Select(g => g.Composition).ToArray(),
+                    Is.EqualTo(new[] { "N1", "N1", "H1N1", "H1N1" }));
+                Assert.That(glycans.Select(g => g.Target.ToString()).ToArray(),
+                    Is.EqualTo(new[] { "S", "T", "S", "T" }));
+
+                for (int i = 0; i < glycans.Length; i++)
+                {
+                    Assert.That(glycans[i].GlyId, Is.EqualTo(i + 1));
+                    Assert.That(glycans[i].Type, Is.EqualTo(GlycanType.O_glycan));
+                    Assert.That(glycans[i].Ions, Is.Not.Null);
+                    Assert.That(glycans[i].Ions.Count, Is.GreaterThan(0)); // ToGenerateIons=true must populate child ions
+                }
+            }
+            finally
+            {
+                if (addedToGlobals)
+                {
+                    GlobalVariables.OGlycanDatabasePaths.Remove(customPath);
+                }
+                File.Delete(customPath);
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+
+        [Test]
+        public static void LoadStructureGlycan_UnknownCharThrowsWithFileAndLineNumber()
+        {
+            string[] lines =
+            {
+                "# Custom structure file with a bad row",
+                "",
+                "(N(H(A)))",
+                "(N(Z))" // line 4 -- Z is not a recognized monosaccharide code
+            };
+
+            string path = Path.GetTempFileName();
+            try
+            {
+                File.WriteAllLines(path, lines);
+                var ex = Assert.Throws<MetaMorpheusException>(
+                    () => GlycanDatabase.LoadGlycan(path, false, true).ToList());
+
+                Assert.That(ex.Message, Does.Contain(Path.GetFileName(path)));
+                Assert.That(ex.Message, Does.Contain("line 4"));
+                Assert.That(ex.Message, Does.Contain("(N(Z))"));
+                Assert.That(ex.Message, Does.Contain("'Z'"));
+                Assert.That(ex.InnerException, Is.InstanceOf<FormatException>());
+            }
+            finally
+            {
+                File.Delete(path);
+            }
         }
     }
 }


### PR DESCRIPTION
# Enable user-supplied custom glycan databases and monosaccharides

## Summary

Users can now extend MetaMorpheus glyco search **without modifying any built-in file**:

1. **Custom glycan databases** — drop entries into two new empty, documented templates (or any new `.gdb` file in the same folder):
   - `Glycan_Mods/NGlycan/NGlycan_Custom.gdb`
   - `Glycan_Mods/OGlycan/OGlycan_Custom.gdb`
2. **Custom monosaccharides** — register monosaccharides that ship neither as built-ins nor as part of any glycan database, via a new documented TSV:
   - `Glycan_Mods/MonosaccharidesCustom.tsv`

The glycan loader also understands `#` comment lines and blank lines now (so the in-file headers do not break parsing), and reports malformed rows with file name, line number, and the offending line content.

---

## How to add custom glycans (user instructions)

You have **two ways** to add your own glycan compositions. Both produce identical search results.

### Option A — edit the shipped custom template (fastest)

1. Find the template inside your MetaMorpheus install folder:
   - N-glycans: `Glycan_Mods\NGlycan\NGlycan_Custom.gdb`
   - O-glycans: `Glycan_Mods\OGlycan\OGlycan_Custom.gdb`
2. Open it in any text editor. The top of the file is a fully commented header — leave it alone.
3. Below the `GLYCAN DEFINITIONS` banner near the bottom of the file, add one glycan composition per line. For example:
   ```
   HexNAc(2)Hex(5)NeuAc(1)
   HexNAc(4)Hex(5)NeuAc(2)Fuc(1)
   ```
4. Save the file and **restart MetaMorpheus**.
5. In the Glyco Search task window, the matching dropdown (`O-Glycan Database` or `N-Glycan Database`) will now offer `OGlycan_Custom.gdb` or `NGlycan_Custom.gdb`. Pick that one to search against the entries you added.

### Option B — drop your own `.gdb` file in the folder

1. Create a new text file with the extension `.gdb` (e.g. `MyProjectGlycans.gdb`) anywhere on disk.
2. Add one glycan per line, in either format described below.
3. Move (or copy) the file into the right folder inside your MetaMorpheus install:
   - O-glycans go in `Glycan_Mods\OGlycan\`
   - N-glycans go in `Glycan_Mods\NGlycan\`
4. Restart MetaMorpheus. Your file will appear by its filename in the relevant Glyco Search dropdown.

> Tip: copy the header from `OGlycan_Custom.gdb` / `NGlycan_Custom.gdb` into your new file so future readers know the format.

### Glycan file format

Each glycan goes on its own line. **Two formats are supported**, and the parser auto-detects which one a file uses from the first non-comment, non-blank line. **Do not mix formats in one file.**

#### Composition format (recommended)

```
<Monosaccharide>(<count>)<Monosaccharide>(<count>)...
```

Examples:

```
HexNAc(1)                       single GalNAc (Tn antigen)
HexNAc(1)Hex(1)                 core-1 O-glycan (T antigen)
HexNAc(2)Hex(5)                 N-glycan core mannose-5
HexNAc(4)Hex(5)NeuAc(2)Fuc(1)   biantennary, fucosylated, sialylated
```

Order does not matter; monosaccharides with zero count are simply omitted.

#### Structure format (advanced)

Each line is a parenthesized linkage tree where each single-character code is one monosaccharide and parenthesized groups attached to it are its branches:

```
(N)                              single GlcNAc
(N(H))                           GlcNAc-Hex linear
(N(H(A))(N(H(A))(F)))            biantennary, sialylated, fucosylated
```

The built-in `OGlycan.gdb` and `OGlycan_withIsobaric.gdb` use this format; the built-in `NGlycan.gdb` uses composition format. Both shipped custom templates use composition format because it is easier for non-experts to write.

### Recognized monosaccharide tokens (built-in)

| Composition name | Structure single-char code |
|---|---|
| Hex | H |
| HexNAc | N |
| NeuAc | A |
| NeuGc | G |
| Fuc (or dHex) | F |
| Phospho | P |
| Sulfo | S |
| Na | Y |
| Ac | C |
| Xylose | X |
| Kdn | K |

Any token outside this set will cause a load error — **unless** you have registered it in `MonosaccharidesCustom.tsv` (see below).

### Automatic expansion — you do not write these yourself

For every glycan you list, MetaMorpheus automatically generates:

- For **N-glycans**: one entry targeting Asn-X-Ser (`Nxs`) and a second targeting Asn-X-Thr (`Nxt`). Do not duplicate rows for the two motifs.
- For **O-glycans**: one entry targeting Ser (`S`) and a second targeting Thr (`T`). Same — do not duplicate.
- Neutral-loss masses, Y-ions, and diagnostic oxonium ions from the composition. You do not need to enumerate fragments.

### Comments and blank lines

- Lines whose first non-whitespace character is `#` are ignored.
- Blank / whitespace-only lines are ignored.
- Use this freely to annotate your additions:
  ```
  # 2026-05-18, added for the mucin project
  HexNAc(1)Hex(1)NeuAc(1)

  # high-mannose
  HexNAc(2)Hex(9)
  ```

### What happens if a glycan line is malformed

A bad row no longer crashes with a cryptic error. Instead you get a message like:

```
Could not parse glycan composition in 'NGlycan_Custom.gdb' at line 12: "HexNAc(1)Wibble(2)". The given key 'Wibble' was not present in the dictionary.
```

or, for structure-format files with an unknown code:

```
Could not parse glycan structure in 'OGlycan_Custom.gdb' at line 4: "(N(Z))". Unrecognized character 'Z' in glycan structure. Allowed: parentheses and one of HNAGFPSYCXK.
```

— so you can jump straight to the offending line and fix it.

---

## How to add custom monosaccharides (user instructions)

If you need a monosaccharide that MetaMorpheus does not ship with (e.g. HexA, KDO, Pentose, a heavy-labeled variant, …), you can register it once in a single shared file. Custom monosaccharides are usable in BOTH O- and N-glycan searches and BOTH glycan file formats.

### Quick steps

1. Open the template at `Glycan_Mods\MonosaccharidesCustom.tsv` inside your MetaMorpheus install folder.
2. Below the `CUSTOM DEFINITIONS` banner near the bottom, add one tab-separated row per monosaccharide.
3. Save the file and **restart MetaMorpheus**.
4. Use the new name in composition-format glycan files (e.g. `HexNAc(2)Hex(5)HexA(1)`) or the new single-char code in structure-format files (e.g. `(N(H)(U))`).

### TSV file format

Tab-separated, one entry per line. The optional column-header row beginning with `Name<TAB>` is recognized and skipped. Comment (`#`) lines and blank lines are ignored.

| Column | Required? | Meaning |
|---|---|---|
| `Name` | yes | Unique. Must not collide with a built-in (`Hex`, `HexNAc`, `NeuAc`, `NeuGc`, `Fuc`, `dHex`, `Phospho`, `Sulfo`, `Na`, `Ac`, `Xylose`, `Kdn`) or with another entry in this file. |
| `SingleCharCode` | yes | Exactly one ASCII letter (A–Z or a–z). Unique. Must not collide with a built-in code (`H`, `N`, `A`, `G`, `F`, `P`, `S`, `Y`, `C`, `X`, `K`). |
| `MonoisotopicMass` | yes | Decimal Daltons. The mass of the monosaccharide **residue** (the form integrated into the glycan chain, i.e. after water loss). |
| `DiagnosticIonMasses` | optional | Zero or more comma-separated diagnostic-ion m/z values (Daltons). Provide the m/z you would **expect to observe** in the spectrum — no hydrogen-mass offset is applied. Leave blank or omit the column for none. |
| `Description` | optional | Free text, ignored by the parser. Useful for notes, formula, source. |

### Worked example

```
# CUSTOM DEFINITIONS
Name	SingleCharCode	MonoisotopicMass	DiagnosticIonMasses	Description
HexA	U	176.03209	175.02482,157.01425	Hexuronic acid (GlcA, GalA)
Pent	T	132.04226		Generic pentose
Me	M	14.01565		Methyl group as a residue contribution
```

Once loaded, you can write glycans like:

- Composition: `HexNAc(2)Hex(5)HexA(1)`
- Structure: `(N(H)(U))`
- Mass for `HexNAc(2)Hex(5)HexA(1)` becomes `2 × 203.07937 + 5 × 162.05282 + 1 × 176.03209` Da, and the search will emit the two diagnostic m/z values 175.02482 and 157.01425 whenever this glycan appears.

### What gets shared and what does not

| Behavior | Built-ins | Customs |
|---|---|---|
| Recognized in composition-format glycan files | yes | yes |
| Recognized in structure-format glycan files | yes | yes |
| Contributes correct mass to total glycan mass | yes | yes |
| Listed by `GetKindString` (e.g. `H2N2U1`) | yes | yes (at the end of the string) |
| Adds entries to `GlycanDiagnosticIons` | yes (hard-coded set) | yes (any m/z you list in column 4) |
| Counted in OGlycan child-ion combination-filter rules (e.g. "must have at least 1 HexNAc") | yes | **no** — filter rules are tied to specific built-in slots and do not fire for customs |

### What happens if the file is malformed

```
Could not parse custom monosaccharide in 'MonosaccharidesCustom.tsv' at line 5: "HexNAc	U	999.99999		Will collide". Monosaccharide name 'HexNAc' already exists (built-in or previously-registered).
```

```
Could not parse custom monosaccharide in 'MonosaccharidesCustom.tsv' at line 3: SingleCharCode must be exactly one character, got "UU".
```

```
Could not parse custom monosaccharide in 'MonosaccharidesCustom.tsv' at line 7: MonoisotopicMass "not-a-number" is not a valid decimal number.
```

All errors include the file name and line number so you can fix the offending row directly.

---

## What changed under the hood

### Custom-glycan support
- **`EngineLayer/GlycoSearch/GlycanDatabase.cs`** — `LoadKindGlycan` and `LoadStructureGlycan` skip `#`/blank lines, track line numbers, and wrap parse calls in try/catch that throws `MetaMorpheusException` with file + line + raw line. A new `ValidateStructureLine` step rejects unknown characters before `Struct2Glycan` silently miscounts them. Format-detection peek in `LoadGlycan` also skips header comments. The validator consults the live `Glycan.CharMassDic`, so custom monosaccharide codes are accepted automatically.
- **Three shipped `.gdb` files gain a documented header** (no glycan rows changed):
  - `EngineLayer/Glycan_Mods/NGlycan/NGlycan.gdb`
  - `EngineLayer/Glycan_Mods/OGlycan/OGlycan.gdb`
  - `EngineLayer/Glycan_Mods/OGlycan/OGlycan_withIsobaric.gdb`
- **Two new empty templates** ship with the header pre-populated:
  - `EngineLayer/Glycan_Mods/NGlycan/NGlycan_Custom.gdb`
  - `EngineLayer/Glycan_Mods/OGlycan/OGlycan_Custom.gdb`

### Custom-monosaccharide support
- **`EngineLayer/GlycoSearch/Glycan.cs`** — refactored to make the monosaccharide registry dynamic.
  - New private master list `_kindEntries` is the single source of truth; `CharMassDic` and `NameCharDic` become derived dictionaries rebuilt on each registration.
  - New public API `Glycan.RegisterCustomMonosaccharide(name, code, massScaled, diagnosticIonsScaled)` validates collisions and code shape, appends a new slot at index = current `KindCapacity`.
  - New public API `Glycan.ResetCustomMonosaccharides()` for test cleanup.
  - New public property `Glycan.KindCapacity` reports the current `Kind[]` array size (11 built-ins + any customs).
  - `GetMass(string)`, `GetMass(byte[])`, `GetKind(string)`, `GetKindString(byte[])` were hand-unrolled 11-entry expansions; they now iterate `_kindEntries`.
  - `GlycanDiagnosticIons` appends any custom-monosaccharide diagnostic m/z values whose slot has count ≥ 1.
- **All hard-coded `new byte[] { 0, 0, ..., 0 }` (size 11) initializers replaced** with `new byte[Glycan.KindCapacity]`:
  - `Glycan.Struct2Glycan` (cross-ring ion)
  - `GlycanDatabase.String2Kind`
  - `GlycanDatabase.NGlycanCompositionFragments` (start kind)
  - `GlycanDatabase.GenerateGlycanIon` (ion kind)
  - `GlycanBox.GlycanBox(int[], bool)` and `GlycanBox.GlycanBox(int[], int, bool)` (both ctors)
- **`EngineLayer/GlycoSearch/GlycanDatabase.cs::LoadCustomMonosaccharides`** — new method. Parses tab-separated rows (3–5 columns), skips `#`/blank/optional-header rows, validates SingleCharCode shape and uniqueness, parses mass + diagnostic ions with `CultureInfo.InvariantCulture`, calls `Glycan.RegisterCustomMonosaccharide`. All failures throw `MetaMorpheusException` with file + line + raw line.
- **`EngineLayer/GlobalVariables.cs::LoadGlycans`** — now calls `GlycanDatabase.LoadCustomMonosaccharides(DataDir\Glycan_Mods\MonosaccharidesCustom.tsv)` **before** loading any glycan database, so custom tokens are recognized by `.gdb` parsers downstream.
- **`EngineLayer/Glycan_Mods/MonosaccharidesCustom.tsv`** — new file. Ships with a banner header, the built-in-monosaccharide reference table, three commented-out worked examples, and the column-header row only (no active definitions).

### Behavior at default capacity
If no custom monosaccharides are registered (the shipped TSV is data-empty), `KindCapacity` stays at 11 and all glycan-mass / kind-array logic is byte-identical to the prior behavior. Existing search results are unaffected.

### Build + installer wiring
- `EngineLayer/EngineLayer.csproj` — `NGlycan_Custom.gdb`, `OGlycan_Custom.gdb`, and `MonosaccharidesCustom.tsv` all added as `<None Update>` with `PreserveNewest`. Files propagate to every downstream bin output (CMD, EngineLayer, GuiFunctions, TaskLayer, Test).
- `MetaMorpheusSetup/Product.wxs` — three new `<Component>` entries with fresh GUIDs, so the WiX installer ships them too.

### Naming gotcha (worth knowing for future contributors)

Existing tests in `TestOGlyco` select databases via `.Contains("OGlycan.gdb")` / `.Contains("NGlycan.gdb")` substring matching. The custom templates are therefore named `OGlycan_Custom.gdb` and `NGlycan_Custom.gdb` — the underscore breaks the substring match while keeping the files alphabetically near the originals in the dropdown. Names like `CustomOGlycan.gdb` would collide.

---

## Test plan

All test work lives in `Test/TestNGlyco.cs`. **75 glyco tests pass total** (61 baseline + 14 new).

### Custom-glycan loader (6 tests)
- [x] `LoadKindGlycan_SkipsCommentsAndBlankLines` — composition file with header comments, indented comments, and blank lines loads identically to its plain twin.
- [x] `LoadStructureGlycan_SkipsCommentsAndBlankLines` — same, for structure format; also asserts the 2× motif duplication still works (3 lines → 6 glycans).
- [x] `LoadGlycan_CommentOnlyFileYieldsNoGlycans` — comment-only file is valid input, yields zero glycans, does not throw.
- [x] `LoadKindGlycan_UnknownTokenThrowsWithFileAndLineNumber` — composition file with `Wibble(2)` on line 3 throws `MetaMorpheusException` whose message contains the file name, `"line 3"`, and the raw line; inner exception is preserved.
- [x] `LoadStructureGlycan_UnknownCharThrowsWithFileAndLineNumber` — structure file with `(N(Z))` on line 4 throws with the same diagnostics plus `'Z'` quoted in the message; inner is `FormatException`.
- [x] `LoadGlycan_CustomFileRoundTripsThroughEngineSelectionAndIonGeneration` — drops a 2-row commented custom `.gdb` in a temp dir, pushes its path onto `GlobalVariables.OGlycanDatabasePaths`, mirrors the exact selection-by-filename + load-with-ions pattern from `GlycoSearchEngine.cs`, asserts compositions, motif targets (S/T), `GlyId` continuity, and that `ToGenerateIons=true` populates child ions.

### Custom-monosaccharide loader (8 tests)
Each test wraps in `try/finally` calling `Glycan.ResetCustomMonosaccharides()` so registration cannot leak into other tests' static state.
- [x] `LoadCustomMonosaccharides_RoundTripsThroughCompositionAndMass` — register HexA (176.03209 Da), verify `KindCapacity` is now 12, `NameCharDic["HexA"]` maps to `('U', 11)`, parse `HexNAc(2)Hex(5)HexA(1)` and assert the resulting `Kind[]` length and per-slot counts, that `GetMass` sums correctly, and that `GetKindString` produces `"H5N2U1"`.
- [x] `LoadCustomMonosaccharides_CommentsBlanksAndHeaderRowAreSkipped` — file with `#` lines, blank line, optional `Name\t…` header, and one real entry registers exactly one custom MS.
- [x] `LoadCustomMonosaccharides_NameCollisionThrowsWithFileAndLineNumber` — `HexNAc` (built-in) on line 1 throws with file + line + name in message.
- [x] `LoadCustomMonosaccharides_CharCollisionThrows` — code `N` (built-in HexNAc code) throws with `'N'` and `line 1` in the message.
- [x] `LoadCustomMonosaccharides_NonLetterCodeRejected` — digit `1` as code throws with `"ASCII letter"` in message.
- [x] `LoadCustomMonosaccharides_NonNumericMassThrows` — `"not-a-number"` as mass throws with both `"MonoisotopicMass"` and the bad value in message.
- [x] `LoadCustomMonosaccharides_DiagnosticIonsEmittedWhenPresent` — register HexA with two diagnostic m/z values, build a glycan containing HexA, assert both scaled-int m/z values appear in `glycan.GlycanDiagnosticIons`.
- [x] `LoadCustomMonosaccharides_CustomCodeAcceptedInStructureFormat` — register HexA (code `U`), load a structure-format file containing `(N(H)(U))`, assert two glycans yielded (Nxs+Nxt) with the correct combined mass.

> Note: 4 pre-existing failures in `TestNOGlyco` (path resolution for `NGlycan_ForNoSearch.gdb` when tests run in a certain order) are present on the baseline of this branch and are **not** caused by this PR. They are flagged for a separate fix.
