### PR TITLE
Added Da tolerance option to MetaDraw refragmentation

### DIFF
--- a/MetaMorpheus/GUI/Views/FragmentReanalysisControl.xaml
+++ b/MetaMorpheus/GUI/Views/FragmentReanalysisControl.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="MetaMorpheusGUI.FragmentReanalysisControl"
+<UserControl x:Class="MetaMorpheusGUI.FragmentReanalysisControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -34,11 +34,14 @@
             </StackPanel>
 
             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="20 3">
-                <TextBlock Text="Mass Tolerance (ppm): " VerticalAlignment="Center" />
+                <TextBlock Text="Mass Tolerance: " VerticalAlignment="Center" />
                 <local:DoubleTextBoxControl Text="{Binding ProductIonMassTolerance, FallbackValue=20}"
                                             HorizontalAlignment="Center" HorizontalContentAlignment="Center"
                                             VerticalAlignment="Center" VerticalContentAlignment="Center"
                                             BorderThickness="1" Width="60" />
+                <ComboBox ItemsSource="{Binding PossibleToleranceUnits}"
+                          SelectedItem="{Binding SelectedToleranceUnit}"
+                          Width="60" Margin="3 0 0 0" VerticalContentAlignment="Center" />
             </StackPanel>
 
             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="20 3">

--- a/MetaMorpheus/GuiFunctions/MetaDraw/FragmentResearching/FragmentationReanalysisViewModel.cs
+++ b/MetaMorpheus/GuiFunctions/MetaDraw/FragmentResearching/FragmentationReanalysisViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
@@ -118,6 +118,15 @@ namespace GuiFunctions
             get => _productIonMassTolerance;
             set { _productIonMassTolerance = value; OnPropertyChanged(nameof(ProductIonMassTolerance)); }
         }
+
+        private string _selectedToleranceUnit = "ppm";
+        public string SelectedToleranceUnit
+        {
+            get => _selectedToleranceUnit;
+            set { _selectedToleranceUnit = value; OnPropertyChanged(nameof(SelectedToleranceUnit)); }
+        }
+
+        public ObservableCollection<string> PossibleToleranceUnits { get; } = ["ppm", "Da"];
 
         private bool _matchAllCharges;
         public bool MatchAllCharges
@@ -274,8 +283,13 @@ namespace GuiFunctions
                 );
 
 
-            if (Math.Abs(commonParams.ProductMassTolerance.Value - ProductIonMassTolerance) > 0.00001)
-                commonParams.ProductMassTolerance = new PpmTolerance(ProductIonMassTolerance);
+            bool valueChanged = Math.Abs(commonParams.ProductMassTolerance.Value - ProductIonMassTolerance) > 0.00001;
+            bool typeChanged = (SelectedToleranceUnit == "Da" && commonParams.ProductMassTolerance is not AbsoluteTolerance)
+                || (SelectedToleranceUnit == "ppm" && commonParams.ProductMassTolerance is not PpmTolerance);
+            if (typeChanged || valueChanged)
+                commonParams.ProductMassTolerance = SelectedToleranceUnit == "ppm"
+                    ? new PpmTolerance(ProductIonMassTolerance)
+                    : new AbsoluteTolerance(ProductIonMassTolerance);
 
             var specificMass = new Ms2ScanWithSpecificMass(ms2Scan, smToRematch.PrecursorMz,
                 smToRematch.PrecursorCharge, smToRematch.FileNameWithoutExtension, commonParams);
@@ -286,7 +300,7 @@ namespace GuiFunctions
                 : newMatches;
 
             uniqueMatches = uniqueMatches.Where(p => productsSnapshot.Contains(p.NeutralTheoreticalProduct.ProductType))
-                .Where(p => Math.Abs(p.MassErrorPpm) <= ProductIonMassTolerance);
+                .Where(p => Math.Abs(SelectedToleranceUnit == "ppm" ? p.MassErrorPpm : p.MassErrorDa) <= ProductIonMassTolerance);
 
             // retain only internal ions
             if (!FragmentationParamsViewModel.GenerateInternalIons)

--- a/MetaMorpheus/Test/MetaDraw/FragmentReanalysis.cs
+++ b/MetaMorpheus/Test/MetaDraw/FragmentReanalysis.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -34,6 +34,10 @@ namespace Test.MetaDraw
             Assert.That(viewModel.FragmentationParamsViewModel.MinInternalIonLength, Is.EqualTo(0));
             Assert.That(viewModel.DissociationTypes.Count(), Is.EqualTo(7));
             Assert.That(viewModel.ProductIonMassTolerance, Is.EqualTo(20));
+            Assert.That(viewModel.SelectedToleranceUnit, Is.EqualTo("ppm"));
+            Assert.That(viewModel.PossibleToleranceUnits.Count, Is.EqualTo(2));
+            Assert.That(viewModel.PossibleToleranceUnits, Contains.Item("ppm"));
+            Assert.That(viewModel.PossibleToleranceUnits, Contains.Item("Da"));
 
             var productsToUse = viewModel.PossibleProducts.Where(p => p.Use).Select(p => p.ProductType).ToList();
             var hcdProducts = Omics.Fragmentation.Peptide.DissociationTypeCollection.ProductsFromDissociationType[DissociationType.HCD];
@@ -144,6 +148,49 @@ namespace Test.MetaDraw
             // all original ions should be retained
             intersect = internalIonNewIons.Select(p => p.Annotation).Intersect(psmToResearch.MatchedIons.Select(p => p.Annotation));
             Assert.That(intersect.Count(), Is.EqualTo(psmToResearch.MatchedIons.Count));
+
+            // clean up
+            Directory.Delete(outputFolder, true);
+        }
+
+        [Test]
+        public static void TestFragmentationReanalysisViewModel_ToleranceUnit()
+        {
+            var viewModel = new FragmentationReanalysisViewModel();
+
+            // run a quick search
+            var myTomlPath = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\Task1-SearchTaskconfig.toml");
+            var searchTaskLoaded = Toml.ReadFile<SearchTask>(myTomlPath, MetaMorpheusTask.tomlConfig);
+            string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\TestToleranceUnit");
+            string myFile = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\TaGe_SA_A549_3_snip.mzML");
+            string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\TaGe_SA_A549_3_snip.fasta");
+            var engineToml = new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("SearchTOML", searchTaskLoaded) }, new List<string> { myFile }, new List<DbForTask> { new DbForTask(myDatabase, false) }, outputFolder);
+            engineToml.Run();
+            string psmFile = Path.Combine(outputFolder, @"SearchTOML\AllPSMs.psmtsv");
+            var dataFile = MsDataFileReader.GetDataFile(myFile);
+
+            List<PsmFromTsv> parsedPsms = SpectrumMatchTsvReader.ReadPsmTsv(psmFile, out var warnings);
+            var psmToResearch = parsedPsms.First();
+            var scan = dataFile.GetOneBasedScan(psmToResearch.Ms2ScanNumber);
+
+            // baseline: ppm mode with moderate tolerance
+            viewModel.SelectedToleranceUnit = "ppm";
+            viewModel.ProductIonMassTolerance = 20;
+            viewModel.PossibleProducts.ForEach(p => p.Use = true);
+            var ppmMatches = viewModel.MatchIonsWithNewTypes(scan, psmToResearch, true);
+            Assert.That(ppmMatches.Count, Is.GreaterThan(0), "Should have some matches in ppm mode");
+
+            // switch to Da with same numeric value: 20 Da is far more permissive than 20 ppm
+            viewModel.SelectedToleranceUnit = "Da";
+            var daMatches = viewModel.MatchIonsWithNewTypes(scan, psmToResearch, true);
+            Assert.That(daMatches.Count, Is.GreaterThan(ppmMatches.Count),
+                "20 Da tolerance should match more ions than 20 ppm tolerance");
+
+            // switch back to ppm and verify results match the first ppm run (approx)
+            viewModel.SelectedToleranceUnit = "ppm";
+            var ppmMatchesAgain = viewModel.MatchIonsWithNewTypes(scan, psmToResearch, true);
+            Assert.That(ppmMatchesAgain.Count, Is.EqualTo(ppmMatches.Count),
+                "Switching back to ppm should produce same match count");
 
             // clean up
             Directory.Delete(outputFolder, true);


### PR DESCRIPTION
This pull request enhances the fragment reanalysis functionality by allowing users to select the mass tolerance unit (either ppm or Da) in the UI and updates the matching logic and tests accordingly. This makes the tool more flexible and user-friendly for different use cases.

<img width="668" height="165" alt="image" src="https://github.com/user-attachments/assets/2fa93aa0-510d-4e06-9474-e074c0c0fcfa" />
