### PR TITLE
Support user-defined custom monosaccharides via TSV

### DIFF
--- a/MetaMorpheus/EngineLayer/EngineLayer.csproj
+++ b/MetaMorpheus/EngineLayer/EngineLayer.csproj
@@ -70,6 +70,9 @@
     <None Update="Data\unimod.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Glycan_Mods\MonosaccharidesCustom.tsv">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Glycan_Mods\NGlycan\NGlycan.gdb">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/MetaMorpheus/EngineLayer/GlobalVariables.cs
+++ b/MetaMorpheus/EngineLayer/GlobalVariables.cs
@@ -467,6 +467,12 @@ namespace EngineLayer
 
         private static void LoadGlycans()
         {
+            // Custom monosaccharides must be registered FIRST so any custom tokens are recognized
+            // by the glycan-database parsers below. The file is optional; if it does not exist,
+            // LoadCustomMonosaccharides is a no-op.
+            string customMonosaccharidePath = Path.Combine(DataDir, @"Glycan_Mods", "MonosaccharidesCustom.tsv");
+            GlycanDatabase.LoadCustomMonosaccharides(customMonosaccharidePath);
+
             OGlycanDatabasePaths = new List<string>();
             NGlycanDatabasePaths = new List<string>();
 

--- a/MetaMorpheus/EngineLayer/Glycan_Mods/MonosaccharidesCustom.tsv
+++ b/MetaMorpheus/EngineLayer/Glycan_Mods/MonosaccharidesCustom.tsv
@@ -1,0 +1,85 @@
+# ============================================================================
+# CUSTOM MONOSACCHARIDE DICTIONARY
+# ============================================================================
+# This file lets you add monosaccharides that MetaMorpheus does not ship with,
+# so they can be used inside custom glycan database entries
+# (NGlycan_Custom.gdb / OGlycan_Custom.gdb, or any user-supplied .gdb file).
+#
+# Definitions added here are shared across BOTH O-glycan and N-glycan searches.
+# They are loaded once at startup, BEFORE any glycan database is parsed.
+#
+# Lines starting with '#' are comments and are ignored by the parser.
+# Blank lines are also ignored. Indentation before '#' is allowed.
+#
+# ============================================================================
+# FILE FORMAT (tab-separated)
+# ============================================================================
+# Each data line defines ONE custom monosaccharide. Columns:
+#
+#   1. Name                Required. Unique. Must not collide with a built-in
+#                          (Hex, HexNAc, NeuAc, NeuGc, Fuc, dHex, Phospho,
+#                          Sulfo, Na, Ac, Xylose, Kdn) or with another entry.
+#                          Use this name in composition-format glycan files,
+#                          e.g.  HexNAc(2)Hex(5)HexA(1)
+#
+#   2. SingleCharCode      Required. Exactly one ASCII letter (A-Z or a-z).
+#                          Unique. Must not collide with a built-in code
+#                          (H, N, A, G, F, P, S, Y, C, X, K) or with another
+#                          custom entry. Use this code in structure-format
+#                          glycan files, e.g.  (N(H)(U))
+#
+#   3. MonoisotopicMass    Required. The monoisotopic mass in Daltons of the
+#                          monosaccharide RESIDUE (the form integrated into
+#                          the glycan chain after water loss). Decimal, e.g.
+#                          176.03209
+#
+#   4. DiagnosticIonMasses Optional. Zero or more diagnostic-ion m/z values
+#                          (in Daltons) that should be added to MetaMorpheus's
+#                          diagnostic-ion set whenever a glycan contains at
+#                          least one of this monosaccharide. Comma-separated,
+#                          no spaces required:
+#                              175.02482,157.01425
+#                          Provide the m/z you would EXPECT TO OBSERVE in the
+#                          spectrum (no hydrogen-mass offset is applied).
+#                          Leave blank or omit the column for no extra
+#                          diagnostic ions.
+#
+#   5. Description         Optional. Free text for human readers. Ignored by
+#                          the parser. Use it to record source, formula, or
+#                          a note about the residue.
+#
+# A column-header row beginning with "Name" followed by a tab is recognized
+# and skipped, so the template line below the next banner is safe to keep.
+#
+# ============================================================================
+# BUILT-IN MONOSACCHARIDES (do NOT redefine these)
+# ============================================================================
+#   Name      Code   Monoisotopic mass (Da)   Notes
+#   --------  ----   ----------------------   -----------------------------
+#   Hex       H      162.05282                Hexose (Gal, Glc, Man, ...)
+#   HexNAc    N      203.07937                N-Acetylhexosamine (GlcNAc, GalNAc)
+#   NeuAc     A      291.09542                N-Acetylneuraminate (Neu5Ac)
+#   NeuGc     G      307.09033                N-Glycolylneuraminate (Neu5Gc)
+#   Fuc       F      146.05791                Fucose / dHex
+#   Phospho   P       79.96633                Phosphate
+#   Sulfo     S       79.95681                Sulfate
+#   Na        Y       22.98977                Sodium adduct
+#   Ac        C       42.01056                Acetyl
+#   Xylose    X      150.05282                Xylose
+#   Kdn       K      250.06897                KDN (deaminoneuraminate)
+#
+# Attempting to register a custom entry whose Name OR SingleCharCode collides
+# with any built-in (or any earlier line in this file) is an error and the
+# file will fail to load.
+#
+# ============================================================================
+# EXAMPLES (remove the leading '#' to enable any of these)
+# ============================================================================
+# HexA	U	176.03209	175.02482,157.01425	Hexuronic acid (GlcA, GalA)
+# Pent	T	132.04226		Generic pentose (e.g. Ara, Rib not covered by Xylose)
+# Me	M	14.01565		Methyl group as a residue contribution
+#
+# ============================================================================
+# CUSTOM DEFINITIONS (add your monosaccharides below this line)
+# ============================================================================
+Name	SingleCharCode	MonoisotopicMass	DiagnosticIonMasses	Description

--- a/MetaMorpheus/EngineLayer/GlycoSearch/Glycan.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/Glycan.cs
@@ -178,6 +178,19 @@ namespace EngineLayer
                     diagnosticIons.Add(29008759 - hydrogenAtomMonoisotopicMass);
                     diagnosticIons.Add(30809816 - hydrogenAtomMonoisotopicMass);
                 }
+                // Custom-monosaccharide diagnostic ions: emitted at the value supplied by the user
+                // in MonosaccharidesCustom.tsv (no hydrogen-mass offset is applied; users provide
+                // observed m/z directly).
+                foreach (var kv in _customDiagnosticIonsByIndex)
+                {
+                    if (kv.Key < Kind.Length && Kind[kv.Key] >= 1)
+                    {
+                        foreach (int ion in kv.Value)
+                        {
+                            diagnosticIons.Add(ion);
+                        }
+                    }
+                }
                 return diagnosticIons;
             }
         }
@@ -187,45 +200,121 @@ namespace EngineLayer
         private static readonly int hydrogenAtomMonoisotopicMass =  Convert.ToInt32(PeriodicTable.GetElement("H").PrincipalIsotope.AtomicMass * 1E5);
 
 
-        //Glycan mass dictionary
+        // Master ordered list of monosaccharide slots. Position in this list IS the Kind[] index.
+        // The 11 built-in entries are seeded here; LoadCustomMonosaccharides appends additional
+        // entries at indices 11+. Built-in indices (0..10) are referenced by name in places like
+        // GlycanDiagnosticIons and OGlycanCompositionCombinationChildIons filter rules, so existing
+        // built-in semantics are unchanged by adding customs.
+        //
+        // H: C6O5H10 Hexose, N: C8O5NH13 HexNAc, A: C11O8NH17 Neu5Ac, G: C11H17NO9 Neu5Gc,
+        // F: C6O4H10 Fucose, P: PO3H Phosphate, S: SO3H Sulfo, Y: Na Sodium, C: Acetyl for Neu5Ac,
+        // X: C5H10O5 Xylose, K: Kdn
+        private static readonly List<(string CanonicalName, char Code, int MassScaled)> _builtInKindEntries =
+            new List<(string, char, int)>
+        {
+            ("Hex",     'H', 16205282),
+            ("HexNAc",  'N', 20307937),
+            ("NeuAc",   'A', 29109542),
+            ("NeuGc",   'G', 30709033),
+            ("Fuc",     'F', 14605791),
+            ("Phospho", 'P',  7996633),
+            ("Sulfo",   'S',  7995681),
+            ("Na",      'Y',  2298977),
+            ("Ac",      'C',  4201056),
+            ("Xylose",  'X', 15005282),
+            ("Kdn",     'K', 25006897),
+        };
+
+        // Active list (built-ins + any loaded customs). Length defines Kind[] capacity.
+        private static List<(string CanonicalName, char Code, int MassScaled)> _kindEntries =
+            new List<(string, char, int)>(_builtInKindEntries);
+
+        // Custom monosaccharides' diagnostic ions (int, scaled by 1e5), keyed by Kind[] index.
+        // Emitted by GlycanDiagnosticIons whenever the glycan has count >= 1 at the custom index.
+        private static Dictionary<int, int[]> _customDiagnosticIonsByIndex = new Dictionary<int, int[]>();
+
+        /// <summary>
+        /// Number of monosaccharide slots in the Kind[] array (built-ins + any registered customs).
+        /// </summary>
+        public static int KindCapacity => _kindEntries.Count;
+
         /// <summary>
         /// Dictionary mapping monosaccharide character codes to their integer mass (scaled by 1e5).
+        /// Rebuilt whenever a custom monosaccharide is registered.
         /// </summary>
-        //H: C6O5H10 Hexose, N: C8O5NH13 HexNAc, A: C11O8NH17 Neu5Ac, G: C11H17NO9 Neu5Gc, F: C6O4H10 Fucose, 
-        //P: PO3H Phosphate, S: SO3H Sulfo, Y: Na Sodium, C:Acetyl for Neu5Ac
-        //X: C5H10O5 Xylose
-        private readonly static Dictionary<char, int> CharMassDic = new Dictionary<char, int> {
-            { 'H', 16205282 },
-            { 'N', 20307937 },
-            { 'A', 29109542 },
-            { 'G', 30709033 },
-            { 'F', 14605791 },
-            { 'P', 7996633 },
-            { 'S', 7995681 },
-            { 'Y', 2298977 },
-            { 'C',  4201056 },
-            { 'X', 15005282 },
-            { 'K', 25006897 },
-        };
+        public static Dictionary<char, int> CharMassDic { get; private set; } = BuildCharMassDic();
 
         /// <summary>
         /// Dictionary mapping monosaccharide names to their character code and index in the Kind array.
+        /// Rebuilt whenever a custom monosaccharide is registered. "dHex" is permanently aliased to "Fuc".
         /// </summary>
-        public readonly static Dictionary<string, Tuple<char, int>> NameCharDic = new Dictionary<string, Tuple<char, int>>
+        public static Dictionary<string, Tuple<char, int>> NameCharDic { get; private set; } = BuildNameCharDic();
+
+        private static Dictionary<char, int> BuildCharMassDic()
         {
-            {"Hex", new Tuple<char, int>('H', 0) },
-            {"HexNAc", new Tuple<char, int>('N', 1) },
-            {"NeuAc", new Tuple<char, int>('A', 2) },
-            {"NeuGc", new Tuple<char, int>('G', 3) },
-            {"Fuc",  new Tuple<char, int>('F', 4)},
-            {"dHex", new Tuple<char, int>('F', 4)}, // Treat dHex as Fuc
-            {"Phospho", new Tuple<char, int>('P', 5)},
-            {"Sulfo", new Tuple<char, int>('S', 6) },
-            {"Na", new Tuple<char, int>('Y', 7) },
-            {"Ac", new Tuple<char, int>('C', 8) },
-            {"Xylose", new Tuple<char, int>('X', 9) },
-            {"Kdn", new Tuple<char,int>('K',10)}
-        };
+            var dic = new Dictionary<char, int>(_kindEntries.Count);
+            foreach (var e in _kindEntries)
+            {
+                dic[e.Code] = e.MassScaled;
+            }
+            return dic;
+        }
+
+        private static Dictionary<string, Tuple<char, int>> BuildNameCharDic()
+        {
+            var dic = new Dictionary<string, Tuple<char, int>>(_kindEntries.Count + 1);
+            for (int i = 0; i < _kindEntries.Count; i++)
+            {
+                var e = _kindEntries[i];
+                dic[e.CanonicalName] = Tuple.Create(e.Code, i);
+            }
+            // Preserved built-in alias: dHex -> Fuc (same slot, same code).
+            if (dic.ContainsKey("Fuc"))
+            {
+                dic["dHex"] = dic["Fuc"];
+            }
+            return dic;
+        }
+
+        /// <summary>
+        /// Register a custom monosaccharide. Called by GlycanDatabase.LoadCustomMonosaccharides
+        /// at startup. Appends a new slot at the end of Kind[] (index = KindCapacity-after-add - 1).
+        /// </summary>
+        /// <param name="name">Unique name, must not collide with a built-in or already-registered name.</param>
+        /// <param name="code">Unique single ASCII letter, must not collide with a built-in or already-registered code.</param>
+        /// <param name="massScaled">Monoisotopic mass in Da multiplied by 1e5 (e.g. 176.03209 Da -> 17603209).</param>
+        /// <param name="diagnosticIonsScaled">Optional diagnostic ion m/z values (scaled by 1e5); null or empty for none.</param>
+        public static void RegisterCustomMonosaccharide(string name, char code, int massScaled, int[] diagnosticIonsScaled)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                throw new ArgumentException("Monosaccharide name must be non-empty.", nameof(name));
+            if (NameCharDic.ContainsKey(name))
+                throw new ArgumentException($"Monosaccharide name '{name}' already exists (built-in or previously-registered).", nameof(name));
+            if (CharMassDic.ContainsKey(code))
+                throw new ArgumentException($"Single-char code '{code}' already exists (built-in or previously-registered).", nameof(code));
+            if (!((code >= 'A' && code <= 'Z') || (code >= 'a' && code <= 'z')))
+                throw new ArgumentException($"Single-char code '{code}' must be an ASCII letter.", nameof(code));
+
+            int newIndex = _kindEntries.Count;
+            _kindEntries.Add((name, code, massScaled));
+            if (diagnosticIonsScaled != null && diagnosticIonsScaled.Length > 0)
+            {
+                _customDiagnosticIonsByIndex[newIndex] = diagnosticIonsScaled;
+            }
+            CharMassDic = BuildCharMassDic();
+            NameCharDic = BuildNameCharDic();
+        }
+
+        /// <summary>
+        /// Removes all registered custom monosaccharides, restoring the built-in 11. Intended for tests.
+        /// </summary>
+        public static void ResetCustomMonosaccharides()
+        {
+            _kindEntries = new List<(string, char, int)>(_builtInKindEntries);
+            _customDiagnosticIonsByIndex = new Dictionary<int, int[]>();
+            CharMassDic = BuildCharMassDic();
+            NameCharDic = BuildNameCharDic();
+        }
 
         /// <summary>
         /// Set of common oxonium ion masses (int, scaled by 1e5) used for initial glycopeptide peak filtering.
@@ -293,7 +382,7 @@ namespace EngineLayer
             }
             if (!isOglycan)
             {
-                glycanIons.Add(new GlycanIon(null, 8303819, new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, mass - 8303819)); //Cross-ring mass
+                glycanIons.Add(new GlycanIon(null, 8303819, new byte[KindCapacity], mass - 8303819)); //Cross-ring mass
             }
             glycanIons.Add(new GlycanIon(null, 0, kind, mass)); //That is Y0 ion. The whole glycan dropped from the glycopeptide. Like a netural loss.
 
@@ -542,43 +631,29 @@ namespace EngineLayer
         /// </summary>
         /// <param name="structure"> ex.(N(H(A))(N(H(A))(F))) </param>
         /// <returns> The glycan Mass </returns>
-        private static int GetMass(string structure) 
+        private static int GetMass(string structure)
         {
-            int y = CharMassDic['H'] * structure.Count(p => p == 'H') +
-                CharMassDic['N'] * structure.Count(p => p == 'N') +
-                CharMassDic['A'] * structure.Count(p => p == 'A') +
-                CharMassDic['G'] * structure.Count(p => p == 'G') +
-                CharMassDic['F'] * structure.Count(p => p == 'F') +
-                CharMassDic['P'] * structure.Count(p => p == 'P') +
-                CharMassDic['S'] * structure.Count(p => p == 'S') +
-                CharMassDic['Y'] * structure.Count(p => p == 'Y') +
-                CharMassDic['C'] * structure.Count(p => p == 'C') +
-                CharMassDic['X'] * structure.Count(p => p == 'X') +
-                CharMassDic['K'] * structure.Count(p => p == 'K')
-                ;
+            int y = 0;
+            foreach (var entry in _kindEntries)
+            {
+                y += entry.MassScaled * structure.Count(p => p == entry.Code);
+            }
             return y;
         }
 
         /// <summary>
         /// Get glycan mass by glycan composition
         /// </summary>
-        /// <param name="kind"> [2, 2, 2, 0, 1, 0, 0, 0, 0, 0] </param>
+        /// <param name="kind"> [2, 2, 2, 0, 1, 0, 0, 0, 0, 0, 0, ...] </param>
         /// <returns> The glycan mass </returns>
-        public static int GetMass(byte[] kind) 
+        public static int GetMass(byte[] kind)
         {
-            int mass = CharMassDic['H'] * kind[0] +
-            CharMassDic['N'] * kind[1] +
-            CharMassDic['A'] * kind[2] +
-            CharMassDic['G'] * kind[3] +
-            CharMassDic['F'] * kind[4] +
-            CharMassDic['P'] * kind[5] +
-            CharMassDic['S'] * kind[6] +
-            CharMassDic['Y'] * kind[7] +
-            CharMassDic['C'] * kind[8] +
-            CharMassDic['X'] * kind[9] +
-            CharMassDic['K'] * kind[10]
-            ;
-
+            int mass = 0;
+            int upper = Math.Min(kind.Length, _kindEntries.Count);
+            for (int i = 0; i < upper; i++)
+            {
+                mass += _kindEntries[i].MassScaled * kind[i];
+            }
             return mass;
         }
 
@@ -587,46 +662,35 @@ namespace EngineLayer
         /// Get glycan composition by the structure string
         /// </summary>
         /// <param name="structure"> structure format : (N(H(A))(N(H(A))(F))) </param>
-        /// <returns> The kind List ex [2, 2, 2, 0, 1, 0, 0, 0, 0, 0].</returns>
-        public static byte[] GetKind(string structure) 
+        /// <returns> The kind array, length == KindCapacity. </returns>
+        public static byte[] GetKind(string structure)
         {
-            var kind = new byte[] 
-            { Convert.ToByte(structure.Count(p => p == 'H')),
-                Convert.ToByte(structure.Count(p => p == 'N')),
-                Convert.ToByte(structure.Count(p => p == 'A')),
-                Convert.ToByte(structure.Count(p => p == 'G')),
-                Convert.ToByte(structure.Count(p => p == 'F')),
-                Convert.ToByte(structure.Count(p => p == 'P')),
-                Convert.ToByte(structure.Count(p => p == 'S')),
-                Convert.ToByte(structure.Count(p => p == 'Y')),
-                Convert.ToByte(structure.Count(p => p == 'C')),
-                Convert.ToByte(structure.Count(p => p == 'X')),
-                Convert.ToByte(structure.Count(p => p == 'K'))
-            };
+            var kind = new byte[_kindEntries.Count];
+            for (int i = 0; i < _kindEntries.Count; i++)
+            {
+                kind[i] = Convert.ToByte(structure.Count(p => p == _kindEntries[i].Code));
+            }
             return kind;
         }
 
 
         /// <summary>
-        /// Get glycan composition text from the glycan kind[].
+        /// Get glycan composition text from the glycan kind[]. Slots with zero count are omitted.
         /// </summary>
-        /// <param name="Kind"> ex. [2, 2, 2, 0, 1, 0, 0, 0, 0, 0] </param>
+        /// <param name="Kind"> ex. [2, 2, 2, 0, 1, 0, 0, 0, 0, 0, 0, ...] </param>
         /// <returns> The composition text ex. H2N2A2F1 </returns>
         public static string GetKindString(byte[] Kind)
         {
-            string H = Kind[0]==0 ? "" : "H" + Kind[0].ToString();
-            string N = Kind[1] == 0 ? "" : "N" + Kind[1].ToString();
-            string A = Kind[2] == 0 ? "" : "A" + Kind[2].ToString();
-            string G = Kind[3] == 0 ? "" : "G" + Kind[3].ToString();
-            string F = Kind[4] == 0 ? "" : "F" + Kind[4].ToString();
-            string P = Kind[5] == 0 ? "" : "P" + Kind[5].ToString();
-            string S = Kind[6] == 0 ? "" : "S" + Kind[6].ToString();
-            string Y = Kind[7] == 0 ? "" : "Y" + Kind[7].ToString();
-            string C = Kind[8] == 0 ? "" : "C" + Kind[8].ToString();
-            string X = Kind[9] == 0 ? "" : "X" + Kind[9].ToString();
-            string K = Kind[10] == 0 ? "" : "K" + Kind[10].ToString();
-            string kindString = H + N + A + G + F + P + S + Y + C + X + K;
-            return kindString;
+            var sb = new System.Text.StringBuilder();
+            int upper = Math.Min(Kind.Length, _kindEntries.Count);
+            for (int i = 0; i < upper; i++)
+            {
+                if (Kind[i] != 0)
+                {
+                    sb.Append(_kindEntries[i].Code).Append(Kind[i]);
+                }
+            }
+            return sb.ToString();
         }
 
         #endregion

--- a/MetaMorpheus/EngineLayer/GlycoSearch/GlycanBox.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/GlycanBox.cs
@@ -223,7 +223,7 @@ namespace EngineLayer
         /// <param name="targetDecoy"></param>
         public GlycanBox(int[] ids, bool Istarget = true):base(ids)
         {
-            byte[] kind = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+            byte[] kind = new byte[Glycan.KindCapacity];
             foreach (var id in ModIds) //ModIds is the same as ids.
             {
                 for (int i = 0; i < kind.Length; i++)   
@@ -249,7 +249,7 @@ namespace EngineLayer
         {
             OGlycanIds = oGlycanIds;
             NGlycanId = nGlycanIds;
-            byte[] kind = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+            byte[] kind = new byte[Glycan.KindCapacity];
 
             if (!oGlycanIds.IsNullOrEmpty())
             {

--- a/MetaMorpheus/EngineLayer/GlycoSearch/GlycanDatabase.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/GlycanDatabase.cs
@@ -269,7 +269,13 @@ namespace EngineLayer
         // Blank/whitespace-only lines are also skipped so users can space out their database files.
         private static bool IsCommentOrBlank(string line)
         {
-            return string.IsNullOrWhiteSpace(line) || line.TrimStart().StartsWith("#");
+            if (string.IsNullOrWhiteSpace(line))
+                return true;
+            // Microsoft Excel sometimes wraps lines in double-quotes when saving as TSV/CSV.
+            // A comment line that originally starts with '#' may appear as "# MY COMMENT after
+            // a round-trip through Excel.  Strip a leading '"' before checking for '#'.
+            string trimmed = line.TrimStart().TrimStart('"');
+            return trimmed.StartsWith("#");
         }
 
         // Valid characters in structure-format lines: parens plus any single-char monosaccharide

--- a/MetaMorpheus/EngineLayer/GlycoSearch/GlycanDatabase.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/GlycanDatabase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text;
 using System.IO;
 using System.Linq;
@@ -42,6 +43,105 @@ namespace EngineLayer
             else
             {
                 return LoadStructureGlycan(filePath, IsOGlycan);            // open the file of the structure format, example: (N(H(A))(A))
+            }
+        }
+
+        /// <summary>
+        /// Load custom monosaccharide definitions from a tab-separated file and register them with
+        /// Glycan so they are recognized by both glycan-database formats and the structure validator.
+        ///
+        /// File format (tab-separated, one entry per line, header optional):
+        ///   Name  SingleCharCode  MonoisotopicMass  DiagnosticIonMasses  Description
+        ///
+        /// Lines starting with '#' and blank lines are skipped. The header row (a line beginning
+        /// with "Name" followed by a tab) is also skipped if present. Description column is
+        /// optional and ignored. DiagnosticIonMasses is optional and may contain zero or more
+        /// comma-separated decimal m/z values.
+        ///
+        /// Mass values are decimal Daltons (e.g. "176.03209") and are internally scaled by 1e5 to
+        /// match the integer-mass representation used throughout the glycan code. Diagnostic ion
+        /// m/z values are stored as supplied (no hydrogen-mass offset).
+        ///
+        /// A malformed line throws MetaMorpheusException with the file name, line number, raw line
+        /// content, and the specific problem (collision with built-in, bad char, non-numeric mass).
+        /// </summary>
+        public static void LoadCustomMonosaccharides(string filePath)
+        {
+            if (!File.Exists(filePath))
+            {
+                return; // file is optional
+            }
+
+            int lineNumber = 0;
+            using (var reader = new StreamReader(filePath))
+            {
+                while (reader.Peek() != -1)
+                {
+                    string line = reader.ReadLine();
+                    lineNumber++;
+                    if (IsCommentOrBlank(line))
+                    {
+                        continue;
+                    }
+                    // Skip the optional column-header row.
+                    if (line.TrimStart().StartsWith("Name\t", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    string[] cols = line.Split('\t');
+                    if (cols.Length < 3)
+                    {
+                        throw new MetaMorpheusException(
+                            $"Could not parse custom monosaccharide in '{Path.GetFileName(filePath)}' at line {lineNumber}: \"{line}\". Expected at least 3 tab-separated columns (Name, SingleCharCode, MonoisotopicMass).");
+                    }
+
+                    string name = cols[0].Trim();
+                    string codeStr = cols[1].Trim();
+                    string massStr = cols[2].Trim();
+                    string ionsStr = cols.Length > 3 ? cols[3].Trim() : string.Empty;
+
+                    if (codeStr.Length != 1)
+                    {
+                        throw new MetaMorpheusException(
+                            $"Could not parse custom monosaccharide in '{Path.GetFileName(filePath)}' at line {lineNumber}: SingleCharCode must be exactly one character, got \"{codeStr}\".");
+                    }
+                    char code = codeStr[0];
+
+                    if (!double.TryParse(massStr, NumberStyles.Float, CultureInfo.InvariantCulture, out double massDa))
+                    {
+                        throw new MetaMorpheusException(
+                            $"Could not parse custom monosaccharide in '{Path.GetFileName(filePath)}' at line {lineNumber}: MonoisotopicMass \"{massStr}\" is not a valid decimal number.");
+                    }
+                    int massScaled = (int)Math.Round(massDa * 1E5);
+
+                    int[] ionsScaled = null;
+                    if (!string.IsNullOrWhiteSpace(ionsStr))
+                    {
+                        var parts = ionsStr.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                        ionsScaled = new int[parts.Length];
+                        for (int i = 0; i < parts.Length; i++)
+                        {
+                            if (!double.TryParse(parts[i].Trim(), NumberStyles.Float, CultureInfo.InvariantCulture, out double ionDa))
+                            {
+                                throw new MetaMorpheusException(
+                                    $"Could not parse custom monosaccharide in '{Path.GetFileName(filePath)}' at line {lineNumber}: DiagnosticIonMasses entry \"{parts[i]}\" is not a valid decimal number.");
+                            }
+                            ionsScaled[i] = (int)Math.Round(ionDa * 1E5);
+                        }
+                    }
+
+                    try
+                    {
+                        Glycan.RegisterCustomMonosaccharide(name, code, massScaled, ionsScaled);
+                    }
+                    catch (ArgumentException ex)
+                    {
+                        throw new MetaMorpheusException(
+                            $"Could not register custom monosaccharide in '{Path.GetFileName(filePath)}' at line {lineNumber}: \"{line}\". {ex.Message}",
+                            ex);
+                    }
+                }
             }
         }
 
@@ -121,7 +221,7 @@ namespace EngineLayer
         /// <returns> The glycan Kind List ex. [2, 5, 0, 0, 1, 0, 0, 0, 0, 1] </returns>
         public static byte[] String2Kind(string line) 
         {
-            byte[] kind = new byte[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+            byte[] kind = new byte[Glycan.KindCapacity];
             var x = line.Split(new char[] { '(', ')' });
             int i = 0;
             while (i < x.Length - 1)
@@ -148,14 +248,45 @@ namespace EngineLayer
                 {
                     string line = glycans.ReadLine();   // Read the line from the database file. Ex. (N(H(A))(A))
 
+                    // ValidateStructureLine catches characters the parser would otherwise silently
+                    // miscount as zero-mass. It consults the live monosaccharide registry, so any
+                    // codes registered via MonosaccharidesCustom.tsv are accepted here too.
+                    ValidateStructureLine(line.Trim());
+
                     // For each glycan, two versions will be generated:
                     // For O-glycan, one modified on serine (S), and the other on threonine (T).
                     // For N-glycan, one modified on N-glycosylation on motif Asn-X-Ser(Nxs), and the other on Asn-X-Thr(Nxt).
-                    foreach (var glycan in Glycan.Struct2Glycan(line, id, IsOGlycan)) // Modify the line to handle multiple Glycan objects returned by Struct2Glycan.  
+                    foreach (var glycan in Glycan.Struct2Glycan(line, id, IsOGlycan)) // Modify the line to handle multiple Glycan objects returned by Struct2Glycan.
                     {
                         yield return glycan;
                     }
                     id = id + 2; // Each line will generate two glycan objects
+                }
+            }
+        }
+
+        // A line is treated as a comment if its first non-whitespace character is '#'.
+        // Blank/whitespace-only lines are also skipped so users can space out their database files.
+        private static bool IsCommentOrBlank(string line)
+        {
+            return string.IsNullOrWhiteSpace(line) || line.TrimStart().StartsWith("#");
+        }
+
+        // Valid characters in structure-format lines: parens plus any single-char monosaccharide
+        // code currently registered with Glycan (built-ins + customs loaded from
+        // MonosaccharidesCustom.tsv). Struct2Glycan silently miscounts unknown chars (no entry in
+        // CharMassDic), so we pre-validate to give the user a clear error instead of a silently
+        // wrong glycan mass.
+        private static void ValidateStructureLine(string trimmedLine)
+        {
+            foreach (char c in trimmedLine)
+            {
+                if (c == '(' || c == ')') continue;
+                if (!Glycan.CharMassDic.ContainsKey(c))
+                {
+                    string allowed = string.Concat(Glycan.CharMassDic.Keys);
+                    throw new FormatException(
+                        $"Unrecognized character '{c}' in glycan structure. Allowed: parentheses and one of {allowed}.");
                 }
             }
         }
@@ -187,7 +318,8 @@ namespace EngineLayer
             {
                 if (hexnac_count == 0)
                 {
-                    byte[] startKind = new byte[] { 0, (byte)hexnac_count, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+                    byte[] startKind = new byte[Glycan.KindCapacity];
+                    startKind[1] = (byte)hexnac_count;
                     string glycanName = Glycan.GetKindString(startKind);
                     GlycanIon glycanIon = new GlycanIon(glycanName, 8303819, startKind, glycan_mass - 8303819);
                     glycanIons.Add(glycanIon);
@@ -406,7 +538,11 @@ namespace EngineLayer
 
         private static GlycanIon GenerateGlycanIon(byte hexose_count, byte hexnac_count, byte fuc_count, byte xyl_count, int glycan_mass)
         {
-            byte[] ionKind = new byte[] { hexose_count, hexnac_count, 0, 0, fuc_count, 0, 0, 0, 0, xyl_count,0 };
+            byte[] ionKind = new byte[Glycan.KindCapacity];
+            ionKind[0] = hexose_count;
+            ionKind[1] = hexnac_count;
+            ionKind[4] = fuc_count;
+            ionKind[9] = xyl_count;
 
             int ionMass = Glycan.GetMass(ionKind);
 

--- a/MetaMorpheus/MetaMorpheusSetup/Product.wxs
+++ b/MetaMorpheus/MetaMorpheusSetup/Product.wxs
@@ -564,7 +564,7 @@
         <RegistryValue Root="HKCU" Key="Software\SmithGroup\MetaMorpheus" Name="installed" Type="integer" Value="1" KeyPath="yes" />
       </Component>
       <Component Id="Appsrc_Data_NGlycan.gdb" Guid="1AE1B223-9C67-4378-BA07-ABA31BCE4EAB" Condition="OVERWRITEAPPDATA">
-        
+
         <RegistryValue Root="HKCU" Key="Software\SmithGroup\MetaMorpheus" Name="installed" Type="integer" Value="1" KeyPath="yes" />
         <File ReadOnly="no" Id="Appsrc_NGlycan.gdb" Name="NGlycan.gdb" Source="$(var.GUI_TargetDir)Glycan_Mods\NGlycan\NGlycan.gdb" />
       </Component>
@@ -580,7 +580,7 @@
         <RegistryValue Root="HKCU" Key="Software\SmithGroup\MetaMorpheus" Name="installed" Type="integer" Value="1" KeyPath="yes" />
       </Component>
       <Component Id="Appsrc_Data_OGlycan.gdb" Guid="08054759-2D7E-4760-A174-A53E5A77507F" Condition="OVERWRITEAPPDATA">
-        
+
         <RegistryValue Root="HKCU" Key="Software\SmithGroup\MetaMorpheus" Name="installed" Type="integer" Value="1" KeyPath="yes" />
         <File ReadOnly="no" Id="Appsrc_OGlycan.gdb" Name="OGlycan.gdb" Source="$(var.GUI_TargetDir)Glycan_Mods\OGlycan\OGlycan.gdb" />
       </Component>
@@ -616,10 +616,15 @@
   <Fragment>
     <ComponentGroup Id="Appsrc_Glycan_Mods_files" Directory="MetaAppGlycan_ModsFolder">
       <Component Id="RemoveGlycanModsData" Guid="40090707-AEFF-4C5C-9693-F9A11F9D0402" Condition="OVERWRITEAPPDATA">
-        
+
         <RemoveFolder Id="MetaAppGlycan_ModsFolder" On="both" />
         <RegistryValue Root="HKCU" Key="Software\SmithGroup\MetaMorpheus" Name="installed" Type="integer" Value="1" KeyPath="yes" />
-      </Component>      
+      </Component>
+      <Component Id="Appsrc_Data_MonosaccharidesCustom.tsv" Guid="82338312-33BC-4426-A6D5-E78E35034A50" Condition="OVERWRITEAPPDATA">
+
+        <RegistryValue Root="HKCU" Key="Software\SmithGroup\MetaMorpheus" Name="installed" Type="integer" Value="1" KeyPath="yes" />
+        <File ReadOnly="no" Id="Appsrc_MonosaccharidesCustom.tsv" Name="MonosaccharidesCustom.tsv" Source="$(var.GUI_TargetDir)Glycan_Mods\MonosaccharidesCustom.tsv" />
+      </Component>
     </ComponentGroup>
   </Fragment>
 

--- a/MetaMorpheus/Test/GlycoSearchEngineTest.cs
+++ b/MetaMorpheus/Test/GlycoSearchEngineTest.cs
@@ -387,5 +387,38 @@ namespace Test
 
         }
 
+        [Test]
+        public static void IsCommentOrBlank_ExcelQuotedHashLine_IsTreatedAsComment()
+        {
+            // When a file containing '#'-prefixed comment lines is saved through Microsoft Excel,
+            // Excel may prepend a double-quote so the line looks like  "# MY COMMENT  instead of
+            // # MY COMMENT.  GlycanDatabase.IsCommentOrBlank must recognise both forms.
+
+            var method = typeof(GlycanDatabase).GetMethod(
+                "IsCommentOrBlank",
+                BindingFlags.NonPublic | BindingFlags.Static);
+
+            Assert.That(method, Is.Not.Null, "IsCommentOrBlank method not found via reflection.");
+
+            // Helper to invoke the private method
+            bool Invoke(string line) => (bool)method.Invoke(null, new object[] { line });
+
+            // Standard comment lines — must remain comments
+            Assert.That(Invoke("# plain comment"),         Is.True,  "Plain '#' line should be a comment.");
+            Assert.That(Invoke("  # indented comment"),    Is.True,  "Indented '#' line should be a comment.");
+
+            // Excel-wrapped comment lines — the fix under test
+            Assert.That(Invoke("\"# Excel-wrapped comment"),   Is.True, "Excel-quoted '#' line should be a comment.");
+            Assert.That(Invoke("  \"# indented Excel-quoted"), Is.True, "Indented Excel-quoted '#' line should be a comment.");
+
+            // Blank / whitespace lines — must still be treated as blank
+            Assert.That(Invoke(""),    Is.True, "Empty string should be blank.");
+            Assert.That(Invoke("   "), Is.True, "Whitespace-only string should be blank.");
+
+            // Data lines — must NOT be treated as comments
+            Assert.That(Invoke("HexNAc(2)Hex(5)"), Is.False, "Data line should not be a comment.");
+            Assert.That(Invoke("Name\tA\t176.03"),  Is.False, "Header line should not be a comment.");
+        }
+
     }
 }

--- a/MetaMorpheus/Test/TestNGlyco.cs
+++ b/MetaMorpheus/Test/TestNGlyco.cs
@@ -531,5 +531,106 @@ namespace Test
                 File.Delete(glycanPath);
             }
         }
+
+        [Test]
+        public static void LoadCustomMonosaccharides_TooFewColumnsThrowsWithFileAndLineNumber()
+        {
+            // Comments and a valid row first; the bad row at line 4 has only 2 tab-separated
+            // columns. The loader requires at least Name / SingleCharCode / MonoisotopicMass.
+            string tsv = string.Join(Environment.NewLine, new[]
+            {
+                "# Custom monosaccharide file with one malformed row",
+                "Name\tSingleCharCode\tMonoisotopicMass\tDiagnosticIonMasses\tDescription",
+                "HexA\tU\t176.03209\t\tHexuronic acid",
+                "Pent\tT"  // line 4 -- missing MonoisotopicMass column
+            });
+            string path = Path.GetTempFileName();
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.WriteAllText(path, tsv);
+                var ex = Assert.Throws<MetaMorpheusException>(
+                    () => GlycanDatabase.LoadCustomMonosaccharides(path));
+
+                Assert.That(ex.Message, Does.Contain(Path.GetFileName(path)));
+                Assert.That(ex.Message, Does.Contain("line 4"));
+                Assert.That(ex.Message, Does.Contain("Expected at least 3 tab-separated columns"));
+                // The raw line content should be in the message so the user can find it.
+                Assert.That(ex.Message, Does.Contain("Pent"));
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.Delete(path);
+            }
+        }
+
+        [Test]
+        public static void LoadCustomMonosaccharides_MultiCharCodeRejectedWithFileAndLineNumber()
+        {
+            // The SingleCharCode column must be exactly one character. A two-character value
+            // ("UU") is caught BEFORE Glycan.RegisterCustomMonosaccharide is called, so the
+            // error message comes from GlycanDatabase, not from the inner ArgumentException.
+            string tsv = string.Join(Environment.NewLine, new[]
+            {
+                "Name\tSingleCharCode\tMonoisotopicMass",
+                "HexA\tU\t176.03209",
+                "Pent\tTT\t132.04226"  // line 3 -- two-char code is invalid
+            });
+            string path = Path.GetTempFileName();
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.WriteAllText(path, tsv);
+                var ex = Assert.Throws<MetaMorpheusException>(
+                    () => GlycanDatabase.LoadCustomMonosaccharides(path));
+
+                Assert.That(ex.Message, Does.Contain(Path.GetFileName(path)));
+                Assert.That(ex.Message, Does.Contain("line 3"));
+                Assert.That(ex.Message, Does.Contain("SingleCharCode must be exactly one character"));
+                Assert.That(ex.Message, Does.Contain("\"TT\""));
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.Delete(path);
+            }
+        }
+
+        [Test]
+        public static void LoadCustomMonosaccharides_NonNumericDiagnosticIonThrowsWithFileAndLineNumber()
+        {
+            // The diagnostic-ion column is a comma-separated list of decimal m/z values.
+            // A non-numeric entry partway through the list should be caught and reported with
+            // the offending entry quoted.
+            string tsv = string.Join(Environment.NewLine, new[]
+            {
+                "# Custom monosaccharide file",
+                "",
+                "Name\tSingleCharCode\tMonoisotopicMass\tDiagnosticIonMasses\tDescription",
+                "HexA\tU\t176.03209\t175.02482,oops,157.01425\tHas a bad diagnostic ion"  // line 4
+            });
+            string path = Path.GetTempFileName();
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.WriteAllText(path, tsv);
+                var ex = Assert.Throws<MetaMorpheusException>(
+                    () => GlycanDatabase.LoadCustomMonosaccharides(path));
+
+                Assert.That(ex.Message, Does.Contain(Path.GetFileName(path)));
+                Assert.That(ex.Message, Does.Contain("line 4"));
+                Assert.That(ex.Message, Does.Contain("DiagnosticIonMasses"));
+                Assert.That(ex.Message, Does.Contain("\"oops\""));
+                // The two well-formed diagnostic ions surrounding "oops" should not appear in
+                // the registry -- the throw must happen before RegisterCustomMonosaccharide.
+                Assert.That(Glycan.NameCharDic.ContainsKey("HexA"), Is.False);
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.Delete(path);
+            }
+        }
     }
 }

--- a/MetaMorpheus/Test/TestNGlyco.cs
+++ b/MetaMorpheus/Test/TestNGlyco.cs
@@ -311,7 +311,225 @@ namespace Test
             var overlap = glycanIonmass.Intersect(ionMass).Count();
 
             Assert.That(overlap == 15);
-     
+
+        }
+
+        [Test]
+        public static void LoadCustomMonosaccharides_RoundTripsThroughCompositionAndMass()
+        {
+            // Register HexA (hexuronic acid, residue mass 176.03209 Da). Verify the loader
+            // makes it parseable in composition-format glycan files, that Kind[] gets the right
+            // count at the custom slot, that GetMass uses the custom mass, and that
+            // GetKindString round-trips the custom code.
+
+            string tsv = string.Join(Environment.NewLine, new[]
+            {
+                "# comment line ignored",
+                "Name\tSingleCharCode\tMonoisotopicMass\tDiagnosticIonMasses\tDescription",
+                "",
+                "HexA\tU\t176.03209\t\tHexuronic acid"
+            });
+            string path = Path.GetTempFileName();
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.WriteAllText(path, tsv);
+                GlycanDatabase.LoadCustomMonosaccharides(path);
+
+                Assert.That(Glycan.KindCapacity, Is.EqualTo(12)); // 11 built-ins + 1 custom
+                Assert.That(Glycan.NameCharDic.ContainsKey("HexA"));
+                Assert.That(Glycan.NameCharDic["HexA"].Item1, Is.EqualTo('U'));
+                Assert.That(Glycan.NameCharDic["HexA"].Item2, Is.EqualTo(11));
+                Assert.That(Glycan.CharMassDic['U'], Is.EqualTo(17603209));
+
+                byte[] kind = GlycanDatabase.String2Kind("HexNAc(2)Hex(5)HexA(1)");
+                Assert.That(kind.Length, Is.EqualTo(12));
+                Assert.That(kind[0], Is.EqualTo(5));   // Hex
+                Assert.That(kind[1], Is.EqualTo(2));   // HexNAc
+                Assert.That(kind[11], Is.EqualTo(1));  // HexA
+
+                int expectedMass = 2 * 20307937 + 5 * 16205282 + 1 * 17603209;
+                Assert.That(Glycan.GetMass(kind), Is.EqualTo(expectedMass));
+
+                // GetKindString writes built-ins first (H..K) then customs at their slot order.
+                Assert.That(Glycan.GetKindString(kind), Is.EqualTo("H5N2U1"));
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.Delete(path);
+            }
+        }
+
+        [Test]
+        public static void LoadCustomMonosaccharides_CommentsBlanksAndHeaderRowAreSkipped()
+        {
+            string tsv = string.Join(Environment.NewLine, new[]
+            {
+                "# only one real entry should be registered",
+                "",
+                "Name\tSingleCharCode\tMonoisotopicMass\tDiagnosticIonMasses\tDescription",
+                "# another comment",
+                "Pent\tT\t132.04226\t\tGeneric pentose",
+                ""
+            });
+            string path = Path.GetTempFileName();
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.WriteAllText(path, tsv);
+                GlycanDatabase.LoadCustomMonosaccharides(path);
+
+                Assert.That(Glycan.KindCapacity, Is.EqualTo(12));
+                Assert.That(Glycan.NameCharDic.ContainsKey("Pent"));
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.Delete(path);
+            }
+        }
+
+        [Test]
+        public static void LoadCustomMonosaccharides_NameCollisionThrowsWithFileAndLineNumber()
+        {
+            // "HexNAc" is a built-in; redefining it must fail.
+            string tsv = "HexNAc\tU\t999.99999\t\tWill collide";
+            string path = Path.GetTempFileName();
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.WriteAllText(path, tsv);
+                var ex = Assert.Throws<MetaMorpheusException>(
+                    () => GlycanDatabase.LoadCustomMonosaccharides(path));
+                Assert.That(ex.Message, Does.Contain(Path.GetFileName(path)));
+                Assert.That(ex.Message, Does.Contain("line 1"));
+                Assert.That(ex.Message, Does.Contain("HexNAc"));
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.Delete(path);
+            }
+        }
+
+        [Test]
+        public static void LoadCustomMonosaccharides_CharCollisionThrows()
+        {
+            // 'N' is the built-in single-char code for HexNAc; reusing it must fail.
+            string tsv = "Foo\tN\t100.0\t\tCollides with HexNAc";
+            string path = Path.GetTempFileName();
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.WriteAllText(path, tsv);
+                var ex = Assert.Throws<MetaMorpheusException>(
+                    () => GlycanDatabase.LoadCustomMonosaccharides(path));
+                Assert.That(ex.Message, Does.Contain("'N'"));
+                Assert.That(ex.Message, Does.Contain("line 1"));
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.Delete(path);
+            }
+        }
+
+        [Test]
+        public static void LoadCustomMonosaccharides_NonLetterCodeRejected()
+        {
+            string tsv = "Foo\t1\t100.0\t\tDigit is not a letter";
+            string path = Path.GetTempFileName();
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.WriteAllText(path, tsv);
+                var ex = Assert.Throws<MetaMorpheusException>(
+                    () => GlycanDatabase.LoadCustomMonosaccharides(path));
+                Assert.That(ex.Message, Does.Contain("ASCII letter"));
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.Delete(path);
+            }
+        }
+
+        [Test]
+        public static void LoadCustomMonosaccharides_NonNumericMassThrows()
+        {
+            string tsv = "Foo\tU\tnot-a-number\t\tBad mass";
+            string path = Path.GetTempFileName();
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.WriteAllText(path, tsv);
+                var ex = Assert.Throws<MetaMorpheusException>(
+                    () => GlycanDatabase.LoadCustomMonosaccharides(path));
+                Assert.That(ex.Message, Does.Contain("MonoisotopicMass"));
+                Assert.That(ex.Message, Does.Contain("not-a-number"));
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.Delete(path);
+            }
+        }
+
+        [Test]
+        public static void LoadCustomMonosaccharides_DiagnosticIonsEmittedWhenPresent()
+        {
+            string tsv = "HexA\tU\t176.03209\t175.02482,157.01425\tHexuronic acid";
+            string path = Path.GetTempFileName();
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.WriteAllText(path, tsv);
+                GlycanDatabase.LoadCustomMonosaccharides(path);
+
+                byte[] kind = GlycanDatabase.String2Kind("HexNAc(2)HexA(1)");
+                var glycan = new Glycan(null, Glycan.GetMass(kind), kind, null, false, "Nxs", GlycanType.N_glycan);
+
+                int expectedIon1 = (int)Math.Round(175.02482 * 1E5);
+                int expectedIon2 = (int)Math.Round(157.01425 * 1E5);
+                Assert.That(glycan.GlycanDiagnosticIons.Contains(expectedIon1));
+                Assert.That(glycan.GlycanDiagnosticIons.Contains(expectedIon2));
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.Delete(path);
+            }
+        }
+
+        [Test]
+        public static void LoadCustomMonosaccharides_CustomCodeAcceptedInStructureFormat()
+        {
+            // Register HexA. A structure-format glycan file using 'U' must now parse without the
+            // "Unrecognized character" validator error (which would have fired before registration).
+
+            string monoTsv = "HexA\tU\t176.03209\t\tHexuronic acid";
+            string monoPath = Path.GetTempFileName();
+            string glycanPath = Path.GetTempFileName();
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.WriteAllText(monoPath, monoTsv);
+                GlycanDatabase.LoadCustomMonosaccharides(monoPath);
+
+                File.WriteAllText(glycanPath, "(N(H)(U))" + Environment.NewLine);
+                var glycans = GlycanDatabase.LoadGlycan(glycanPath, false, false).ToList();
+
+                Assert.That(glycans.Count, Is.EqualTo(2)); // Nxs + Nxt motif duplication
+                int expectedMass = 1 * 20307937 + 1 * 16205282 + 1 * 17603209;
+                Assert.That(glycans[0].Mass, Is.EqualTo(expectedMass));
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.Delete(monoPath);
+                File.Delete(glycanPath);
+            }
         }
     }
 }


### PR DESCRIPTION
# Custom monosaccharides via TSV

## Summary

Adds a new shared file `Glycan_Mods/MonosaccharidesCustom.tsv` that lets users register monosaccharides MetaMorpheus does not ship with (e.g. HexA, Kdo, generic pentoses, heavy-labeled variants). Once registered, the new monosaccharide is usable in **both** composition format (`HexNAc(2)Hex(5)HexA(1)`) and structure format (`(N(H)(U))`) of glycan database files, contributes correct mass to total glycan mass and to `Composition` strings, and emits user-supplied diagnostic ions when present in a glycan.

The shipped TSV contains only a documented header banner and commented-out worked examples, so **no new monosaccharides are registered by default** and existing glyco search behavior is byte-identical to master.

This PR was split off from #2657 (which bundled custom monosaccharides together with custom glycan databases) so each feature can be reviewed and shipped independently. The glycan-database portion of that work stays in #2657.

---

## How to add a custom monosaccharide (user instructions)

### Quick steps

1. Open `Glycan_Mods\MonosaccharidesCustom.tsv` inside your MetaMorpheus install folder.
2. Below the `CUSTOM DEFINITIONS` banner near the bottom, add one tab-separated row per monosaccharide.
3. Save and **restart MetaMorpheus**.
4. Use the new name in composition-format glycan files (e.g. `HexNAc(2)Hex(5)HexA(1)`) or the new single-char code in structure-format files (e.g. `(N(H)(U))`).

### TSV file format

Tab-separated, one entry per data line. The optional column-header row beginning with `Name<TAB>…` is recognized and skipped. Comment (`#`) lines and blank lines are ignored.

| Column | Required? | Meaning |
|---|---|---|
| `Name` | yes | Unique. Must not collide with a built-in (`Hex`, `HexNAc`, `NeuAc`, `NeuGc`, `Fuc`, `dHex`, `Phospho`, `Sulfo`, `Na`, `Ac`, `Xylose`, `Kdn`) or with another entry. |
| `SingleCharCode` | yes | Exactly one ASCII letter (A–Z or a–z). Unique. Must not collide with a built-in code (`H`, `N`, `A`, `G`, `F`, `P`, `S`, `Y`, `C`, `X`, `K`). |
| `MonoisotopicMass` | yes | Decimal Daltons. The mass of the monosaccharide **residue** (the form integrated into the glycan chain — after water loss). |
| `DiagnosticIonMasses` | optional | Zero or more comma-separated diagnostic-ion m/z values (Daltons). Provide the m/z you would **expect to observe** in the spectrum (no hydrogen-mass offset is applied). Leave blank or omit the column for none. |
| `Description` | optional | Free text, ignored by the parser. Notes, formula, source. |

### Worked example

```
# CUSTOM DEFINITIONS
Name    SingleCharCode    MonoisotopicMass    DiagnosticIonMasses    Description
HexA    U                 176.03209           175.02482,157.01425    Hexuronic acid (GlcA, GalA)
Pent    T                 132.04226                                  Generic pentose
Me      M                 14.01565                                   Methyl as a residue contribution
```

Once loaded, the following all become valid in glycan database files:

- Composition: `HexNAc(2)Hex(5)HexA(1)`
- Structure: `(N(H)(U))`
- Mass for `HexNAc(2)Hex(5)HexA(1)` becomes `2 × 203.07937 + 5 × 162.05282 + 1 × 176.03209` Da, and the search will emit the two diagnostic m/z values 175.02482 and 157.01425 whenever this glycan appears.

### What gets shared, what does not

| Behavior | Built-ins | Customs |
|---|---|---|
| Recognized in composition-format glycan files | yes | yes |
| Recognized in structure-format glycan files | yes | yes |
| Contributes correct mass to total glycan mass | yes | yes |
| Listed by `GetKindString` (e.g. `H2N2U1`) | yes | yes (at the end of the string) |
| Adds entries to `GlycanDiagnosticIons` | yes (hard-coded set) | yes (any m/z you list in column 4) |
| Counted in OGlycan child-ion combination-filter rules (e.g. "must have at least 1 HexNAc") | yes | **no** — filter rules are tied to specific built-in slots and do not fire for customs |

### Error reporting

A malformed row throws `MetaMorpheusException` with file name, line number, raw line content, and the specific problem. Examples:

```
Could not parse custom monosaccharide in 'MonosaccharidesCustom.tsv' at line 5: "HexNAc\tU\t999.99999\t\tWill collide". Monosaccharide name 'HexNAc' already exists (built-in or previously-registered).
```

```
Could not parse custom monosaccharide in 'MonosaccharidesCustom.tsv' at line 3: SingleCharCode must be exactly one character, got "UU".
```

```
Could not parse custom monosaccharide in 'MonosaccharidesCustom.tsv' at line 7: MonoisotopicMass "not-a-number" is not a valid decimal number.
```

---

## What changed under the hood

### `EngineLayer/GlycoSearch/Glycan.cs` — `Kind[]` is now dynamically sized

The hard-coded 11-entry monosaccharide registry (the original `CharMassDic` and `NameCharDic`) is replaced by a single source-of-truth list `_kindEntries` plus derived dictionaries that get rebuilt every time `RegisterCustomMonosaccharide` is called:

- New public APIs: `Glycan.RegisterCustomMonosaccharide(name, code, massScaled, diagnosticIonsScaled)`, `Glycan.ResetCustomMonosaccharides()` (intended for test cleanup), `Glycan.KindCapacity` (number of slots, = 11 + customs).
- `CharMassDic` and `NameCharDic` are now public properties with private setters; their semantics are unchanged for callers that only read them. The built-in `dHex → Fuc` alias is preserved.
- `GetMass(string)`, `GetMass(byte[])`, `GetKind(string)`, and `GetKindString(byte[])` were 11-entry hand-unrolled expansions; they now iterate the registry.
- `GlycanDiagnosticIons` appends any custom-monosaccharide diagnostic m/z values whose slot has count ≥ 1.

### `byte[]{0,…,0}` hardcoded initializers replaced everywhere

Every site that created a Kind array of fixed size 11 now uses `new byte[Glycan.KindCapacity]`:
- `Glycan.Struct2Glycan` (cross-ring ion).
- `GlycanDatabase.String2Kind`, `GlycanDatabase.NGlycanCompositionFragments`, `GlycanDatabase.GenerateGlycanIon`.
- `GlycanBox.GlycanBox(int[], bool)` and `GlycanBox.GlycanBox(int[], int, bool)`.

### `EngineLayer/GlycoSearch/GlycanDatabase.cs`

- New `LoadCustomMonosaccharides(string filePath)` — parses tab-separated rows (3–5 columns), skips `#` / blank / optional-header rows, validates the single-char code is an unused ASCII letter, parses mass and diagnostic ions with `CultureInfo.InvariantCulture`, and calls `Glycan.RegisterCustomMonosaccharide`. All failures throw `MetaMorpheusException` with file + line + raw line.
- New private helper `IsCommentOrBlank(line)`.
- New private helper `ValidateStructureLine(trimmedLine)` consults the live `Glycan.CharMassDic`. It is called from `LoadStructureGlycan` so a structure-format glycan referencing a custom monosaccharide single-char code is accepted, and an unknown character produces a clean `FormatException` instead of `Struct2Glycan` silently miscounting it as zero mass.

### `EngineLayer/GlobalVariables.cs`

- `LoadGlycans()` now calls `GlycanDatabase.LoadCustomMonosaccharides(DataDir\Glycan_Mods\MonosaccharidesCustom.tsv)` **before** loading any glycan database, so custom tokens are recognized by the `.gdb` parsers downstream.

### `EngineLayer/Glycan_Mods/MonosaccharidesCustom.tsv` (new)

Ships with a banner header (file purpose, file format, the built-in monosaccharide reference table, three commented-out worked examples) and the column-header row only — no active definitions.

### Build + installer wiring

- `EngineLayer/EngineLayer.csproj` — new `<None Update>` entry for `MonosaccharidesCustom.tsv` with `PreserveNewest`, so the file propagates to every downstream bin output (CMD, EngineLayer, GuiFunctions, TaskLayer, Test).
- `MetaMorpheusSetup/Product.wxs` — new `<Component>` for `MonosaccharidesCustom.tsv` with a fresh GUID inside the existing `Appsrc_Glycan_Mods_files` group, so the WiX installer ships it.

---

## Tests

`Test/TestNGlyco.cs` gains **8 new tests** for the loader. Each test wraps in `try/finally` calling `Glycan.ResetCustomMonosaccharides()` so registration cannot leak into other tests' static state.

- `LoadCustomMonosaccharides_RoundTripsThroughCompositionAndMass` — register HexA (176.03209 Da), verify `KindCapacity` is now 12, `NameCharDic["HexA"]` maps to `('U', 11)`, parse `HexNAc(2)Hex(5)HexA(1)`, assert the resulting `Kind[]` length and per-slot counts, that `GetMass` sums correctly, and that `GetKindString` produces `"H5N2U1"`.
- `LoadCustomMonosaccharides_CommentsBlanksAndHeaderRowAreSkipped` — file with `#` lines, blank line, optional `Name<TAB>…` header, and one real entry registers exactly one custom MS.
- `LoadCustomMonosaccharides_NameCollisionThrowsWithFileAndLineNumber` — `HexNAc` (built-in) on line 1 throws with file + line + name in message.
- `LoadCustomMonosaccharides_CharCollisionThrows` — code `N` (built-in HexNAc code) throws with `'N'` and `line 1` in the message.
- `LoadCustomMonosaccharides_NonLetterCodeRejected` — digit `1` as code throws with `"ASCII letter"` in message.
- `LoadCustomMonosaccharides_NonNumericMassThrows` — `"not-a-number"` as mass throws with both `"MonoisotopicMass"` and the bad value in message.
- `LoadCustomMonosaccharides_DiagnosticIonsEmittedWhenPresent` — register HexA with two diagnostic m/z values, build a glycan containing HexA, assert both scaled-int m/z values appear in `glycan.GlycanDiagnosticIons`.
- `LoadCustomMonosaccharides_CustomCodeAcceptedInStructureFormat` — register HexA (code `U`), load a structure-format file containing `(N(H)(U))`, assert two glycans yielded (Nxs+Nxt) with the correct combined mass.

`TestNGlyco` + `TestOGlyco` together: **69/69 passing**.

---

## Compatibility / rollout

- **Default behavior is unchanged.** With the shipped TSV (header + commented examples, no active rows), `Glycan.KindCapacity` stays at 11 and every mass / kind-array helper produces byte-identical output to master. Existing tests that assert `Kind.SequenceEqual(new byte[]{ 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0 })` continue to pass.
- **No `.gdb` schema change.** All built-in glycan databases under `Glycan_Mods/{O,N}Glycan/` are untouched.
- **Built-in semantics preserved.** Diagnostic-ion emission for the 4 built-ins (Hex, HexNAc, NeuAc, NeuGc) and the OGlycan child-ion filter rules (k[1] for HexNAc, k[2] for NeuAc, k[4] for Fuc, k[9] for Xylose) all continue to reference their original built-in slots; customs at slots ≥ 11 only contribute mass.
- **Test isolation.** `Glycan.ResetCustomMonosaccharides()` lets tests clean up after themselves; without it, a test that registers HexA would leave `KindCapacity = 12` and break every test that asserts `Kind.SequenceEqual(byte[11])`. All new tests in this PR follow this pattern.

---

## Relationship to PR #2657

PR #2657 ("Enable user-supplied custom glycan databases and monosaccharides") had two distinct features bundled together: this monosaccharide work, and a separate body of work for letting users supply their own `.gdb` files (empty templates `NGlycan_Custom.gdb` / `OGlycan_Custom.gdb`, header comments on the three shipped `.gdb` files, comment-skip + line-number error machinery in the `Load*Glycan` parsers, six glycan-database test methods, etc.).

This PR contains **only** the monosaccharide subset, with two small carry-overs from the glycan-database work that the monosaccharide feature depends on in a non-trivial way:

- `IsCommentOrBlank` — used by `LoadCustomMonosaccharides` to skip header/comment rows in the TSV.
- `ValidateStructureLine` (using the live `Glycan.CharMassDic`) — called from `LoadStructureGlycan` so a structure-format glycan referencing a custom single-char code is recognized. Without this, the parser would silently miscount the custom character as zero mass.

The glycan-database half stays in PR #2657 (or can be reworked into its own follow-up PR).
