### PR TITLE
feat: write a ProForma 2.0 column in search output (+ MetaDraw)

### DIFF
--- a/MetaMorpheus/EngineLayer/SpectrumMatch/PsmTsvWriter.cs
+++ b/MetaMorpheus/EngineLayer/SpectrumMatch/PsmTsvWriter.cs
@@ -11,6 +11,7 @@ using Omics.Modifications;
 using Proteomics;
 using Proteomics.ProteolyticDigestion;
 using Readers;
+using Readers.ProForma;
 
 namespace EngineLayer
 {
@@ -198,6 +199,7 @@ namespace EngineLayer
 
             s[SpectrumMatchFromTsvHeader.BaseSequence] = pepWithModsIsNull ? " " : sm.BaseSequence ?? Resolve(pepWithModsIsNull ? null : pepsWithMods.Select(b => b.BaseSequence)).ResolvedString;
             s[SpectrumMatchFromTsvHeader.FullSequence] = pepWithModsIsNull ? " " : sm.FullSequence != null ? sm.FullSequence : Resolve(pepWithModsIsNull ? null : pepsWithMods.Select(b => b.FullSequence)).ResolvedString;
+            s[SpectrumMatchFromTsvHeader.ProForma] = pepWithModsIsNull ? " " : Resolve(pepsWithMods.Select(b => b.ToProFormaString())).ResolvedString;
             s[SpectrumMatchFromTsvHeader.EssentialSequence] = pepWithModsIsNull ? " " : sm.EssentialSequence != null ? sm.EssentialSequence : Resolve(pepWithModsIsNull ? null : pepsWithMods.Select(b => b.EssentialSequence(ModsToWritePruned))).ResolvedString;
             string geneString = pepWithModsIsNull ? " " : Resolve(pepsWithMods.Select(b => string.Join(", ", b.Parent.GeneNames.Select(d => $"{d.Item1}:{d.Item2}"))), sm.FullSequence).ResolvedString;
             s[SpectrumMatchFromTsvHeader.AmbiguityLevel] = ProteoformLevelClassifier.ClassifyPrSM(s[SpectrumMatchFromTsvHeader.FullSequence], geneString);

--- a/MetaMorpheus/GUI/MetaDraw/MetaDraw.xaml
+++ b/MetaMorpheus/GUI/MetaDraw/MetaDraw.xaml
@@ -211,7 +211,8 @@
                                             <DataGridTextColumn Header="MS2 Scan" Binding="{Binding Ms2ScanNumber}" Width="70" 
                                                                 ElementStyle="{StaticResource DataGridCenteredCellStyle}" />
                                             <DataGridTextColumn Header="Full Sequence" Binding="{Binding FullSequence}" Width="160" />
-                                            <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="100" 
+                                            <DataGridTextColumn Header="ProForma" Binding="{Binding ProForma}" Width="160" />
+                                            <DataGridTextColumn Header="Name" Binding="{Binding Name}" Width="100"
                                                                 />
                                             <DataGridTextColumn Header="Organism Name" Binding="{Binding OrganismName}" Width="100" />
                                             <DataGridTextColumn Header="Q-Value" Binding="{Binding QValue}" Width="60"

--- a/MetaMorpheus/Test/PsmTsvWriterTests.cs
+++ b/MetaMorpheus/Test/PsmTsvWriterTests.cs
@@ -20,6 +20,35 @@ namespace Test
     internal static class PsmTsvWriterTests
     {
         [Test]
+        public static void ProFormaColumn_IsWrittenForPeptide()
+        {
+            ModificationMotif.TryGetMotif("M", out ModificationMotif motifM);
+            Modification oxidation = new Modification(_originalId: "Oxidation", _modificationType: "testMods",
+                _target: motifM, _locationRestriction: "Anywhere.", _monoisotopicMass: 15.99491);
+
+            // M is the 3rd residue (one-based) of PEMTIDEK
+            var oneBasedMods = new Dictionary<int, List<Modification>> { { 3, new List<Modification> { oxidation } } };
+            Protein protein = new Protein("PEMTIDEK", "prot1", oneBasedModifications: oneBasedMods);
+            var allModsOneIsNterminus = new Dictionary<int, Modification> { { 4, oxidation } }; // M (0-based index 2) -> key 4
+            PeptideWithSetModifications pwsm = new PeptideWithSetModifications(protein, new DigestionParams(),
+                1, 8, CleavageSpecificity.Unknown, null, 0, allModsOneIsNterminus, 0);
+
+            Ms2ScanWithSpecificMass scan = new Ms2ScanWithSpecificMass(new MsDataScan(new MzSpectrum(new double[,] { }),
+                0, 0, true, Polarity.Positive, 0, new MzLibUtil.MzRange(0, 0), "", MZAnalyzerType.FTICR, 0, null, null, ""),
+                1000.0, 1, "", new CommonParameters());
+
+            SpectralMatch psm = new PeptideSpectralMatch(pwsm, 0, 10, 0, scan, new CommonParameters(), new List<MatchedFragmentIon>());
+            psm.ResolveAllAmbiguities();
+
+            string[] header = SpectralMatch.GetTabSeparatedHeader().Split('\t');
+            Assert.That(header, Does.Contain(SpectrumMatchFromTsvHeader.ProForma));
+
+            int proFormaIndex = header.IndexOf(SpectrumMatchFromTsvHeader.ProForma);
+            string[] row = psm.ToString().Split('\t');
+            Assert.That(row[proFormaIndex], Is.EqualTo("PEM[Oxidation]TIDEK"));
+        }
+
+        [Test]
         public static void ResolveModificationsTest()
         {
             double mass = 12.0 + new PeptideWithSetModifications(new Protein("LNLDLDND", "prot1"),new DigestionParams(),1,8,CleavageSpecificity.Full,"",0, new Dictionary<int, Modification>(),0,null).MonoisotopicMass.ToMz(1);


### PR DESCRIPTION
## Overview
This PR surfaces **ProForma 2.0** in MetaMorpheus search output. `PsmTsvWriter` now writes a `ProForma` column immediately after `Full Sequence` for every PSM/proteoform — bottom-up and top-down alike — by calling the new mzLib `IBioPolymerWithSetMods.ToProFormaString()`, which resolves each modification to its Unimod/PSI-MOD/RESID accession (or name) and emits a standards-compliant proteoform string. **MetaDraw** displays the column in its PSM grid. Because the value flows through the existing `DataDictionary`, it appears in both the header (`GetTabSeparatedHeader`) and every row with no change to column-ordering logic; crosslink and glyco searches keep their own headers and are untouched. The feature was verified end-to-end on a real top-down human (Jurkat) search, where carbamidomethyl renders as `C[UNIMOD:4]`. This PR requires the companion mzLib ProForma changes.

## What's included
- `EngineLayer/SpectrumMatch/PsmTsvWriter.cs` — populate `s[SpectrumMatchFromTsvHeader.ProForma]` via `Resolve(pepsWithMods.Select(b => b.ToProFormaString()))` (ambiguity handled like Full Sequence).
- `GUI/MetaDraw/MetaDraw.xaml` — `DataGridTextColumn` bound to `ProForma` next to Full Sequence.
- `Test/PsmTsvWriterTests.cs` — `ProFormaColumn_IsWrittenForPeptide` (header contains the column; row emits `PEM[Oxidation]TIDEK`).

## Dependency
**Requires mzLib with the ProForma reader/writer** (companion PR: smith-chem-wisc/mzLib `feature/proforma-reader-writer`). The local-feed PackageReference version bumps used during development are **not** committed; this branch should reference the published mzLib version once the mzLib PR merges. **CI will be red until then** — this is expected.

## Notes for reviewers
- Existing header tests use name-based `IndexOf`, so the added column does not break them.
- **Verified live:** CMD top-down classic search (Jurkat `fract1` + human reviewed PTM DB) produced `AllProteoforms.psmtsv`/`AllPSMs.psmtsv` with a populated ProForma column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
