### PR TITLE
Custom oxonium ions via the monosaccharide diagnostic-ion column

### DIFF
--- a/MetaMorpheus/EngineLayer/Glycan_Mods/MonosaccharidesCustom.tsv
+++ b/MetaMorpheus/EngineLayer/Glycan_Mods/MonosaccharidesCustom.tsv
@@ -44,6 +44,17 @@
 #                          Leave blank or omit the column for no extra
 #                          diagnostic ions.
 #
+#                          These ions also act as STRICT custom oxonium ions
+#                          when the oxonium-ion filter is enabled (Glyco search
+#                          parameter "Oxonium Ion Filter"). Under that filter a
+#                          candidate is rejected if such an ion is observed in
+#                          the spectrum but the candidate lacks this
+#                          monosaccharide, or if the candidate contains this
+#                          monosaccharide but the ion is absent. Ion prevalence
+#                          depends on collision energy, instrument and glycan
+#                          structure, so validate an ion against your own
+#                          acquisition conditions before relying on it to filter.
+#
 #   5. Description         Optional. Free text for human readers. Ignored by
 #                          the parser. Use it to record source, formula, or
 #                          a note about the residue.

--- a/MetaMorpheus/EngineLayer/GlycoSearch/Glycan.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/Glycan.cs
@@ -329,6 +329,61 @@ namespace EngineLayer
         {10902895, 11503951, 12605550, 12703952, 13805550, 14406607, 16306064, 16806607, 18607663, 20408720, 27409268, 29008759, 29210324, 30809816, 36614002, 65723544, 67323035};
 
         /// <summary>
+        /// True when one or more custom monosaccharides registered diagnostic ions (column 4 of
+        /// MonosaccharidesCustom.tsv). Cheap gate so the default no-customs path allocates nothing.
+        /// </summary>
+        public static bool HasCustomOxoniumIons => _customDiagnosticIonsByIndex.Count > 0;
+
+        /// <summary>
+        /// Custom-monosaccharide diagnostic ions exposed as (observed m/z scaled by 1e5, Kind[] index)
+        /// pairs in a deterministic order (by Kind index, then declaration order). Empty unless customs
+        /// were registered. Consumed by the strict custom-oxonium branch of GlycoPeptides.DiagonsticFilter
+        /// and used to size the oxonium intensity list. No hydrogen offset is applied: values are observed
+        /// m/z, matching the convention of AllOxoniumIons and the MonosaccharidesCustom.tsv documentation.
+        /// </summary>
+        public static IReadOnlyList<(int MzScaled, int KindIndex)> CustomOxoniumIons
+        {
+            get
+            {
+                var list = new List<(int MzScaled, int KindIndex)>();
+                var keys = new List<int>(_customDiagnosticIonsByIndex.Keys);
+                keys.Sort();
+                foreach (int kindIndex in keys)
+                {
+                    foreach (int ionScaled in _customDiagnosticIonsByIndex[kindIndex])
+                    {
+                        list.Add((ionScaled, kindIndex));
+                    }
+                }
+                return list;
+            }
+        }
+
+        /// <summary>
+        /// AllOxoniumIons with any CustomOxoniumIons appended (built-ins keep indices 0..N-1, customs
+        /// follow in CustomOxoniumIons order). When no customs are registered this returns the built-in
+        /// AllOxoniumIons array reference unchanged, so default search behavior is byte-identical.
+        /// </summary>
+        public static int[] AllOxoniumIonsIncludingCustoms
+        {
+            get
+            {
+                if (!HasCustomOxoniumIons)
+                {
+                    return AllOxoniumIons;
+                }
+                var customs = CustomOxoniumIons;
+                int[] combined = new int[AllOxoniumIons.Length + customs.Count];
+                Array.Copy(AllOxoniumIons, combined, AllOxoniumIons.Length);
+                for (int j = 0; j < customs.Count; j++)
+                {
+                    combined[AllOxoniumIons.Length + j] = customs[j].MzScaled;
+                }
+                return combined;
+            }
+        }
+
+        /// <summary>
         /// Dictionary mapping N-glycan core ion indices to their monoisotopic mass (double).
         /// </summary>
         public readonly static Dictionary<int, double> TrimannosylCores = new Dictionary<int, double>

--- a/MetaMorpheus/EngineLayer/GlycoSearch/GlycoPeptides.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/GlycoPeptides.cs
@@ -490,10 +490,10 @@ namespace EngineLayer.GlycoSearch
         /// <returns >True : The Oglycan pass the filter, False : The OGl</returns>
         public static bool DiagonsticFilter(double[] oxoniumIonsintensities, GlycanBox glycanBox)
         {
-            double HexNAc_diagnostic = oxoniumIonsintensities[4];
-            double NeuAc_diagnostic1 = oxoniumIonsintensities[10];
-            double NeuAc_diagnostic2 = oxoniumIonsintensities[12];
-            double HexNAcPlusHex_diagnostic = oxoniumIonsintensities[14];
+            double HexNAc_diagnostic = oxoniumIonsintensities[OxoniumIonReservedIndices.R138];
+            double NeuAc_diagnostic1 = oxoniumIonsintensities[OxoniumIonReservedIndices.NeuAc274];
+            double NeuAc_diagnostic2 = oxoniumIonsintensities[OxoniumIonReservedIndices.NeuAc292];
+            double HexNAcPlusHex_diagnostic = oxoniumIonsintensities[OxoniumIonReservedIndices.HexHexNAc366];
 
             //If a glycopeptide spectrum does not have 292.1027 or 274.0921, then remove all glycans that have sialic acids from the search.
             if (NeuAc_diagnostic1 / HexNAc_diagnostic > 0.02 && NeuAc_diagnostic2 / HexNAc_diagnostic > 0.02)

--- a/MetaMorpheus/EngineLayer/GlycoSearch/GlycoPeptides.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/GlycoPeptides.cs
@@ -20,11 +20,12 @@ namespace EngineLayer.GlycoSearch
         /// <returns> int[], The intensity list </returns>
         public static double[] ScanOxoniumIonFilter(Ms2ScanWithSpecificMass theScan, MassDiffAcceptor massDiffAcceptor)
         {
-            double[] oxoniumIonsintensities = new double[Glycan.AllOxoniumIons.Length];
+            int[] allOxoniumIons = Glycan.AllOxoniumIonsIncludingCustoms;
+            double[] oxoniumIonsintensities = new double[allOxoniumIons.Length];
 
-            for (int i = 0; i < Glycan.AllOxoniumIons.Length; i++)
+            for (int i = 0; i < allOxoniumIons.Length; i++)
             {
-                var oxoMass = ((double)Glycan.AllOxoniumIons[i] / 1E5).ToMass(1);
+                var oxoMass = ((double)allOxoniumIons[i] / 1E5).ToMass(1);
                 var envelope = theScan.GetClosestExperimentalIsotopicEnvelope(oxoMass);
                 if (massDiffAcceptor.Accepts(envelope.MonoisotopicMass, oxoMass) >= 0)
                 {
@@ -522,11 +523,54 @@ namespace EngineLayer.GlycoSearch
             }
 
             //Other rules:
-            //A spectrum needs to have 204.0867 to be considered as a glycopeptide.              
+            //A spectrum needs to have 204.0867 to be considered as a glycopeptide.
             //Ratio of 138.055 to 144.0655 can seperate O/N glycan.
             // use some other oxonium ions to determine the glycan type.
 
+            // Strict custom-oxonium filter. Reuses the per-monosaccharide diagnostic ions registered
+            // from MonosaccharidesCustom.tsv (column 4). Each custom ion was probed into
+            // oxoniumIonsintensities at the offset after the built-ins, in Glycan.CustomOxoniumIons order.
+            // Strict semantics: a custom ion observed while its monosaccharide is absent from the
+            // candidate -- or its monosaccharide present while the ion is absent -- rejects the spectrum.
+            // Gated on HasCustomOxoniumIons so the default (no customs) path is unchanged.
+            if (Glycan.HasCustomOxoniumIons)
+            {
+                var customOxoniumIons = Glycan.CustomOxoniumIons;
+                int builtInCount = Glycan.AllOxoniumIons.Length;
+                for (int j = 0; j < customOxoniumIons.Count; j++)
+                {
+                    int idx = builtInCount + j;
+                    bool hasSignal = idx < oxoniumIonsintensities.Length
+                        && CheckOxoniumPresence(oxoniumIonsintensities, idx);
+                    int kindIndex = customOxoniumIons[j].KindIndex;
+                    bool hasMono = kindIndex < glycanBox.Kind.Length && glycanBox.Kind[kindIndex] >= 1;
+                    if (!ApplyStrictMonoFilter(hasSignal, hasMono))
+                    {
+                        return false;
+                    }
+                }
+            }
+
             return true;
+        }
+
+        /// <summary>
+        /// Presence test for an oxonium ion. ScanOxoniumIonFilter records a non-zero intensity only when
+        /// a matching experimental envelope is found within the product mass tolerance, so intensity &gt; 0
+        /// means observed. Mirrors the built-in 204 presence check (oxoniumIonIntensities[...] == 0).
+        /// </summary>
+        internal static bool CheckOxoniumPresence(double[] oxoniumIonsintensities, int index)
+        {
+            return oxoniumIonsintensities[index] > 0;
+        }
+
+        /// <summary>
+        /// Strict custom-oxonium rule: accept only when the ion's observed state matches the candidate's
+        /// possession of the linked monosaccharide. A mismatch in either direction rejects.
+        /// </summary>
+        internal static bool ApplyStrictMonoFilter(bool hasSignal, bool hasMono)
+        {
+            return hasSignal == hasMono;
         }
 
         #endregion

--- a/MetaMorpheus/EngineLayer/GlycoSearch/GlycoSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/GlycoSearchEngine.cs
@@ -14,7 +14,7 @@ namespace EngineLayer.GlycoSearch
     public class GlycoSearchEngine : ModernSearchEngine
     {
         public static readonly double ToleranceForMassDifferentiation = 1e-9;
-        private readonly int OxoniumIon204Index = 9;               // Check Glycan.AllOxoniumIons
+        private readonly int OxoniumIon204Index = OxoniumIonReservedIndices.HexNAc204; // Check Glycan.AllOxoniumIons
         protected readonly List<GlycoSpectralMatch>[] GlobalGsms;  // Why don't we call it GlobalGsms?
 
         private GlycoSearchType GlycoSearchType;
@@ -381,13 +381,13 @@ namespace EngineLayer.GlycoSearch
 
             psmGlyco.LocalizationGraphs = localizationGraphs;
 
-            if (oxoniumIonIntensities[5] <= 0.00000001)
+            if (oxoniumIonIntensities[OxoniumIonReservedIndices.R144] <= 0.00000001)
             {
                 psmGlyco.R138vs144 = 100000000;
             }
             else
             {
-                psmGlyco.R138vs144 = oxoniumIonIntensities[4] / oxoniumIonIntensities[5]; // if the ratio is high, that means the glycan is more likely to be N-glycan. Oppsitely, ration is small means close to O-glycan.
+                psmGlyco.R138vs144 = oxoniumIonIntensities[OxoniumIonReservedIndices.R138] / oxoniumIonIntensities[OxoniumIonReservedIndices.R144]; // if the ratio is high, that means the glycan is more likely to be N-glycan. Oppsitely, ration is small means close to O-glycan.
             }
 
             return psmGlyco;
@@ -578,13 +578,13 @@ namespace EngineLayer.GlycoSearch
                     psmGlyco.Rank = ind;
                     psmGlyco.NGlycanLocalizations = new List<int> { bestSite - 1 }; //TO DO: ambiguity modification site
 
-                    if (oxoniumIonIntensities[5] <= 0.00000001)
+                    if (oxoniumIonIntensities[OxoniumIonReservedIndices.R144] <= 0.00000001)
                     {
                         psmGlyco.R138vs144 = 100000000;
                     }
                     else
                     {
-                        psmGlyco.R138vs144 = oxoniumIonIntensities[4] / oxoniumIonIntensities[5];
+                        psmGlyco.R138vs144 = oxoniumIonIntensities[OxoniumIonReservedIndices.R138] / oxoniumIonIntensities[OxoniumIonReservedIndices.R144];
                     }
 
                     possibleMatches.Add(psmGlyco);

--- a/MetaMorpheus/EngineLayer/GlycoSearch/OxoniumIonReservedIndices.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/OxoniumIonReservedIndices.cs
@@ -1,0 +1,37 @@
+namespace EngineLayer.GlycoSearch
+{
+    /// <summary>
+    /// Frozen positions inside <see cref="Glycan.AllOxoniumIons"/> that legacy production code
+    /// indexes by number. Naming these is the only refactor; the ordering of AllOxoniumIons
+    /// itself MUST NOT change. The <c>Reserved_Indices_Match_AllOxoniumIons_Positions</c> test
+    /// guards the ordering by asserting the scaled-int mass at each index below.
+    ///
+    /// Ion assignments are well-established in the glycoproteomics literature
+    /// (see Halim et al., Anal Chem 2014 for oxonium fragmentation profiles;
+    /// Polasky et al., J Proteome Res 2024 for experimentally validated diagnostic ion sets;
+    /// Toghi Eshghi et al., Anal Chem 2016 for the 138/144 ratio as an N- vs O-glycopeptide classifier).
+    /// </summary>
+    internal static class OxoniumIonReservedIndices
+    {
+        /// <summary>HexNAc fragment at 138.055 (numerator of the 138/144 ratio used to
+        /// discriminate N-glycan from O-glycan; both 138 and 144 are HexNAc-derived, the
+        /// <i>ratio</i> is diagnostic).</summary>
+        public const int R138 = 4;
+
+        /// <summary>HexNAc fragment at 144.066 (denominator of the same ratio).</summary>
+        public const int R144 = 5;
+
+        /// <summary>HexNAc oxonium 204.087 — canonical glycopeptide marker; spectra lacking
+        /// this peak are filtered out in FindNGlycan and MatchGlycopeptide.</summary>
+        public const int HexNAc204 = 9;
+
+        /// <summary>NeuAc-H2O 274.093 (sialylation marker).</summary>
+        public const int NeuAc274 = 10;
+
+        /// <summary>NeuAc 292.103 (sialic acid marker).</summary>
+        public const int NeuAc292 = 12;
+
+        /// <summary>HexHexNAc 366.140 (LacNAc-type composite diagnostic).</summary>
+        public const int HexHexNAc366 = 14;
+    }
+}

--- a/MetaMorpheus/Test/CustomOxoniumFilterTests.cs
+++ b/MetaMorpheus/Test/CustomOxoniumFilterTests.cs
@@ -206,6 +206,29 @@ namespace Test
         }
 
         [Test]
+        public void DiagonsticFilter_UndersizedInputs_GuardsTreatAsAbsentAndDoNotThrow()
+        {
+            // Defensive guards: a custom ion index past the end of the intensity array, or a custom
+            // monosaccharide index past the end of glycanBox.Kind, must be treated as "absent" rather
+            // than throwing IndexOutOfRange. Here both are undersized; with neither observed nor present
+            // the strict rule accepts.
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                Glycan.RegisterCustomMonosaccharide("SugarU", 'U', 17603209, new[] { Ion512 });
+
+                double[] tooShortIntensities = new double[Glycan.AllOxoniumIons.Length]; // no custom slot
+                var boxShortKind = BoxWithKind(new byte[2]);                              // shorter than custom index
+
+                Assert.That(GlycoPeptides.DiagonsticFilter(tooShortIntensities, boxShortKind), Is.True);
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+            }
+        }
+
+        [Test]
         public void LoadCustomMonosaccharides_DiagnosticIonsColumn_RoundTripsIntoCustomOxoniumIons()
         {
             string tsv = string.Join("\n", new[]

--- a/MetaMorpheus/Test/CustomOxoniumFilterTests.cs
+++ b/MetaMorpheus/Test/CustomOxoniumFilterTests.cs
@@ -1,0 +1,247 @@
+using EngineLayer;
+using EngineLayer.GlycoSearch;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace Test
+{
+    /// <summary>
+    /// Strict custom-oxonium filter (option B): the diagnostic ions a user attaches to a custom
+    /// monosaccharide (MonosaccharidesCustom.tsv column 4) feed GlycoPeptides.DiagonsticFilter with
+    /// strict bidirectional semantics. All tests that register custom monosaccharides restore global
+    /// state in a finally block via Glycan.ResetCustomMonosaccharides().
+    /// </summary>
+    [TestFixture]
+    public class CustomOxoniumFilterTests
+    {
+        private const int Ion512 = 51219700; // 512.197 m/z * 1e5
+        private const int Ion657 = 65723544; // 657.23544 m/z * 1e5
+
+        // Build a GlycanBox with a chosen Kind[] without touching the glycan database. DiagonsticFilter
+        // only reads glycanBox.Kind, so an uninitialized instance with the private setter invoked is enough.
+        private static GlycanBox BoxWithKind(byte[] kind)
+        {
+            var box = (GlycanBox)RuntimeHelpers.GetUninitializedObject(typeof(GlycanBox));
+            MethodInfo setter = typeof(GlycanBox).GetProperty("Kind").GetSetMethod(nonPublic: true);
+            Assert.That(setter, Is.Not.Null, "GlycanBox.Kind private setter not found via reflection.");
+            setter.Invoke(box, new object[] { kind });
+            return box;
+        }
+
+        [Test]
+        public void CustomOxoniumIons_DefaultNoCustoms_EmptyAndArrayIsByteIdentical()
+        {
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                Assert.Multiple(() =>
+                {
+                    Assert.That(Glycan.HasCustomOxoniumIons, Is.False);
+                    Assert.That(Glycan.CustomOxoniumIons, Is.Empty);
+                    // No customs => the combined array is the very same built-in array reference.
+                    Assert.That(Glycan.AllOxoniumIonsIncludingCustoms, Is.SameAs(Glycan.AllOxoniumIons));
+                });
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+            }
+        }
+
+        [Test]
+        public void RegisterCustomMonosaccharide_WithDiagnosticIons_AppearsInCustomOxoniumIonsAndCombinedArray()
+        {
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                Glycan.RegisterCustomMonosaccharide("SugarU", 'U', 17603209, new[] { Ion512 });
+
+                int customIndex = Glycan.NameCharDic["SugarU"].Item2; // Kind[] index of the new mono
+                Assert.Multiple(() =>
+                {
+                    Assert.That(Glycan.HasCustomOxoniumIons, Is.True);
+                    Assert.That(Glycan.CustomOxoniumIons.Count, Is.EqualTo(1));
+                    Assert.That(Glycan.CustomOxoniumIons[0].MzScaled, Is.EqualTo(Ion512));
+                    Assert.That(Glycan.CustomOxoniumIons[0].KindIndex, Is.EqualTo(customIndex));
+                    Assert.That(Glycan.AllOxoniumIonsIncludingCustoms.Length,
+                        Is.EqualTo(Glycan.AllOxoniumIons.Length + 1));
+                    Assert.That(Glycan.AllOxoniumIonsIncludingCustoms[Glycan.AllOxoniumIons.Length],
+                        Is.EqualTo(Ion512));
+                });
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+            }
+        }
+
+        [Test]
+        public void ApplyStrictMonoFilter_AcceptsOnlyWhenSignalMatchesMonoPresence()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(GlycoPeptides.ApplyStrictMonoFilter(true, true), Is.True);
+                Assert.That(GlycoPeptides.ApplyStrictMonoFilter(false, false), Is.True);
+                Assert.That(GlycoPeptides.ApplyStrictMonoFilter(true, false), Is.False);
+                Assert.That(GlycoPeptides.ApplyStrictMonoFilter(false, true), Is.False);
+            });
+        }
+
+        [Test]
+        public void CheckOxoniumPresence_PositiveIntensityIsPresentZeroIsAbsent()
+        {
+            double[] intensities = { 0.0, 12.5 };
+            Assert.Multiple(() =>
+            {
+                Assert.That(GlycoPeptides.CheckOxoniumPresence(intensities, 0), Is.False);
+                Assert.That(GlycoPeptides.CheckOxoniumPresence(intensities, 1), Is.True);
+            });
+        }
+
+        [Test]
+        public void DiagonsticFilter_NoCustoms_BuiltInRejectStillApplies()
+        {
+            // Built-in rule: both NeuAc ratios > 0.02 but glycan has no NeuAc (Kind[2]==0) -> reject.
+            // Proves the legacy filter path is untouched when no customs are registered.
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                double[] intensities = new double[Glycan.AllOxoniumIons.Length];
+                intensities[OxoniumIndex_R138] = 100;
+                intensities[OxoniumIndex_NeuAc274] = 100;
+                intensities[OxoniumIndex_NeuAc292] = 100;
+                var box = BoxWithKind(new byte[Glycan.KindCapacity]); // all zero -> no NeuAc
+
+                Assert.That(GlycoPeptides.DiagonsticFilter(intensities, box), Is.False);
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+            }
+        }
+
+        [Test]
+        public void DiagonsticFilter_CustomIonObservedAndMonoPresent_Accepts()
+        {
+            RunSingleCustom(ionObserved: true, monoPresent: true, expectedAccept: true);
+        }
+
+        [Test]
+        public void DiagonsticFilter_CustomIonAbsentButMonoPresent_Rejects()
+        {
+            RunSingleCustom(ionObserved: false, monoPresent: true, expectedAccept: false);
+        }
+
+        [Test]
+        public void DiagonsticFilter_CustomIonObservedButMonoAbsent_Rejects()
+        {
+            RunSingleCustom(ionObserved: true, monoPresent: false, expectedAccept: false);
+        }
+
+        [Test]
+        public void DiagonsticFilter_CustomIonAbsentAndMonoAbsent_Accepts()
+        {
+            RunSingleCustom(ionObserved: false, monoPresent: false, expectedAccept: true);
+        }
+
+        private static void RunSingleCustom(bool ionObserved, bool monoPresent, bool expectedAccept)
+        {
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                Glycan.RegisterCustomMonosaccharide("SugarU", 'U', 17603209, new[] { Ion512 });
+                int customIndex = Glycan.NameCharDic["SugarU"].Item2;
+
+                // Built-in slots left at 0 so legacy rules do not reject; custom ion appended at the end.
+                double[] intensities = new double[Glycan.AllOxoniumIonsIncludingCustoms.Length];
+                if (ionObserved)
+                {
+                    intensities[Glycan.AllOxoniumIons.Length] = 500; // first (only) custom slot
+                }
+
+                byte[] kind = new byte[Glycan.KindCapacity];
+                if (monoPresent)
+                {
+                    kind[customIndex] = 1;
+                }
+
+                Assert.That(GlycoPeptides.DiagonsticFilter(intensities, BoxWithKind(kind)),
+                    Is.EqualTo(expectedAccept));
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+            }
+        }
+
+        [Test]
+        public void DiagonsticFilter_TwoCustoms_OneMismatch_Rejects()
+        {
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                Glycan.RegisterCustomMonosaccharide("SugarU", 'U', 17603209, new[] { Ion512 });
+                Glycan.RegisterCustomMonosaccharide("SugarV", 'V', 18000000, new[] { Ion657 });
+                int idxU = Glycan.NameCharDic["SugarU"].Item2;
+                int idxV = Glycan.NameCharDic["SugarV"].Item2;
+
+                // CustomOxoniumIons order is by Kind index: [Ion512@U, Ion657@V] at the two appended slots.
+                double[] intensities = new double[Glycan.AllOxoniumIonsIncludingCustoms.Length];
+                intensities[Glycan.AllOxoniumIons.Length] = 500;     // Ion512 observed (matches U)
+                // Ion657 slot left 0 (absent) -> mismatches V which IS present below.
+
+                byte[] kind = new byte[Glycan.KindCapacity];
+                kind[idxU] = 1;
+                kind[idxV] = 1;
+
+                Assert.That(GlycoPeptides.DiagonsticFilter(intensities, BoxWithKind(kind)), Is.False);
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+            }
+        }
+
+        [Test]
+        public void LoadCustomMonosaccharides_DiagnosticIonsColumn_RoundTripsIntoCustomOxoniumIons()
+        {
+            string tsv = string.Join("\n", new[]
+            {
+                "# comment",
+                "Name\tSingleCharCode\tMonoisotopicMass\tDiagnosticIonMasses\tDescription",
+                "HexA\tU\t176.03209\t512.197\tHexuronic acid"
+            });
+            string path = Path.GetTempFileName();
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.WriteAllText(path, tsv);
+                GlycanDatabase.LoadCustomMonosaccharides(path);
+
+                int idx = Glycan.NameCharDic["HexA"].Item2;
+                Assert.Multiple(() =>
+                {
+                    Assert.That(Glycan.HasCustomOxoniumIons, Is.True);
+                    Assert.That(Glycan.CustomOxoniumIons.Count, Is.EqualTo(1));
+                    Assert.That(Glycan.CustomOxoniumIons[0].MzScaled, Is.EqualTo(Ion512));
+                    Assert.That(Glycan.CustomOxoniumIons[0].KindIndex, Is.EqualTo(idx));
+                });
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+                File.Delete(path);
+            }
+        }
+
+        // Reserved built-in indices used by the legacy filter. Spelled as literals (rather than the
+        // OxoniumIonReservedIndices constants) so this built-in-behavior test does not depend on the
+        // very constants it is meant to be independent of.
+        private const int OxoniumIndex_R138 = 4;
+        private const int OxoniumIndex_NeuAc274 = 10;
+        private const int OxoniumIndex_NeuAc292 = 12;
+    }
+}

--- a/MetaMorpheus/Test/CustomOxoniumPerformanceTests.cs
+++ b/MetaMorpheus/Test/CustomOxoniumPerformanceTests.cs
@@ -1,0 +1,164 @@
+using EngineLayer;
+using EngineLayer.GlycoSearch;
+using NUnit.Framework;
+using System;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace Test
+{
+    /// <summary>
+    /// Performance bounds for the strict custom-oxonium branch of GlycoPeptides.DiagonsticFilter.
+    /// Marked [Explicit] + [Category("Performance")] so they never run in the normal suite (timing
+    /// assertions would be noisy in CI). Invoke via Test\perf\run-perf.ps1, which filters on
+    /// Category=Performance. Bounds are deliberately generous: they catch a gross regression, not a
+    /// few-nanosecond drift. The exact ns/call is written to the test output for the report.
+    /// </summary>
+    [TestFixture]
+    public class CustomOxoniumPerformanceTests
+    {
+        private const int Iterations = 200_000;
+        private const int Rounds = 5;
+
+        [Test, Explicit, Category("Performance")]
+        public void Filter_NoCustoms_OverheadOverLegacyIsNegligible()
+        {
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                var box = BoxWithKind(new byte[Glycan.KindCapacity]);
+                double[] oxo = new double[Glycan.AllOxoniumIons.Length]; // all zero, no customs
+
+                double legacyNs = MinNsPerCall(() => DiagonsticFilter_LegacyForBenchmark(oxo, box));
+                double newNs = MinNsPerCall(() => GlycoPeptides.DiagonsticFilter(oxo, box));
+                double addedNs = newNs - legacyNs;
+
+                // The headline is the absolute per-call addition (one Dictionary.Count check). The
+                // percentage is reported only for completeness: it is inflated because a ~9 ns method
+                // is measured in isolation, where any fixed addition looks large relative to the base.
+                TestContext.WriteLine(
+                    $"no customs: legacy={legacyNs:F1} ns/call, new={newNs:F1} ns/call, " +
+                    $"added={addedNs:F1} ns/call ({addedNs / legacyNs * 100.0:F0}% of the isolated base; " +
+                    $"negligible against real per-scan search cost)");
+
+                // Robust ceiling: at zero customs the only added work is one Dictionary.Count check.
+                Assert.That(addedNs, Is.LessThan(legacyNs + 50),
+                    $"No-customs absolute overhead too high: {addedNs:F1} ns/call");
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+            }
+        }
+
+        [Test, Explicit, Category("Performance")]
+        public void Filter_FiftyCustomIons_PerCallUnderTenMicroseconds()
+        {
+            try
+            {
+                Glycan.ResetCustomMonosaccharides();
+                RegisterFiftyCustomIons();
+                var customs = Glycan.CustomOxoniumIons;
+                Assert.That(customs.Count, Is.EqualTo(50));
+
+                double[] oxo = new double[Glycan.AllOxoniumIonsIncludingCustoms.Length];
+                byte[] kind = new byte[Glycan.KindCapacity];
+                for (int j = 0; j < customs.Count; j++)
+                {
+                    oxo[Glycan.AllOxoniumIons.Length + j] = 1.0; // every custom ion observed
+                    kind[customs[j].KindIndex] = 1;              // every linked mono present
+                }
+                var box = BoxWithKind(kind);
+
+                // Worst case: all match, so the loop iterates all 50 entries and returns true.
+                Assert.That(GlycoPeptides.DiagonsticFilter(oxo, box), Is.True);
+
+                double ns = MinNsPerCall(() => GlycoPeptides.DiagonsticFilter(oxo, box));
+                TestContext.WriteLine($"50 custom ions: {ns:F1} ns/call");
+                Assert.That(ns, Is.LessThan(10_000)); // 10 microseconds
+            }
+            finally
+            {
+                Glycan.ResetCustomMonosaccharides();
+            }
+        }
+
+        private static void RegisterFiftyCustomIons()
+        {
+            char[] codes = { 'U', 'V', 'W', 'Z', 'Q' }; // none collide with built-in codes
+            for (int m = 0; m < codes.Length; m++)
+            {
+                int[] ions = new int[10];
+                for (int k = 0; k < ions.Length; k++)
+                {
+                    ions[k] = 30_000_000 + m * 1000 + k; // distinct scaled-int m/z values
+                }
+                Glycan.RegisterCustomMonosaccharide($"PerfSugar{m}", codes[m], 18_000_000 + m, ions);
+            }
+        }
+
+        private static double MinNsPerCall(Func<bool> action)
+        {
+            for (int i = 0; i < 10_000; i++) // warm the JIT
+            {
+                action();
+            }
+            double best = double.MaxValue;
+            for (int r = 0; r < Rounds; r++)
+            {
+                var sw = Stopwatch.StartNew();
+                for (int i = 0; i < Iterations; i++)
+                {
+                    action();
+                }
+                sw.Stop();
+                double ns = sw.Elapsed.TotalMilliseconds * 1e6 / Iterations;
+                if (ns < best) best = ns;
+            }
+            return best;
+        }
+
+        private static GlycanBox BoxWithKind(byte[] kind)
+        {
+            var box = (GlycanBox)RuntimeHelpers.GetUninitializedObject(typeof(GlycanBox));
+            MethodInfo setter = typeof(GlycanBox).GetProperty("Kind").GetSetMethod(nonPublic: true);
+            setter.Invoke(box, new object[] { kind });
+            return box;
+        }
+
+        // Pre-Phase-3 DiagonsticFilter body (built-in rules only), kept here as the benchmark baseline.
+        private static bool DiagonsticFilter_LegacyForBenchmark(double[] oxoniumIonsintensities, GlycanBox glycanBox)
+        {
+            double HexNAc_diagnostic = oxoniumIonsintensities[4];
+            double NeuAc_diagnostic1 = oxoniumIonsintensities[10];
+            double NeuAc_diagnostic2 = oxoniumIonsintensities[12];
+            double HexNAcPlusHex_diagnostic = oxoniumIonsintensities[14];
+
+            if (NeuAc_diagnostic1 / HexNAc_diagnostic > 0.02 && NeuAc_diagnostic2 / HexNAc_diagnostic > 0.02)
+            {
+                if (glycanBox.Kind[2] == 0)
+                {
+                    return false;
+                }
+            }
+
+            if (NeuAc_diagnostic1 / HexNAc_diagnostic < 0.02 && NeuAc_diagnostic2 / HexNAc_diagnostic < 0.02)
+            {
+                if (glycanBox.Kind[2] != 0)
+                {
+                    return false;
+                }
+            }
+            else if (HexNAcPlusHex_diagnostic / HexNAc_diagnostic > 0.02)
+            {
+                if (glycanBox.Kind[0] < 1 && glycanBox.Kind[1] < 1)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/MetaMorpheus/Test/OxoniumIonReservedIndicesTests.cs
+++ b/MetaMorpheus/Test/OxoniumIonReservedIndicesTests.cs
@@ -1,0 +1,31 @@
+using EngineLayer;
+using EngineLayer.GlycoSearch;
+using NUnit.Framework;
+
+namespace Test
+{
+    [TestFixture]
+    public class OxoniumIonReservedIndicesTests
+    {
+        /// <summary>
+        /// Ordering-freeze guard. Production code (GlycoSearchEngine, GlycoPeptides.DiagonsticFilter)
+        /// reaches into Glycan.AllOxoniumIons by the named indices in OxoniumIonReservedIndices. If
+        /// anyone reorders or edits AllOxoniumIons, the scaled-int mass at a reserved index changes
+        /// and this test fails loudly. Values are the int masses (monoisotopic m/z * 1e5) that must
+        /// live at each reserved slot.
+        /// </summary>
+        [Test]
+        public void Reserved_Indices_Match_AllOxoniumIons_Positions()
+        {
+            Assert.Multiple(() =>
+            {
+                Assert.That(Glycan.AllOxoniumIons[OxoniumIonReservedIndices.R138], Is.EqualTo(13805550), "R138 (138.055)");
+                Assert.That(Glycan.AllOxoniumIons[OxoniumIonReservedIndices.R144], Is.EqualTo(14406607), "R144 (144.066)");
+                Assert.That(Glycan.AllOxoniumIons[OxoniumIonReservedIndices.HexNAc204], Is.EqualTo(20408720), "HexNAc204 (204.087)");
+                Assert.That(Glycan.AllOxoniumIons[OxoniumIonReservedIndices.NeuAc274], Is.EqualTo(27409268), "NeuAc274 (274.093)");
+                Assert.That(Glycan.AllOxoniumIons[OxoniumIonReservedIndices.NeuAc292], Is.EqualTo(29210324), "NeuAc292 (292.103)");
+                Assert.That(Glycan.AllOxoniumIons[OxoniumIonReservedIndices.HexHexNAc366], Is.EqualTo(36614002), "HexHexNAc366 (366.140)");
+            });
+        }
+    }
+}

--- a/MetaMorpheus/Test/perf/run-perf.ps1
+++ b/MetaMorpheus/Test/perf/run-perf.ps1
@@ -1,0 +1,8 @@
+# Runs the custom-oxonium performance bounds. These tests are [Explicit] + [Category("Performance")],
+# so they are skipped by the normal `dotnet test` run and only execute when selected here.
+#
+# Usage:  pwsh Test\perf\run-perf.ps1     (from the MetaMorpheus solution directory)
+$ErrorActionPreference = 'Stop'
+$solutionDir = Resolve-Path (Join-Path $PSScriptRoot '..' '..')
+Set-Location $solutionDir
+dotnet test Test\Test.csproj --filter "Category=Performance" --nologo -v n

--- a/docs/Custom-Monosaccharides-and-Diagnostic-Ions.md
+++ b/docs/Custom-Monosaccharides-and-Diagnostic-Ions.md
@@ -1,0 +1,261 @@
+# Custom Monosaccharides & Diagnostic (Oxonium) Ions
+
+A guide to extending MetaMorpheus glyco search with **your own monosaccharides** and **your own diagnostic oxonium ions**, without recompiling.
+
+This covers two related features:
+
+1. **Custom monosaccharides** — register sugars MetaMorpheus does not ship with, so they can appear in your glycan databases.
+2. **Diagnostic / oxonium ions** — attach observed oxonium-ion *m/z* values to a monosaccharide so they boost scoring and (optionally) act as a **strict spectrum filter**.
+
+Both are configured in a single tab-separated file: **`MonosaccharidesCustom.tsv`**.
+
+---
+
+## Contents
+
+- [Quick start](#quick-start)
+- [Where the file lives](#where-the-file-lives)
+- [The file format](#the-file-format)
+- [Built-in monosaccharides (do not redefine)](#built-in-monosaccharides-do-not-redefine)
+- [Part 1 — Define a custom monosaccharide](#part-1--define-a-custom-monosaccharide)
+- [Part 2 — Use it in a glycan search](#part-2--use-it-in-a-glycan-search)
+- [Part 3 — Diagnostic & oxonium ions (column 4)](#part-3--diagnostic--oxonium-ions-column-4)
+- [End-to-end worked example](#end-to-end-worked-example)
+- [Validation & error messages](#validation--error-messages)
+- [Tips & caveats](#tips--caveats)
+- [FAQ](#faq)
+
+---
+
+## Quick start
+
+1. Open `Glycan_Mods/MonosaccharidesCustom.tsv` in the MetaMorpheus data directory.
+2. Add a row: a unique **name**, a unique **single-character code**, the **residue monoisotopic mass**, optionally a comma-separated list of **diagnostic ion m/z**, and an optional description.
+3. Reference the new monosaccharide (by name or code) in a glycan database file (`.gdb`).
+4. Restart MetaMorpheus, point your Glyco Search task at that database, and run.
+5. To make the diagnostic ions *filter* spectra, leave **`OxoniumIonFilt`** checked in the Glyco Search task.
+
+```
+Name	SingleCharCode	MonoisotopicMass	DiagnosticIonMasses	Description
+HexA	U	176.03209	175.02482,157.01425	Hexuronic acid (GlcA, GalA)
+```
+
+---
+
+## Where the file lives
+
+`MonosaccharidesCustom.tsv` sits in the **`Glycan_Mods`** folder of the MetaMorpheus data directory, alongside the `OGlycan` and `NGlycan` database folders.
+
+| Install type | Typical path |
+|---|---|
+| Windows GUI install | `%LOCALAPPDATA%\MetaMorpheus\Data\Glycan_Mods\MonosaccharidesCustom.tsv` |
+| Built from source | `…\MetaMorpheus\EngineLayer\Glycan_Mods\MonosaccharidesCustom.tsv` |
+
+The file ships with documentation and commented-out examples and **no active rows**, so out of the box nothing changes. It is loaded **once at startup**, **before** any glycan database is parsed, and is **shared by both O-glycan and N-glycan searches**.
+
+> **You must restart MetaMorpheus after editing the file** for changes to take effect.
+
+---
+
+## The file format
+
+Tab-separated, five columns. Only the first three are required.
+
+| # | Column | Required | Notes |
+|---|---|---|---|
+| 1 | **Name** | ✅ | Unique. Used in *composition-format* glycans, e.g. `HexNAc(2)Hex(5)HexA(1)`. Must not collide with a built-in name or another row. |
+| 2 | **SingleCharCode** | ✅ | Exactly one ASCII letter (`A–Z`/`a–z`). Used in *structure-format* glycans, e.g. `(N(H)(U))`. Must not collide with a built-in code or another row. |
+| 3 | **MonoisotopicMass** | ✅ | Monoisotopic mass in **Daltons** of the **residue** (the form built into the chain, i.e. after water loss). Decimal, e.g. `176.03209`. |
+| 4 | **DiagnosticIonMasses** | ⬜ | Comma-separated observed **m/z** values, no spaces required, e.g. `175.02482,157.01425`. See [Part 3](#part-3--diagnostic--oxonium-ions-column-4). Leave blank for none. |
+| 5 | **Description** | ⬜ | Free text, ignored by the parser. Use it to cite a source or note a formula. |
+
+Parsing rules:
+
+- Lines beginning with `#` are **comments** and ignored. A line that Excel re-saved as `"#…` (leading double-quote) is also treated as a comment.
+- **Blank lines** are ignored. Indentation before `#` is allowed.
+- A **header row** beginning with `Name<TAB>` is recognized and skipped, so you can keep the template header in place.
+- A **missing file is not an error** — the loader simply registers no customs.
+
+---
+
+## Built-in monosaccharides (do not redefine)
+
+These names and codes are reserved. A custom row whose **Name** *or* **SingleCharCode** collides with any of these (or with an earlier custom row) is an error and the file fails to load.
+
+| Name | Code | Residue mass (Da) |
+|---|---|---|
+| Hex | H | 162.05282 |
+| HexNAc | N | 203.07937 |
+| NeuAc | A | 291.09542 |
+| NeuGc | G | 307.09033 |
+| Fuc | F | 146.05791 |
+| Phospho | P | 79.96633 |
+| Sulfo | S | 79.95681 |
+| Na | Y | 22.98977 |
+| Ac | C | 42.01056 |
+| Xylose | X | 150.05282 |
+| Kdn | K | 250.06897 |
+
+> `dHex` is a permanent alias of `Fuc` (same code `F`, same slot).
+
+Available single-char codes are therefore any ASCII letter **except** `H N A G F P S Y C X K`.
+
+---
+
+## Part 1 — Define a custom monosaccharide
+
+Add one row per sugar. Example — hexuronic acid (GlcA/GalA), residue mass 176.03209 Da:
+
+```
+Name	SingleCharCode	MonoisotopicMass	DiagnosticIonMasses	Description
+HexA	U	176.03209		Hexuronic acid (GlcA, GalA)
+```
+
+Rules recap:
+
+- **Name** unique, used in composition format.
+- **Code** one ASCII letter, unique, used in structure format.
+- **Mass** is the **residue** monoisotopic mass (subtract one water from the free-sugar mass).
+
+That is all that is needed to make the sugar *known* to MetaMorpheus. It does **not** yet appear in any search — for that, see Part 2.
+
+---
+
+## Part 2 — Use it in a glycan search
+
+Defining a monosaccharide only adds it to the vocabulary. To search for glycans that contain it, the monosaccharide must appear in a **glycan database file** (`.gdb`) that your Glyco Search task uses.
+
+### Glycan database formats
+
+MetaMorpheus ships two database styles, and your custom sugar is written differently in each:
+
+| Search | Format | Uses | Example with custom `HexA` (name) / `U` (code) |
+|---|---|---|---|
+| **O-glycan** | **Structure** format | single-char **codes** | `(N(H)(U))` |
+| **N-glycan** | **Composition** format | **names** with counts | `HexNAc(2)Hex(5)HexA(1)` |
+
+(For reference, the built-in `OGlycan.gdb` contains lines like `(N(H))`, `(N(A))`, `(N(H)(N))`; the built-in `NGlycan.gdb` contains lines like `HexNAc(2)Hex(1)Fuc(1)`.)
+
+### Steps
+
+1. Make a copy of the relevant database (e.g. `OGlycan.gdb` or `NGlycan.gdb`) and add lines that use your custom sugar in the format above. Keep one glycan per line.
+2. In the MetaMorpheus GUI, open the **Glyco Search** task.
+3. Point the **O-glycan database** or **N-glycan database** selector at your custom `.gdb`.
+4. Make sure `MonosaccharidesCustom.tsv` defines every custom name/code your `.gdb` references (the monosaccharide file is loaded first, so unknown tokens in the `.gdb` would otherwise fail to parse).
+5. Run the task.
+
+> In a saved task `.toml`, the relevant keys are `OGlycanDatabasefile` and `NGlycanDatabasefile`.
+
+---
+
+## Part 3 — Diagnostic & oxonium ions (column 4)
+
+Column 4, `DiagnosticIonMasses`, is a comma-separated list of **observed oxonium-ion m/z values** for that monosaccharide. Provide the m/z exactly as you would **see it in the spectrum** — no hydrogen-mass offset is applied.
+
+These ions play **two roles**:
+
+### Role 1 — Scoring (always on)
+
+Whenever a candidate glycan contains the monosaccharide, its diagnostic ions are added to the theoretical diagnostic-ion set, matched against the spectrum, and folded into the **diagnostic-ion score**. This happens regardless of any filter setting and never rejects a candidate.
+
+### Role 2 — Strict filter (when `OxoniumIonFilt` is enabled)
+
+The Glyco Search task has a checkbox labelled **`OxoniumIonFilt`** (on by default; `OxoniumIonFilt = true` in the task `.toml`). When it is enabled, each custom diagnostic ion becomes a **strict gate**:
+
+| Ion observed in spectrum? | Candidate contains the monosaccharide? | Result |
+|:---:|:---:|---|
+| Yes | Yes | ✅ keep |
+| Yes | No | ❌ reject |
+| No | Yes | ❌ reject |
+| No | No | ✅ keep |
+
+"Observed" means a peak matching the ion's m/z was found within your **product-mass tolerance** — the same presence test used for the built-in HexNAc 204.087 check. If **any** listed ion disagrees with the candidate's composition, the candidate is rejected.
+
+This runs **after** the built-in oxonium rules (the 138/144 ratio, the 204 requirement, the 274/292 sialic-acid and 366 HexHexNAc rules), which are unchanged.
+
+> **Turn the filter off** (uncheck `OxoniumIonFilt`) and column-4 ions keep only their scoring role.
+
+### Choosing good ions
+
+Oxonium-ion prevalence depends on **collision energy, stepped-HCD settings, instrument type, precursor charge state, glycan branching, sialylation, and derivatization chemistry**. An ion that is reliably present under one method may be weak under another. **Validate any ion against your own acquisition conditions before relying on it to filter** — otherwise the strict rule may discard real identifications. When in doubt, list ions for scoring but leave `OxoniumIonFilt` off, or start with a single, robust ion.
+
+---
+
+## End-to-end worked example
+
+**Goal:** search for N-glycans containing hexuronic acid (HexA), and require its diagnostic ions when present.
+
+1. **Define the sugar with diagnostic ions** in `MonosaccharidesCustom.tsv`:
+
+   ```
+   Name	SingleCharCode	MonoisotopicMass	DiagnosticIonMasses	Description
+   HexA	U	176.03209	175.02482,157.01425	Hexuronic acid (GlcA, GalA)
+   ```
+
+2. **Add glycans that use it** to a copy of the N-glycan database, e.g. `NGlycan_HexA.gdb` (composition format, by name):
+
+   ```
+   HexNAc(2)Hex(3)HexA(1)
+   HexNAc(2)Hex(5)HexA(1)
+   ```
+
+3. **Restart MetaMorpheus.**
+
+4. In the **Glyco Search** task: set the search type to N-glycan, point the **N-glycan database** at `NGlycan_HexA.gdb`, and leave **`OxoniumIonFilt`** checked.
+
+5. **Run.** Candidate glycopeptides whose spectra show 175.02482 / 157.01425 but lack HexA — or that contain HexA but show neither ion — are rejected; matching candidates keep these ions in their diagnostic-ion score.
+
+---
+
+## Validation & error messages
+
+If a row is malformed, the file fails to load with a `MetaMorpheusException` that names the **file** and the **1-based line number**:
+
+```
+Could not parse custom monosaccharide in 'MonosaccharidesCustom.tsv' at line 7: "...".
+Expected at least 3 tab-separated columns (Name, SingleCharCode, MonoisotopicMass).
+```
+
+Conditions that raise an error:
+
+| Problem | Message contains |
+|---|---|
+| Fewer than 3 columns | `Expected at least 3 tab-separated columns` |
+| Code not exactly one character | `SingleCharCode must be exactly one character` |
+| Code is not an ASCII letter | `must be an ASCII letter` |
+| Mass not a number | `MonoisotopicMass "…" is not a valid decimal number` |
+| A diagnostic-ion value not a number | `DiagnosticIonMasses entry "…" is not a valid decimal number` |
+| Name already exists (built-in or earlier row) | `name '…' already exists` |
+| Code already exists | `code '…' already exists` |
+
+A **missing file is not an error**.
+
+---
+
+## Tips & caveats
+
+- **Restart required.** The file is read once at startup.
+- **Mass is the residue mass** (free sugar minus one water), not the free monosaccharide mass.
+- **Defining ≠ using.** A custom monosaccharide does nothing until a glycan database references it and that database is selected in the task.
+- **Shared across O- and N-glycan searches** — names/codes must be globally unique.
+- **Excel-safe.** You can edit the file in Excel; comment lines re-saved as `"#…` are still treated as comments. Keep the file **tab-separated**.
+- **Default behavior is unchanged.** With no custom rows, search output is identical to stock MetaMorpheus.
+
+---
+
+## FAQ
+
+**Do I have to provide diagnostic ions?**
+No. Column 4 is optional. Without it, the monosaccharide still works in databases; it just contributes no extra diagnostic ions.
+
+**Will adding diagnostic ions change results even if I don't filter?**
+They can slightly affect the *diagnostic-ion score* (they are matched and scored), but they never reject a candidate unless `OxoniumIonFilt` is enabled.
+
+**Can custom ions tie to a built-in monosaccharide?**
+Yes — put a built-in name (e.g. `HexNAc`) in column 1 with ions in column 4. The strict filter then ties those ions to that built-in sugar.
+
+**What m/z do I enter — neutral mass or observed?**
+The **observed** singly-charged oxonium m/z, exactly as it appears in the spectrum. No hydrogen offset is applied.
+
+**The strict filter is discarding good hits — what now?**
+Your listed ions may be weak under your acquisition method. Remove the unreliable ions, reduce to a single robust ion, or uncheck `OxoniumIonFilt` to keep scoring only.


### PR DESCRIPTION
﻿# Custom oxonium ions via the monosaccharide diagnostic-ion column

## Summary

Lets users turn the diagnostic ions they attach to a custom monosaccharide into a **strict diagnostic filter** during glyco search. The data source is the existing `DiagnosticIonMasses` column (column 4) of `Glycan_Mods/MonosaccharidesCustom.tsv` added in #2660 â€” there is no new file and no new registry. When the glyco **Oxonium Ion Filter** is enabled, each such ion must co-occur with its linked monosaccharide: an ion observed without its monosaccharide (or a monosaccharide present without its ion) rejects the candidate.

Default behavior is unchanged. The shipped TSV registers no custom monosaccharides, so the new code path is gated off and the combined oxonium-ion array is the built-in array itself.

## How to add a custom oxonium ion

1. Open `Glycan_Mods/MonosaccharidesCustom.tsv` in the MetaMorpheus data directory.
2. Add (or uncomment) a monosaccharide row and list one or more diagnostic ion m/z values in column 4 (`DiagnosticIonMasses`), comma-separated.
3. Restart MetaMorpheus and run a glyco search with **Oxonium Ion Filter** enabled.

## TSV format (column 4)

| Column | Name | Notes |
|---|---|---|
| 1 | Monosaccharide name | built-in or custom |
| 2 | Single-char code | unique ASCII letter |
| 3 | Monoisotopic mass (Da) | residue mass |
| 4 | **DiagnosticIonMasses** | comma-separated observed m/z; these are the custom oxonium ions |
| 5 | Description | free text |

## Worked example

```
Name	SingleCharCode	MonoisotopicMass	DiagnosticIonMasses	Description
HexA	U	176.03209	175.02482,157.01425	Hexuronic acid (GlcA, GalA)
```

With the oxonium filter on, a candidate glycopeptide is rejected if 175.02482 or 157.01425 is observed but the candidate has no HexA, or if it has HexA but neither ion is observed.

## What the strict filter does

For each registered custom diagnostic ion, with the oxonium filter enabled:

- ion observed **and** linked monosaccharide present â†’ keep
- ion observed **but** monosaccharide absent â†’ reject
- monosaccharide present **but** ion absent â†’ reject
- ion absent **and** monosaccharide absent â†’ keep

"Observed" uses the same presence rule as the built-in 204 check (a peak matched within the product mass tolerance). The filter is gated by the existing Oxonium Ion Filter parameter; with it off, column-4 ions keep their prior scoring-only role.

## What changed under the hood

- `GlycoSearch/OxoniumIonReservedIndices.cs` (new): named constants for the six built-in oxonium-array indices the engine had hardcoded (4, 5, 9, 10, 12, 14).
- `GlycoSearch/GlycoSearchEngine.cs`: the hardcoded indices now use those constants (pure rename).
- `GlycoSearch/Glycan.cs`: `HasCustomOxoniumIons`, `CustomOxoniumIons` ((m/z, Kind-index) pairs), and `AllOxoniumIonsIncludingCustoms` (built-ins + appended customs; returns the built-in array unchanged when there are no customs).
- `GlycoSearch/GlycoPeptides.cs`: `ScanOxoniumIonFilter` probes the combined ion list; `DiagonsticFilter` applies the strict rule after the unchanged built-in rules, gated on `HasCustomOxoniumIons`; helpers `CheckOxoniumPresence` and `ApplyStrictMonoFilter`.
- `Glycan_Mods/MonosaccharidesCustom.tsv`: banner documents the column-4 ions' new strict-filter role.

## Tests

1. Ordering-freeze guard for the six reserved indices.
2. Accessor behavior: empty default (combined array is the built-in array reference); registration appears in `CustomOxoniumIons` and the combined array.
3. Helper units: `ApplyStrictMonoFilter` (four cases), `CheckOxoniumPresence`.
4. Strict filter matrix: the four observedÃ—present combinations, a two-custom single-mismatch reject, and a built-in-reject test proving the legacy path is intact with no customs.
5. Defensive guards: undersized intensity/Kind inputs treated as absent without throwing.
6. Round-trip: `LoadCustomMonosaccharides` column-4 ions appear in `CustomOxoniumIons`.
7. Performance bounds (`[Explicit]`, `Category=Performance`): negligible per-call overhead at zero customs; under 10 Âµs/call at 50 custom ions.

## Compatibility / rollout

- No new files, no schema change, no GUI change. Built-in `AllOxoniumIons` ordering is unchanged and guarded by a test.
- With the shipped (no-customs) TSV, search output is byte-identical to the base branch.
- Builds on #2660 (custom monosaccharides). A GUI surface for managing these ions can follow in a later PR.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

