### PR TITLE
Fix UniProt proteome download URL and tests

### DIFF
--- a/MetaMorpheus/GuiFunctions/Databases/DownloadUniProtDatabaseFunctions.cs
+++ b/MetaMorpheus/GuiFunctions/Databases/DownloadUniProtDatabaseFunctions.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
@@ -13,14 +13,14 @@ namespace GuiFunctions.Databases
         public static string GetUniProtHtmlQueryString(string proteomeID, bool reviewed, bool isoforms, bool xmlFormat, bool compressed)
         {
             StringBuilder htmlQueryString = new StringBuilder();
-            htmlQueryString.Append("https://rest.uniprot.org/uniprotkb/search?");
+            htmlQueryString.Append("https://rest.uniprot.org/uniprotkb/stream?");
 
             string[] queryArray = new string[4];
 
             queryArray[0] = compressed ? "compressed=true" : null;
             queryArray[1] = xmlFormat ? "format=xml" : "format=fasta";
             queryArray[2] = isoforms && !xmlFormat ? "includeIsoform=true" : null;
-            queryArray[3] = reviewed ? $"query=reviewed:true&proteome:{proteomeID}" : $"query=proteome:{proteomeID}";
+            queryArray[3] = reviewed ? $"query=reviewed:true AND proteome:{proteomeID}" : $"query=proteome:{proteomeID}";
 
             IEnumerable<string> queryArrayReduced = queryArray.Where(x => x != null);
 

--- a/MetaMorpheus/Test/GuiTests/GuiFunctionsTest.cs
+++ b/MetaMorpheus/Test/GuiTests/GuiFunctionsTest.cs
@@ -1,4 +1,4 @@
-﻿using GuiFunctions.Databases;
+using GuiFunctions.Databases;
 using NUnit.Framework;
 using Proteomics;
 using System;
@@ -47,18 +47,19 @@ namespace Test.GuiTests
         // Occasionally the downloaded files will change, and thus the expected result will need to be updated.
         // To verify, download the database and count the number of entries.
         // The expected result will be double the number of entries, due to decoys - 9/1/23 NB
+        // UP000001207 = Bacillus phage phi29 (Reference proteome, 24 reviewed, 3 unreviewed, 2 isoforms) - 6/11/26 NB
         [Test]
-        [TestCase("UP000000280", true, true, true, true, "1.fasta.gz", 160)] // Reviewed, isoforms, XML, compressed don't let the name fool you, this is actually XML
-        [TestCase("UP000000280", true, true, true, false, "2.fasta", 160)] // Reviewed, isoforms, XML, uncompressed don't let the name fool you, this is actually XML
-        [TestCase("UP000000280", true, true, false, true, "3.fasta.gz", 50)]
-        [TestCase("UP000000280", true, false, true, true, "4.xml.gz", 160)]
-        [TestCase("UP000000280", false, true, true, true, "5.fasta.gz", 2)]
-        [TestCase("UP000000280", true, true, false, false, "6.fasta", 50)]
-        [TestCase("UP000000280", true, false, true, false, "7.xml", 160)]
-        [TestCase("UP000000280", false, true, true, false, "8.fasta", 2)]
-        [TestCase("UP000000280", true, false, false, false, "9.fasta", 50)]
-        [TestCase("UP000000280", false, false, true, false, "10.xml", 2)]
-        [TestCase("UP000000280", false, false, false, false, "11.fasta", 2)]
+        [TestCase("UP000001207", true, true, true, true, "1.fasta.gz", 48)] // reviewed=true XML: 24*2
+        [TestCase("UP000001207", true, true, true, false, "2.fasta", 48)] // same
+        [TestCase("UP000001207", true, true, false, true, "3.fasta.gz", 52)] // reviewed=true FASTA+isoforms: (24+2)*2
+        [TestCase("UP000001207", true, false, true, true, "4.xml.gz", 48)] // reviewed=true XML: 24*2
+        [TestCase("UP000001207", false, true, true, true, "5.fasta.gz", 54)] // all XML: 27*2
+        [TestCase("UP000001207", true, true, false, false, "6.fasta", 52)] // reviewed=true FASTA+isoforms: (24+2)*2
+        [TestCase("UP000001207", true, false, true, false, "7.xml", 48)] // reviewed=true XML: 24*2
+        [TestCase("UP000001207", false, true, true, false, "8.fasta", 54)] // all XML: 27*2
+        [TestCase("UP000001207", true, false, false, false, "9.fasta", 48)] // reviewed=true FASTA: 24*2
+        [TestCase("UP000001207", false, false, true, false, "10.xml", 54)] // all XML: 27*2
+        [TestCase("UP000001207", false, false, false, false, "11.fasta", 54)] // all FASTA: 27*2
         public static async Task UniprotHtmlQueryTest(string proteomeID, bool reviewed, bool isoforms, bool xmlFormat, bool compressed,
            string testName, int listCount)
         {
@@ -93,7 +94,7 @@ namespace Test.GuiTests
             if (xmlFormat)
             {
                 reader = ProteinDbLoader.LoadProteinXML(proteinDbLocation: filePath, generateTargets: true, decoyType: DecoyType.Reverse,
-                    allKnownModifications: null, isContaminant: false, modTypesToExclude: null, out var unknownMod);
+                    allKnownModifications: null, isContaminant: false, modTypesToExclude: null, out var unknownMod, maxHeterozygousVariants: 0);
             }
             else
             {


### PR DESCRIPTION
## Human Summary

Uniprot recently 1) Changed their API a bit and 2) removed some of the bad proteomes from their index. This resulted in failing tests when nobody had touched any related code in years. I fixed it by swapping the proteome we check for a different one and fixed the API call. 

## Summary

Fix three bugs in the UniProt proteome download feature and its integration tests.

### Bug 1: `proteome:` filter outside `query` parameter
The `proteome:` field was placed as a separate query parameter (`&proteome:UP000000280`) instead of inside the `query=` value. The API ignored it, returning all reviewed entries (575K+) instead of proteome-filtered results.

**Fix**: Changed `query=reviewed:true&proteome:{id}` to `query=reviewed:true AND proteome:{id}` — keeps both filters inside the `query` parameter.

### Bug 2: `search` endpoint paginates at 25 entries
The URL was changed from `uniprotkb/stream` to `uniprotkb/search` in a prior refactor, but the search endpoint caps responses at 25 by default. Downloads of proteomes with >25 entries were silently truncated.

**Fix**: Reverted endpoint from `search` to `stream`, which returns all results.

### Bug 3: XML loader expands sequence variants
`LoadProteinXML` calls `GetVariantBioPolymers` (default `maxHeterozygousVariants=4`) which inflates the protein count beyond the expected `targets × 2` formula. FASTA loader does not expand variants, causing XML/FASTA count mismatches.

**Fix**: Added `maxHeterozygousVariants: 0` to the `LoadProteinXML` call in the test to match FASTA behavior.

### Test data updated
Replaced `UP000000280` (TMV, non-reference proteome, `proteome:` filter returns 0) with `UP000001207` (Bacillus phage phi29, reference proteome, 24 reviewed/3 unreviewed/2 isoforms) providing 3 distinct expected counts (48, 52, 54).

## Testing
- All 11 `UniprotHtmlQueryTest` cases pass (0→11)
- All 11 `TestGetUniprotFilename` cases pass (no regression)
- Tests download live data from `rest.uniprot.org` — counts may drift if UniProt data changes

## Migration
None required. CLI/GUI users will now correctly receive proteome-filtered results instead of all reviewed entries.
