### PR TITLE
Add IrtCalibrationHelper: OLS-based RT calibration math helpers

### DIFF
--- a/MetaMorpheus/EngineLayer/FdrAnalysis/IrtCalibrationHelper.cs
+++ b/MetaMorpheus/EngineLayer/FdrAnalysis/IrtCalibrationHelper.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace EngineLayer.FdrAnalysis
+{
+    /// <summary>
+    /// Static math helpers for retention time calibration and z-score computation.
+    /// Used by PepAnalysisEngine to convert predicted RT values into a normalized
+    /// feature score. Model-agnostic — works for any predictor whose output can be
+    /// linearly calibrated against observed RT.
+    /// </summary>
+    public static class IrtCalibrationHelper
+    {
+        private const double SentinelZScore = 10.0;
+        private const double MinBinStdDev = 0.05;
+        private const int BinWidthMinutes = 2;
+
+        /// <summary>
+        /// Ordinary least squares regression. Returns (slope, intercept).
+        /// Returns (NaN, NaN) if fewer than 2 data points.
+        /// </summary>
+        public static (double Slope, double Intercept) OlsRegression(
+            List<double> x, List<double> y)
+        {
+            if (x.Count < 2 || x.Count != y.Count)
+                return (double.NaN, double.NaN);
+
+            double n = x.Count;
+            double sumX = x.Sum();
+            double sumY = y.Sum();
+            double sumXY = x.Zip(y, (xi, yi) => xi * yi).Sum();
+            double sumX2 = x.Sum(xi => xi * xi);
+
+            double denom = n * sumX2 - sumX * sumX;
+            if (Math.Abs(denom) < 1e-12)
+                return (double.NaN, double.NaN);
+
+            double slope = (n * sumXY - sumX * sumY) / denom;
+            double intercept = (sumY - slope * sumX) / n;
+            return (slope, intercept);
+        }
+
+        /// <summary>
+        /// Returns the 2-minute bin index for a given retention time (in minutes).
+        /// </summary>
+        public static int GetTwoMinuteBin(double retentionTimeMinutes)
+            => (int)(retentionTimeMinutes / BinWidthMinutes);
+
+        /// <summary>
+        /// Computes per-bin mean and standard deviation of residuals.
+        /// Input: list of (observedRT, residual) pairs.
+        /// Output: dictionary of bin -> (mean, stddev).
+        /// </summary>
+        public static Dictionary<int, Tuple<double, double>> ComputeBinStatistics(
+            List<(double ObservedRT, double Residual)> residuals)
+        {
+            var result = new Dictionary<int, Tuple<double, double>>();
+            if (!residuals.Any()) return result;
+
+            var grouped = residuals
+                .GroupBy(r => GetTwoMinuteBin(r.ObservedRT));
+
+            foreach (var group in grouped)
+            {
+                var values = group.Select(g => g.Residual).ToList();
+                double mean = values.Average();
+                double variance = values.Select(v => (v - mean) * (v - mean)).Average();
+                double stddev = Math.Sqrt(variance);
+                result[group.Key] = Tuple.Create(mean, stddev);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Raises any bin standard deviation below MinBinStdDev to MinBinStdDev.
+        /// Prevents artificially tight bins from inflating z-scores.
+        /// Modifies the dictionary in place.
+        /// </summary>
+        public static void StabilizeBinStDevs(
+            Dictionary<int, Tuple<double, double>> binStats)
+        {
+            foreach (var key in binStats.Keys.ToList())
+            {
+                if (binStats[key].Item2 < MinBinStdDev)
+                    binStats[key] = Tuple.Create(binStats[key].Item1, MinBinStdDev);
+            }
+        }
+
+        /// <summary>
+        /// Computes the z-score of a residual given bin mean and stddev.
+        /// Caps at SentinelZScore (10.0). Returns SentinelZScore if stddev is zero.
+        /// </summary>
+        public static double ComputeZScore(double residual, double mean, double stddev)
+        {
+            if (stddev <= 0) return SentinelZScore;
+            double z = Math.Abs(residual - mean) / stddev;
+            return Math.Min(z, SentinelZScore);
+        }
+    }
+}

--- a/MetaMorpheus/Test/PredictedRetentionTimeTests/IrtCalibrationTests.cs
+++ b/MetaMorpheus/Test/PredictedRetentionTimeTests/IrtCalibrationTests.cs
@@ -1,0 +1,168 @@
+using System;
+using NUnit.Framework;
+using EngineLayer.FdrAnalysis;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Test.PredictedRetentionTimeTests
+{
+    [TestFixture]
+    public class IrtCalibrationTests
+    {
+        // ── OLS Regression ────────────────────────────────────────────────
+
+        [Test]
+        public void OlsRegression_PerfectLinearData_ReturnsExactSlopeAndIntercept()
+        {
+            // y = 2x + 5
+            var x = new List<double> { 1, 2, 3, 4, 5 };
+            var y = x.Select(v => 2 * v + 5).ToList();
+
+            var (slope, intercept) = IrtCalibrationHelper.OlsRegression(x, y);
+
+            Assert.That(slope, Is.EqualTo(2.0).Within(1e-9));
+            Assert.That(intercept, Is.EqualTo(5.0).Within(1e-9));
+        }
+
+        [Test]
+        public void OlsRegression_NoisyData_ReturnsReasonableFit()
+        {
+            // y ≈ 1.5x + 10 with small noise
+            var x = Enumerable.Range(1, 50).Select(i => (double)i).ToList();
+            var rng = new System.Random(42);
+            var y = x.Select(v => 1.5 * v + 10 + (rng.NextDouble() - 0.5)).ToList();
+
+            var (slope, intercept) = IrtCalibrationHelper.OlsRegression(x, y);
+
+            Assert.That(slope, Is.EqualTo(1.5).Within(0.1));
+            Assert.That(intercept, Is.EqualTo(10.0).Within(1.0));
+        }
+
+        [Test]
+        public void OlsRegression_InsufficientData_ReturnsNaN()
+        {
+            var x = new List<double> { 1.0 };
+            var y = new List<double> { 2.0 };
+
+            var (slope, intercept) = IrtCalibrationHelper.OlsRegression(x, y);
+
+            Assert.That(double.IsNaN(slope), Is.True);
+            Assert.That(double.IsNaN(intercept), Is.True);
+        }
+
+        [Test]
+        public void OlsRegression_EmptyData_ReturnsNaN()
+        {
+            var (slope, intercept) = IrtCalibrationHelper.OlsRegression(
+                new List<double>(), new List<double>());
+
+            Assert.That(double.IsNaN(slope), Is.True);
+            Assert.That(double.IsNaN(intercept), Is.True);
+        }
+
+        // ── Bin Assignment ────────────────────────────────────────────────
+
+        [Test]
+        public void GetTwoMinuteBin_CorrectlyBinsRetentionTimes()
+        {
+            // Bin width is 2 minutes; bin = (int)(rt / 2)
+            Assert.That(IrtCalibrationHelper.GetTwoMinuteBin(0.0), Is.EqualTo(0));
+            Assert.That(IrtCalibrationHelper.GetTwoMinuteBin(1.9), Is.EqualTo(0));
+            Assert.That(IrtCalibrationHelper.GetTwoMinuteBin(2.0), Is.EqualTo(1));
+            Assert.That(IrtCalibrationHelper.GetTwoMinuteBin(3.9), Is.EqualTo(1));
+            Assert.That(IrtCalibrationHelper.GetTwoMinuteBin(30.0), Is.EqualTo(15));
+        }
+
+        // ── Bin Statistics ────────────────────────────────────────────────
+
+        [Test]
+        public void ComputeBinStatistics_SingleBin_ReturnsCorrectMeanAndStdDev()
+        {
+            // All residuals in the same 2-minute bin, mean=0, stddev=1
+            var residuals = new List<(double observedRT, double residual)>
+            {
+                (5.0, -1.0),
+                (5.1,  0.0),
+                (5.2,  1.0),
+                (5.3,  0.0),
+                (5.4,  0.0),
+            };
+
+            var binStats = IrtCalibrationHelper.ComputeBinStatistics(residuals);
+
+            int bin = IrtCalibrationHelper.GetTwoMinuteBin(5.0);
+            Assert.That(binStats.ContainsKey(bin), Is.True);
+            Assert.That(binStats[bin].Item1, Is.EqualTo(0.0).Within(1e-9)); // mean
+            Assert.That(binStats[bin].Item2, Is.GreaterThan(0)); // stddev
+        }
+
+        [Test]
+        public void ComputeBinStatistics_EmptyInput_ReturnsEmptyDictionary()
+        {
+            var binStats = IrtCalibrationHelper.ComputeBinStatistics(
+                new List<(double, double)>());
+
+            Assert.That(binStats, Is.Empty);
+        }
+
+        // ── StdDev Stabilization ──────────────────────────────────────────
+
+        [Test]
+        public void StabilizeBinStDevs_TooTightBins_AreRaisedToMinimum()
+        {
+            var binStats = new Dictionary<int, Tuple<double, double>>
+            {
+                { 0, Tuple.Create(0.0, 0.001) }, // very tight — below minimum
+                { 1, Tuple.Create(0.0, 2.5) },   // normal
+            };
+
+            IrtCalibrationHelper.StabilizeBinStDevs(binStats);
+
+            // Tight bin should be raised; normal bin should be unchanged
+            Assert.That(binStats[0].Item2, Is.GreaterThan(0.001));
+            Assert.That(binStats[1].Item2, Is.EqualTo(2.5).Within(1e-9));
+        }
+
+        // ── Z-Score Computation ───────────────────────────────────────────
+
+        [Test]
+        public void ComputeZScore_ResidualWithinOneSigma_ReturnsLessThanOne()
+        {
+            double residual = 0.5;
+            double mean = 0.0;
+            double stddev = 1.0;
+
+            double zScore = IrtCalibrationHelper.ComputeZScore(residual, mean, stddev);
+
+            Assert.That(zScore, Is.LessThan(1.0));
+        }
+
+        [Test]
+        public void ComputeZScore_ResidualFarFromMean_ReturnsHighValue()
+        {
+            double residual = 100.0;
+            double mean = 0.0;
+            double stddev = 1.0;
+
+            double zScore = IrtCalibrationHelper.ComputeZScore(residual, mean, stddev);
+
+            Assert.That(zScore, Is.GreaterThan(5.0));
+        }
+
+        [Test]
+        public void ComputeZScore_ZeroStdDev_DoesNotThrow()
+        {
+            Assert.DoesNotThrow(() =>
+                IrtCalibrationHelper.ComputeZScore(1.0, 0.0, 0.0));
+        }
+
+        [Test]
+        public void ComputeZScore_IsCappedAtSentinelValue()
+        {
+            // Z-scores should be capped at 10.0 (the sentinel)
+            double zScore = IrtCalibrationHelper.ComputeZScore(1000.0, 0.0, 0.001);
+
+            Assert.That(zScore, Is.EqualTo(10.0));
+        }
+    }
+}


### PR DESCRIPTION
Extracts the standalone `IrtCalibrationHelper` static math class (and its unit tests) from #2659 into a focused, independently-reviewable PR.

`IrtCalibrationHelper` provides model-agnostic helpers for retention-time calibration and z-score computation:
- OLS regression (slope/intercept, with NaN guards for degenerate input)
- 2-minute residual binning
- per-bin mean/stddev statistics
- stddev stabilization (floor to avoid artificially tight bins inflating z-scores)
- capped z-score computation (sentinel 10.0)

It is pure math with no dependencies on the rest of the RT/PEP work.

**Motivation:** this binned-residual approach is intended to replace the existing dictionary-based RT handling in PEP analysis, offering a performance improvement. Landing the helper + tests in isolation lets the math be reviewed and merged ahead of the larger #2659 integration.

**Tests:** `IrtCalibrationTests` (12 tests) covering regression accuracy, NaN/empty edge cases, bin boundaries, bin statistics, the stddev floor, and z-score capping. All pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
