### PR TITLE
Add PrecursorDeconvolutionScore feature to PEP (bottom-up first)

### DIFF
--- a/MetaMorpheus/EngineLayer/FdrAnalysis/PEPAnalysisEngine.cs
+++ b/MetaMorpheus/EngineLayer/FdrAnalysis/PEPAnalysisEngine.cs
@@ -640,6 +640,7 @@ namespace EngineLayer
                 MostAbundantPrecursorPeakIntensity = mostAbundantPrecursorPeakIntensity,
                 PrecursorFractionalIntensity = fractionalIntensity,
                 InternalIonCount = internalMatchingFragmentCount,
+                PrecursorDeconvolutionScore = (float)psm.PrecursorScanDeconvolutionScore,
             };
 
             return psm.PsmData_forPEPandPercolator;

--- a/MetaMorpheus/EngineLayer/FdrAnalysis/PsmData.cs
+++ b/MetaMorpheus/EngineLayer/FdrAnalysis/PsmData.cs
@@ -15,9 +15,10 @@ namespace EngineLayer.FdrAnalysis
                 "standard", new[]
                 {
                     "TotalMatchingFragmentCount", "Intensity", "PrecursorChargeDiffToMode", "DeltaScore",
-                    "Notch", "ModsCount", "AbsoluteAverageFragmentMassErrorFromMedian", "MissedCleavagesCount", 
+                    "Notch", "ModsCount", "AbsoluteAverageFragmentMassErrorFromMedian", "MissedCleavagesCount",
                     "Ambiguity", "LongestFragmentIonSeries", "ComplementaryIonCount", "HydrophobicityZScore",
-                    "IsVariantPeptide", "IsDeadEnd", "IsLoop", "SpectralAngle", "HasSpectralAngle", 
+                    "IsVariantPeptide", "IsDeadEnd", "IsLoop", "SpectralAngle", "HasSpectralAngle",
+                    "PrecursorDeconvolutionScore",
                 }
             },
 
@@ -85,6 +86,7 @@ namespace EngineLayer.FdrAnalysis
             { "MostAbundantPrecursorPeakIntensity", 1 },
             { "PrecursorFractionalIntensity", 1 },
             { "InternalIonCount", 1},
+            { "PrecursorDeconvolutionScore", 1 },
             }.ToImmutableDictionary();
 
         public string ToString(string searchType)
@@ -189,5 +191,8 @@ namespace EngineLayer.FdrAnalysis
 
         [LoadColumn(28)]
         public float InternalIonCount { get; set; }
+
+        [LoadColumn(29)]
+        public float PrecursorDeconvolutionScore { get; set; }
     }
 }

--- a/MetaMorpheus/EngineLayer/Ms2ScanWithSpecificMass.cs
+++ b/MetaMorpheus/EngineLayer/Ms2ScanWithSpecificMass.cs
@@ -10,7 +10,8 @@ namespace EngineLayer
     public class Ms2ScanWithSpecificMass
     {
         public Ms2ScanWithSpecificMass(MsDataScan mzLibScan, double precursorMonoisotopicPeakMz, int precursorCharge, string fullFilePath, CommonParameters commonParam,
-            IsotopicEnvelope[] neutralExperimentalFragments = null, double? precursorIntensity = null, int? envelopePeakCount = null, double? precursorFractionalIntensity = null)
+            IsotopicEnvelope[] neutralExperimentalFragments = null, double? precursorIntensity = null, int? envelopePeakCount = null, double? precursorFractionalIntensity = null,
+            double precursorDeconvolutionScore = 0)
         {
             PrecursorMonoisotopicPeakMz = precursorMonoisotopicPeakMz;
             PrecursorCharge = precursorCharge;
@@ -18,6 +19,7 @@ namespace EngineLayer
             PrecursorIntensity = precursorIntensity ?? 1;
             PrecursorEnvelopePeakCount = envelopePeakCount ?? 1;
             PrecursorFractionalIntensity = precursorFractionalIntensity ?? -1;
+            PrecursorDeconvolutionScore = precursorDeconvolutionScore;
             FullFilePath = fullFilePath;
             ChildScans = new List<Ms2ScanWithSpecificMass>();
             NativeId = mzLibScan.NativeId;
@@ -45,6 +47,12 @@ namespace EngineLayer
         public double PrecursorIntensity { get; }
         public int PrecursorEnvelopePeakCount { get; }
         public double PrecursorFractionalIntensity { get; }
+        /// <summary>
+        /// Method-agnostic envelope-quality score in [0, 1] from mzLib's DeconvolutionScorer.
+        /// 0 indicates either a maximally low-quality envelope or that no envelope was
+        /// deconvoluted for this scan (e.g. scan-header-only precursor path).
+        /// </summary>
+        public double PrecursorDeconvolutionScore { get; }
         public string FullFilePath { get; }
         public IsotopicEnvelope[] ExperimentalFragments { get; private set; }
         public List<Ms2ScanWithSpecificMass> ChildScans { get; set; } // MS2/MS3 scans that are children of this MS2 scan

--- a/MetaMorpheus/EngineLayer/SpectralMatch.cs
+++ b/MetaMorpheus/EngineLayer/SpectralMatch.cs
@@ -34,6 +34,7 @@ namespace EngineLayer
             ScanPrecursorMass = scan.PrecursorMass;
             PrecursorScanEnvelopePeakCount = scan.PrecursorEnvelopePeakCount;
             PrecursorFractionalIntensity = scan.PrecursorFractionalIntensity;
+            PrecursorScanDeconvolutionScore = scan.PrecursorDeconvolutionScore;
             DigestionParams = commonParameters.DigestionParams;
             NativeId = scan.NativeId;
             RunnerUpScore = commonParameters.ScoreCutoff;
@@ -78,6 +79,12 @@ namespace EngineLayer
         public double PrecursorScanIntensity { get; }
         public int PrecursorScanEnvelopePeakCount { get; }
         public double PrecursorFractionalIntensity { get; }
+        /// <summary>
+        /// Method-agnostic envelope-quality score in [0, 1] from mzLib's DeconvolutionScorer for
+        /// the precursor envelope of this PSM. 0 indicates no envelope was computed or the
+        /// envelope is maximally bad; higher = better-shaped Averagine match.
+        /// </summary>
+        public double PrecursorScanDeconvolutionScore { get; }
         public double ScanPrecursorMass { get; }
         public double? ScanOneOverK0 { get; set; } // this is only used for ion mobility data, so it can be null
         public string FullFilePath { get; private set; }

--- a/MetaMorpheus/EngineLayer/Util/Precursor.cs
+++ b/MetaMorpheus/EngineLayer/Util/Precursor.cs
@@ -96,10 +96,18 @@ public record Precursor
     /// </summary>
     public int EnvelopePeakCount { get; init; }
 
-    /// <summary> 
+    /// <summary>
     /// The fraction of the intensity in the MS1 scan isolation window that is accounted for by this precursor
     /// </summary>
     public double? FractionalIntensity { get; init; }
+
+    /// <summary>
+    /// Method-agnostic envelope-quality score in [0, 1] from mzLib's DeconvolutionScorer, computed
+    /// at deconvolution time. 0 is the sentinel for "no envelope was deconvoluted" (e.g. the
+    /// scan-header-only precursor path) and is also returned by the scorer for a maximally bad
+    /// envelope, so the model cannot distinguish those two cases — accepted limitation for now.
+    /// </summary>
+    public double DeconvolutionScore { get; init; }
 
     public bool Equals(Precursor? other, Tolerance mzTolerance)
     {

--- a/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
+++ b/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
@@ -1588,7 +1588,7 @@ namespace TaskLayer
         }
 
         /// <summary>
-        /// Legacy TOML compatibility � when ProductMassTolerance_LowRes is omitted, the helper falls back to ProductMassTolerance to keep constant result.
+        /// Legacy TOML compatibility when ProductMassTolerance_LowRes is omitted, the helper falls back to ProductMassTolerance to keep constant result.
         /// </summary>
         /// <typeparam name="TTask"></typeparam>
         /// <param name="filePath"></param>

--- a/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
+++ b/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
@@ -275,8 +275,8 @@ namespace TaskLayer
                                     precursorSpectrum.MassSpectrum, commonParameters.PrecursorDeconvolutionParameters))
                                 {
                                     double? intensity = null;
-                                    if (commonParameters.UseMostAbundantPrecursorIntensity) 
-                                        intensity = envelope.Peaks.Max(p => p.intensity); 
+                                    if (commonParameters.UseMostAbundantPrecursorIntensity)
+                                        intensity = envelope.Peaks.Max(p => p.intensity);
 
                                     var fractionalIntensity = envelope.TotalIntensity /
                                           precursorSpectrum.MassSpectrum.YArray
@@ -286,7 +286,15 @@ namespace TaskLayer
                                               precursorSpectrum.MassSpectrum.GetClosestPeakIndex(ms2scan.IsolationRange.Maximum)
                                           ].Sum();
 
-                                    precursorSet.Add(new(envelope, intensity, fractionalIntensity));
+                                    // Method-agnostic envelope-quality score from mzLib (idempotent: caches on the
+                                    // envelope, so re-asking the same envelope is cheap).
+                                    double genericScore = envelope.GetOrComputeGenericScore(
+                                        commonParameters.PrecursorDeconvolutionParameters);
+
+                                    precursorSet.Add(new Precursor(envelope, intensity, fractionalIntensity)
+                                    {
+                                        DeconvolutionScore = genericScore
+                                    });
                                 }
                             }
                         }
@@ -330,7 +338,8 @@ namespace TaskLayer
                             // assign precursor for this MS2 scan
                             var scan = new Ms2ScanWithSpecificMass(ms2scan, precursor.MonoisotopicPeakMz,
                                 precursor.Charge, fullFilePath, commonParameters, neutralExperimentalFragments,
-                                precursor.Intensity, precursor.EnvelopePeakCount, precursor.FractionalIntensity);
+                                precursor.Intensity, precursor.EnvelopePeakCount, precursor.FractionalIntensity,
+                                precursor.DeconvolutionScore);
 
                             // assign precursors for MS2 child scans
                             if (ms2ChildScans != null)
@@ -1579,7 +1588,7 @@ namespace TaskLayer
         }
 
         /// <summary>
-        /// Legacy TOML compatibility — when ProductMassTolerance_LowRes is omitted, the helper falls back to ProductMassTolerance to keep constant result.
+        /// Legacy TOML compatibility ï¿½ when ProductMassTolerance_LowRes is omitted, the helper falls back to ProductMassTolerance to keep constant result.
         /// </summary>
         /// <typeparam name="TTask"></typeparam>
         /// <param name="filePath"></param>

--- a/MetaMorpheus/Test/FdrTest.cs
+++ b/MetaMorpheus/Test/FdrTest.cs
@@ -709,7 +709,8 @@ namespace Test
                 "TotalMatchingFragmentCount", "Intensity", "PrecursorChargeDiffToMode", "DeltaScore", "Notch",
                 "ModsCount", "AbsoluteAverageFragmentMassErrorFromMedian", "MissedCleavagesCount", "Ambiguity",
                 "LongestFragmentIonSeries", "ComplementaryIonCount", "HydrophobicityZScore", "IsVariantPeptide",
-                "IsDeadEnd", "IsLoop", "SpectralAngle", "HasSpectralAngle"
+                "IsDeadEnd", "IsLoop", "SpectralAngle", "HasSpectralAngle",
+                "PrecursorDeconvolutionScore"
             };
             Assert.That(trainingInfoStandard, Is.EqualTo(expectedTrainingInfoStandard));
 
@@ -729,7 +730,8 @@ namespace Test
                 "TotalMatchingFragmentCount", "Intensity", "PrecursorChargeDiffToMode", "DeltaScore",
                 "LongestFragmentIonSeries", "ComplementaryIonCount", "AlphaIntensity", "BetaIntensity",
                 "LongestFragmentIonSeries_Alpha", "LongestFragmentIonSeries_Beta", "PeaksInPrecursorEnvelope",
-                "MostAbundantPrecursorPeakIntensity", "PrecursorFractionalIntensity", "InternalIonCount"
+                "MostAbundantPrecursorPeakIntensity", "PrecursorFractionalIntensity", "InternalIonCount",
+                "PrecursorDeconvolutionScore"
             };
             List<string> negativeAttributes = new List<string>
             {
@@ -777,9 +779,10 @@ namespace Test
                 MostAbundantPrecursorPeakIntensity = 25,
                 PrecursorFractionalIntensity = 26,
                 InternalIonCount = 27,
+                PrecursorDeconvolutionScore = 28,
             };
 
-            string standardToString = "\t0\t1\t2\t3\t4\t5\t6\t7\t8\t9\t10\t11\t12\t17\t18\t21\t22";
+            string standardToString = "\t0\t1\t2\t3\t4\t5\t6\t7\t8\t9\t10\t11\t12\t17\t18\t21\t22\t28";
             Assert.That(pd.ToString("standard"), Is.EqualTo(standardToString));
 
             string topDownToString = "\t0\t1\t2\t3\t4\t5\t6\t8\t9\t10\t21\t22\t23\t24\t25\t26\t27";

--- a/MetaMorpheus/Test/PostSearchAnalysisTaskTests.cs
+++ b/MetaMorpheus/Test/PostSearchAnalysisTaskTests.cs
@@ -106,21 +106,21 @@ namespace Test
             var allResultsFile = Path.Combine(outputFolder, "allResults.txt");
             var allResults = File.ReadAllLines(allResultsFile);
 
-            Assert.That(allResults[10], Is.EqualTo("All target PSMs with pep q-value <= 0.01: 382"));
+            Assert.That(allResults[10], Is.EqualTo("All target PSMs with pep q-value <= 0.01: 384"));
             Assert.That(allResults[11], Is.EqualTo("All target peptides with pep q-value <= 0.01: 153"));
-            Assert.That(allResults[12], Is.EqualTo("All target protein groups with pep q-value <= 0.01: 145"));
+            Assert.That(allResults[12], Is.EqualTo("All target protein groups with pep q-value <= 0.01: 144"));
             Assert.That(allResults[13], Is.EqualTo("All Precursors: 1070"));
             Assert.That(allResults[14], Is.EqualTo("All MS2 Scans: 294"));
 
-            Assert.That(allResults[16], Is.EqualTo("TaGe_SA_A549_3_snip - Target PSMs with pep q-value <= 0.01: 190"));
+            Assert.That(allResults[16], Is.EqualTo("TaGe_SA_A549_3_snip - Target PSMs with pep q-value <= 0.01: 191"));
             Assert.That(allResults[17], Is.EqualTo("TaGe_SA_A549_3_snip - Target peptides with pep q-value <= 0.01: 153"));
-            Assert.That(allResults[18], Is.EqualTo("TaGe_SA_A549_3_snip - Target protein groups with pep q-value <= 0.01: 145"));
+            Assert.That(allResults[18], Is.EqualTo("TaGe_SA_A549_3_snip - Target protein groups with pep q-value <= 0.01: 144"));
             Assert.That(allResults[19], Is.EqualTo("TaGe_SA_A549_3_snip - Precursors: 535"));
             Assert.That(allResults[20], Is.EqualTo("TaGe_SA_A549_3_snip - MS2 Scans: 147"));
 
-            Assert.That(allResults[22], Is.EqualTo("TaGe_SA_A549_3_snip_2 - Target PSMs with pep q-value <= 0.01: 190"));
+            Assert.That(allResults[22], Is.EqualTo("TaGe_SA_A549_3_snip_2 - Target PSMs with pep q-value <= 0.01: 191"));
             Assert.That(allResults[23], Is.EqualTo("TaGe_SA_A549_3_snip_2 - Target peptides with pep q-value <= 0.01: 153"));
-            Assert.That(allResults[24], Is.EqualTo("TaGe_SA_A549_3_snip_2 - Target protein groups with pep q-value <= 0.01: 145"));
+            Assert.That(allResults[24], Is.EqualTo("TaGe_SA_A549_3_snip_2 - Target protein groups with pep q-value <= 0.01: 144"));
             Assert.That(allResults[25], Is.EqualTo("TaGe_SA_A549_3_snip_2 - Precursors: 535"));
             Assert.That(allResults[26], Is.EqualTo("TaGe_SA_A549_3_snip_2 - MS2 Scans: 147"));
 
@@ -128,21 +128,21 @@ namespace Test
             var resultsFile = Path.Combine(outputFolder, @"postSearchAnalysisTaskTestOutput\results.txt");
             var results = File.ReadAllLines(resultsFile);
 
-            Assert.That(results[5], Is.EqualTo("All target PSMs with pep q-value <= 0.01: 382"));
+            Assert.That(results[5], Is.EqualTo("All target PSMs with pep q-value <= 0.01: 384"));
             Assert.That(results[6], Is.EqualTo("All target peptides with pep q-value <= 0.01: 153"));
-            Assert.That(results[7], Is.EqualTo("All target protein groups with pep q-value <= 0.01: 145"));
+            Assert.That(results[7], Is.EqualTo("All target protein groups with pep q-value <= 0.01: 144"));
             Assert.That(results[8], Is.EqualTo("All Precursors: 1070"));
             Assert.That(results[9], Is.EqualTo("All MS2 Scans: 294"));
 
-            Assert.That(results[11], Is.EqualTo("TaGe_SA_A549_3_snip - Target PSMs with pep q-value <= 0.01: 190"));
+            Assert.That(results[11], Is.EqualTo("TaGe_SA_A549_3_snip - Target PSMs with pep q-value <= 0.01: 191"));
             Assert.That(results[12], Is.EqualTo("TaGe_SA_A549_3_snip - Target peptides with pep q-value <= 0.01: 153"));
-            Assert.That(results[13], Is.EqualTo("TaGe_SA_A549_3_snip - Target protein groups with pep q-value <= 0.01: 145"));
+            Assert.That(results[13], Is.EqualTo("TaGe_SA_A549_3_snip - Target protein groups with pep q-value <= 0.01: 144"));
             Assert.That(results[14], Is.EqualTo("TaGe_SA_A549_3_snip - Precursors: 535"));
             Assert.That(results[15], Is.EqualTo("TaGe_SA_A549_3_snip - MS2 Scans: 147"));
 
-            Assert.That(results[17], Is.EqualTo("TaGe_SA_A549_3_snip_2 - Target PSMs with pep q-value <= 0.01: 190"));
+            Assert.That(results[17], Is.EqualTo("TaGe_SA_A549_3_snip_2 - Target PSMs with pep q-value <= 0.01: 191"));
             Assert.That(results[18], Is.EqualTo("TaGe_SA_A549_3_snip_2 - Target peptides with pep q-value <= 0.01: 153"));
-            Assert.That(results[19], Is.EqualTo("TaGe_SA_A549_3_snip_2 - Target protein groups with pep q-value <= 0.01: 145"));
+            Assert.That(results[19], Is.EqualTo("TaGe_SA_A549_3_snip_2 - Target protein groups with pep q-value <= 0.01: 144"));
             Assert.That(results[20], Is.EqualTo("TaGe_SA_A549_3_snip_2 - Precursors: 535"));
             Assert.That(results[21], Is.EqualTo("TaGe_SA_A549_3_snip_2 - MS2 Scans: 147"));
         }


### PR DESCRIPTION
# Add PrecursorDeconvolutionScore feature to PEP (bottom-up first)

## Summary

Wires mzLib's method-agnostic envelope-quality score (mzLib [#1054](https://github.com/smith-chem-wisc/mzLib/pull/1054), shipped in mzLib 1.0.579 as `IsotopicEnvelope.GenericScore`) into MetaMorpheus's PEP analysis pipeline as a new `PsmData.PrecursorDeconvolutionScore` feature. The score is computed once per precursor envelope using mzLib's cached `envelope.GetOrComputeGenericScore(deconvolutionParameters)` extension method and flows through the existing precursor-scalar plumbing (the same path that already carries `PrecursorScanIntensity`, `PrecursorScanEnvelopePeakCount`, and `PrecursorFractionalIntensity`) into the ML.NET training feature vector.

**Scope.** This PR adds the feature to the **bottom-up search type only**. Once it's approved and lands, the identical wiring will be extended to top-down, crosslink, and RNA in a follow-up using this PR as the template. The bottom-up-only restriction keeps the diff small, the test footprint focused, and the baseline shift readable.

## Measured impact (bottom-up benchmark)

`TaGe_SA_A549_3_snip` ×2 files, target counts at pep-q ≤ 0.01:

| Metric | Master | This PR | Δ |
|---|---:|---:|---:|
| All target PSMs | 382 | **384** | +2 |
| All target peptides | 153 | 153 | 0 |
| All target protein groups | 145 | **144** | −1 |
| Per-file PSMs | 190 | **191** | +1 |
| Per-file peptides | 153 | 153 | 0 |
| Per-file protein groups | 145 | **144** | −1 |

A small, mixed effect on this near-saturation dataset. The new feature reshuffles which PSMs land above the 1% pep-q threshold; per-file PSM count nudges up while the aggregate protein-group count drops by one (a few PSMs flip into a group already covered, no new group). The signal will probably matter more on larger or noisier datasets — same pattern observed when wiring Chronologer through the existing z-score path on this same benchmark.

## What changed

### Data path (top → bottom)

| File | Change |
|---|---|
| `EngineLayer/Util/Precursor.cs` | New `double DeconvolutionScore { get; init; }` field on the record. |
| `TaskLayer/MetaMorpheusTask.cs` (line 274 deconvolution loop) | For each yielded `IsotopicEnvelope`, call `envelope.GetOrComputeGenericScore(commonParameters.PrecursorDeconvolutionParameters)` and stash on the `Precursor` via object initializer. mzLib's `GetOrComputeGenericScore` is idempotent and caches on the envelope, so re-asking the same envelope is free. |
| `TaskLayer/MetaMorpheusTask.cs` (line 331 PSM construction) | Pass `precursor.DeconvolutionScore` to the new `Ms2ScanWithSpecificMass` constructor arg. |
| `EngineLayer/Ms2ScanWithSpecificMass.cs` | New constructor parameter `double precursorDeconvolutionScore = 0` (source-compatible — existing callers unaffected); new `PrecursorDeconvolutionScore` property. |
| `EngineLayer/SpectralMatch.cs` | New `PrecursorScanDeconvolutionScore` property, populated from `scan.PrecursorDeconvolutionScore` in the constructor — mirrors the existing `PrecursorScanIntensity` / `PrecursorScanEnvelopePeakCount` / `PrecursorFractionalIntensity` pattern at lines 30–36. |
| `EngineLayer/FdrAnalysis/PsmData.cs` | New `[LoadColumn(29)] public float PrecursorDeconvolutionScore { get; set; }`. Added to `trainingInfos["standard"]` only. `assumedAttributeDirection["PrecursorDeconvolutionScore"] = 1` — higher generic score = better Averagine match = more likely target. |
| `EngineLayer/FdrAnalysis/PEPAnalysisEngine.cs::CreateOnePsmDataEntry` | One line in the `PsmData` initializer: `PrecursorDeconvolutionScore = (float)psm.PrecursorScanDeconvolutionScore`. |

### Sentinel-value handling

When the precursor was constructed from scan-header data alone (the `UseProvidedPrecursorInfo` path at `MetaMorpheusTask.cs:297–304`, used by some `.msalign` inputs), no envelope is deconvoluted, so there is nothing to score. The PSM's `PrecursorDeconvolutionScore` falls through as `0`.

This conflates "no envelope was computed" with "envelope was computed and is maximally bad" (both score 0). Per scope discussion, an accepted limitation for now; the model learns to treat `0` as a generic "no information" value either way. A future improvement could use `-1` to distinguish the two cases.

### Search types

`PrecursorDeconvolutionScore` is added to `trainingInfos["standard"]` only. The other entries in `PsmData.trainingInfos` — `"top-down"`, `"crosslink"`, `"RNA"` — are untouched. Top-down was the original use case the mzLib weights were calibrated against (IsoDec on yeast), so it's the highest-priority follow-up.

## Tests

**Full `Test.csproj` suite: 1,446 passed, 0 failed, 1 skipped, 7m 27s.**

### Updated baselines

- `FdrTest.TestPsmData` — `trainingInfo["standard"]` array gains `"PrecursorDeconvolutionScore"`; `positiveAttributes` gains the same entry; the test's `PsmData` initializer gains `PrecursorDeconvolutionScore = 28`; `standardToString` gains a trailing `\t28`. (Test still passes against the actual `PsmData.ToString("standard")` output.)
- `PostSearchAnalysisTaskTests.AllResultsAndResultsTxtContainsCorrectValues_PepQValue_BottomUp` — count assertions updated to match the new model outputs (see "Measured impact" table). No structural changes to the test, just the expected numeric values.

### Unchanged tests

- `PostSearchAnalysisTaskTests.AllResultsAndResultsTxtContainsCorrectValues_QValue_BottomUp` — passes without modification. Target-decoy q-value counts (vs PEP q-value counts) are not affected by this feature on this dataset.
- All other test classes pass without modification.

## Compatibility / rollout

- **Existing `Ms2ScanWithSpecificMass` call sites are source-compatible.** The new constructor parameter `double precursorDeconvolutionScore = 0` has a default value, so test mocks and external code that construct an `Ms2ScanWithSpecificMass` without supplying it continue to compile and get the sentinel `0`.
- **No `PsmData` schema break for downstream consumers.** The new `[LoadColumn(29)]` is appended; existing column indices 0–28 are unchanged. Pre-PR-trained ML.NET models will need re-training (expected for any feature addition that's actually wired into training).
- **mzLib bump.** `1.0.578 → 1.0.579` is already in master via [#2652](https://github.com/smith-chem-wisc/MetaMorpheus/pull/2652) — no further bump required from this PR.

## Plan after merge

Once this lands and is approved as the bottom-up model, the same wiring will be extended to the three remaining search types in `PsmData.trainingInfos` — adding `"PrecursorDeconvolutionScore"` to each, re-baselining whichever tests assert per-search-type counts (top-down has its own `AllResultsAndResultsTxt…` integration in `PostSearchAnalysisTaskTests`, and crosslink/RNA have their own count-asserting tests too). The data-path plumbing (`Precursor` → `Ms2ScanWithSpecificMass` → `SpectralMatch` → `PsmData`) is search-type-agnostic and won't need to change; the only follow-up edits will be the `PsmData.trainingInfos` entries and test baselines.

## Companion reading

- mzLib PR #1054 — [Generic Deconvolution Scoring for IsotopicEnvelope](https://github.com/smith-chem-wisc/mzLib/pull/1054) — the source of the score and the `GetOrComputeGenericScore` API used here. The mzLib PR's "Three access patterns / One-line ergonomic" section is precisely the pattern adopted in `MetaMorpheusTask.GetMs2Scans` here.
