### PR TITLE
Add Collision Energy column to PSM TSV output and MetaDraw grouping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,3 +240,6 @@ _Pvt_Extensions
 /AGENTS.md
 /.serena
 /Generated Files
+/.omo
+/MetaMorpheus/CMD/Properties/launchSettings.json
+/MetaMorpheus/GUI/Properties/launchSettings.json

--- a/MetaMorpheus/EngineLayer/SpectralMatch.cs
+++ b/MetaMorpheus/EngineLayer/SpectralMatch.cs
@@ -1,4 +1,4 @@
-﻿using Chemistry;
+using Chemistry;
 using EngineLayer.FdrAnalysis;
 using MassSpectrometry;
 using Proteomics;
@@ -11,6 +11,7 @@ using System;
 using Omics.Digestion;
 using EngineLayer.CrosslinkSearch;
 using EngineLayer.SpectrumMatch;
+using System.Globalization;
 
 namespace EngineLayer
 {
@@ -50,6 +51,16 @@ namespace EngineLayer
                 ScanOneOverK0 = null; // this is only used for ion mobility data, so it can be null
             }
 
+            if (scan.TheScan.HcdEnergy != null
+                && double.TryParse(scan.TheScan.HcdEnergy, NumberStyles.Any, CultureInfo.InvariantCulture, out var ce))
+            {
+                CollisionalEnergy = ce;
+            }
+            else
+            {
+                CollisionalEnergy = null;
+            }
+
             AddOrReplace(peptide, score, notch, true, matchedFragmentIons);
         }
 
@@ -87,6 +98,7 @@ namespace EngineLayer
         public double PrecursorScanDeconvolutionScore { get; }
         public double ScanPrecursorMass { get; }
         public double? ScanOneOverK0 { get; set; } // this is only used for ion mobility data, so it can be null
+        public double? CollisionalEnergy { get; }
         public string FullFilePath { get; private set; }
         /// <summary>
         /// Refers to the index of the Ms2ScanWithSpecificMass in an array of Ms2ScansWithSpecificMass that is sorted by precursor mass
@@ -316,9 +328,9 @@ namespace EngineLayer
 
         #region IO
 
-        public static string GetTabSeparatedHeader(bool includeOneOverK0Column = false)
+        public static string GetTabSeparatedHeader(bool includeOneOverK0Column = false, bool includeCollisionalEnergyColumn = false)
         {
-            return string.Join("\t", DataDictionary(null, null, includeOneOverK0Column: includeOneOverK0Column).Keys);
+            return string.Join("\t", DataDictionary(null, null, includeOneOverK0Column: includeOneOverK0Column, includeCollisionalEnergyColumn: includeCollisionalEnergyColumn).Keys);
         }
 
         public override string ToString()
@@ -326,15 +338,15 @@ namespace EngineLayer
             return ToString(new Dictionary<string, int>());
         }
 
-        public string ToString(IReadOnlyDictionary<string, int> ModstoWritePruned, bool writePeptideLevelFdr = false, bool includeOneOverK0Column = false)
+        public string ToString(IReadOnlyDictionary<string, int> ModstoWritePruned, bool writePeptideLevelFdr = false, bool includeOneOverK0Column = false, bool includeCollisionalEnergyColumn = false)
         {
-            return string.Join("\t", DataDictionary(this, ModstoWritePruned, writePeptideLevelFdr, includeOneOverK0Column).Values.Select(v => v?.Trim() ?? string.Empty));
+            return string.Join("\t", DataDictionary(this, ModstoWritePruned, writePeptideLevelFdr, includeOneOverK0Column, includeCollisionalEnergyColumn).Values.Select(v => v?.Trim() ?? string.Empty));
         }
 
-        public static Dictionary<string, string> DataDictionary(SpectralMatch psm, IReadOnlyDictionary<string, int> ModsToWritePruned, bool writePeptideLevelFdr = false, bool includeOneOverK0Column = false)
+        public static Dictionary<string, string> DataDictionary(SpectralMatch psm, IReadOnlyDictionary<string, int> ModsToWritePruned, bool writePeptideLevelFdr = false, bool includeOneOverK0Column = false, bool includeCollisionalEnergyColumn = false)
         {
             Dictionary<string, string> s = new Dictionary<string, string>();
-            PsmTsvWriter.AddBasicMatchData(s, psm, includeOneOverK0Column);
+            PsmTsvWriter.AddBasicMatchData(s, psm, includeOneOverK0Column, includeCollisionalEnergyColumn);
             PsmTsvWriter.AddPeptideSequenceData(s, psm, ModsToWritePruned);
             PsmTsvWriter.AddMatchedIonsData(s, psm?.MatchedFragmentIons);
             PsmTsvWriter.AddMatchScoreData(s, psm, writePeptideLevelFdr);
@@ -409,6 +421,8 @@ namespace EngineLayer
             ScanPrecursorCharge = psm.ScanPrecursorCharge;
             ScanPrecursorMonoisotopicPeakMz = psm.ScanPrecursorMonoisotopicPeakMz;
             ScanPrecursorMass = psm.ScanPrecursorMass;
+            ScanOneOverK0 = psm.ScanOneOverK0;
+            CollisionalEnergy = psm.CollisionalEnergy;
             FullFilePath = psm.FullFilePath;
             ScanIndex = psm.ScanIndex;
             FdrInfo = psm.FdrInfo;

--- a/MetaMorpheus/EngineLayer/SpectrumMatch/PsmTsvWriter.cs
+++ b/MetaMorpheus/EngineLayer/SpectrumMatch/PsmTsvWriter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -171,7 +171,7 @@ namespace EngineLayer
             }
         }
 
-        internal static void AddBasicMatchData(Dictionary<string, string> s, SpectralMatch psm, bool includeOneOverK0Column = false)
+        internal static void AddBasicMatchData(Dictionary<string, string> s, SpectralMatch psm, bool includeOneOverK0Column = false, bool includeCollisionalEnergyColumn = false)
         {
             s[SpectrumMatchFromTsvHeader.FileName] = psm == null ? " " : Path.GetFileNameWithoutExtension(psm.FullFilePath);
             s[SpectrumMatchFromTsvHeader.Ms2ScanNumber] = psm == null ? " " : psm.ScanNumber.ToString(CultureInfo.InvariantCulture);
@@ -185,6 +185,8 @@ namespace EngineLayer
             s[SpectrumMatchFromTsvHeader.PrecursorMass] = psm == null ? " " : psm.ScanPrecursorMass.ToString("F5", CultureInfo.InvariantCulture);
             if ( includeOneOverK0Column) // This information is only written if one or more spectra have a K0 value, otherwise it is not included in the output
                 s[SpectrumMatchFromTsvHeader.OneOverK0] = psm == null ? " " : psm.ScanOneOverK0.HasValue ? psm.ScanOneOverK0.Value.ToString("F5", CultureInfo.InvariantCulture) : "N/A";
+            if (includeCollisionalEnergyColumn) // This information is only written if one or more spectra have collisional energy, otherwise it is not included in the output
+                s[SpectrumMatchFromTsvHeader.CollisionEnergy] = psm == null ? " " : psm.CollisionalEnergy.HasValue ? psm.CollisionalEnergy.Value.ToString("F2", CultureInfo.InvariantCulture) : "N/A";
             s[SpectrumMatchFromTsvHeader.Score] = psm == null ? " " : psm.Score.ToString("F3", CultureInfo.InvariantCulture);
             s[SpectrumMatchFromTsvHeader.DeltaScore] = psm == null ? " " : psm.DeltaScore.ToString("F3", CultureInfo.InvariantCulture);
             s[SpectrumMatchFromTsvHeader.Notch] = psm == null ? " " : Resolve(psm.BestMatchingBioPolymersWithSetMods.Select(p => p.Notch / MassDiffAcceptor.NotchScalar)).ResolvedString;

--- a/MetaMorpheus/GuiFunctions/MetaDraw/MetaDrawSettings.cs
+++ b/MetaMorpheus/GuiFunctions/MetaDraw/MetaDrawSettings.cs
@@ -1,4 +1,4 @@
-﻿using EngineLayer;
+using EngineLayer;
 using OxyPlot;
 using Omics.Fragmentation;
 using System;
@@ -117,7 +117,7 @@ namespace GuiFunctions
         public static string[] CoverageTypes { get; set; } = { "N-Terminal Color", "C-Terminal Color", "Internal Color" };
         public static string[] ExportTypes { get; set; } = { "Pdf", "Png", "Jpeg", "Tiff", "Wmf", "Bmp" };
         public static string[] AmbiguityTypes { get; set; } = { "No Filter", "1", "2A", "2B", "2C", "2D", "3", "4", "5" };
-        public static string[] GroupingProperties { get; set; } = { "None", "Notch", "Precursor Charge", "File Name", "Ambiguity Level", "Missed Cleavages", "OrganismName", "DecoyContamTarget" };
+        public static string[] GroupingProperties { get; set; } = { "None", "Notch", "Precursor Charge", "File Name", "Ambiguity Level", "Missed Cleavages", "Collision Energy", "OrganismName", "DecoyContamTarget" };
 
         #endregion
 

--- a/MetaMorpheus/GuiFunctions/MetaDraw/PlotModelStat.cs
+++ b/MetaMorpheus/GuiFunctions/MetaDraw/PlotModelStat.cs
@@ -991,6 +991,7 @@ namespace GuiFunctions
                 "File Name" => psm.FileNameWithoutExtension,
                 "Ambiguity Level" => psm.AmbiguityLevel ?? "1",
                 "Missed Cleavages" => psm.MissedCleavage ?? "0",
+                "Collision Energy" => psm.CollisionEnergy?.ToString(CultureInfo.InvariantCulture) ?? "N/A",
                 "OrganismName" => psm.OrganismName,
                 "DecoyContamTarget" => psm.DecoyContamTarget,
 

--- a/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
+++ b/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
@@ -1081,10 +1081,11 @@ namespace TaskLayer
             using (StreamWriter output = new StreamWriter(filePath))
             {
                 bool includeOneOverK0Column = psms.Any(p => p.ScanOneOverK0.HasValue);
-                output.WriteLine(SpectralMatch.GetTabSeparatedHeader(includeOneOverK0Column));
+                bool includeCollisionalEnergyColumn = psms.Any(p => p.CollisionalEnergy.HasValue);
+                output.WriteLine(SpectralMatch.GetTabSeparatedHeader(includeOneOverK0Column, includeCollisionalEnergyColumn));
                 foreach (var psm in psms)
                 {
-                    output.WriteLine(psm.ToString(modstoWritePruned, writePeptideLevelResults, includeOneOverK0Column));
+                    output.WriteLine(psm.ToString(modstoWritePruned, writePeptideLevelResults, includeOneOverK0Column, includeCollisionalEnergyColumn));
                 }
             }
         }

--- a/MetaMorpheus/Test/MetaDraw/MetaDrawTest.cs
+++ b/MetaMorpheus/Test/MetaDraw/MetaDrawTest.cs
@@ -214,6 +214,7 @@ namespace Test.MetaDraw
         [TestCase("Notch")]
         [TestCase("File Name")]
         [TestCase("Ambiguity Level")]
+        [TestCase("Collision Energy")]
         [TestCase("OrganismName")]
         [TestCase("DecoyContamTarget")]
         [TestCase("None")]

--- a/MetaMorpheus/Test/PsmTsvWriterTests.cs
+++ b/MetaMorpheus/Test/PsmTsvWriterTests.cs
@@ -1,4 +1,4 @@
-﻿using Chemistry;
+using Chemistry;
 using EngineLayer;
 using MassSpectrometry;
 using NUnit.Framework;
@@ -517,5 +517,148 @@ namespace Test
             Assert.That(psmStringSplit[localizedScoresIndex], Contains.Substring("8.000"));
             Assert.That(psmStringSplit[localizedScoresIndex], Contains.Substring("9.500"));
         }
+        #region Collisional Energy Tests
+
+        [Test]
+        public static void TestCollisionalEnergy_ParsedFromScan()
+        {
+            var protein = new Protein("PEPTIDE", "TestProtein");
+            var digestionParams = new DigestionParams();
+            var peptide = new PeptideWithSetModifications(protein, digestionParams, 1, 7,
+                CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0);
+
+            double mass = 12.0 + peptide.MonoisotopicMass.ToMz(1);
+            var scan = new Ms2ScanWithSpecificMass(
+                new MsDataScan(new MzSpectrum(new double[,] { }), 0, 0, true, Polarity.Positive,
+                    0, new MzLibUtil.MzRange(0, 0), "", MZAnalyzerType.FTICR, 0, null, null, "",
+                    hcdEnergy: "42.00"),
+                mass, 1, "", new CommonParameters());
+
+            var mfi = new List<MatchedFragmentIon>();
+            var psm = new PeptideSpectralMatch(peptide, 0, 10, 0, scan, new CommonParameters(), mfi);
+
+            Assert.That(psm.CollisionalEnergy, Is.EqualTo(42.0));
+        }
+
+        [Test]
+        public static void TestCollisionalEnergy_NullWhenNoHcdEnergy()
+        {
+            var protein = new Protein("PEPTIDE", "TestProtein");
+            var digestionParams = new DigestionParams();
+            var peptide = new PeptideWithSetModifications(protein, digestionParams, 1, 7,
+                CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0);
+
+            double mass = 12.0 + peptide.MonoisotopicMass.ToMz(1);
+            var scan = new Ms2ScanWithSpecificMass(
+                new MsDataScan(new MzSpectrum(new double[,] { }), 0, 0, true, Polarity.Positive,
+                    0, new MzLibUtil.MzRange(0, 0), "", MZAnalyzerType.FTICR, 0, null, null, ""),
+                mass, 1, "", new CommonParameters());
+
+            var mfi = new List<MatchedFragmentIon>();
+            var psm = new PeptideSpectralMatch(peptide, 0, 10, 0, scan, new CommonParameters(), mfi);
+
+            Assert.That(psm.CollisionalEnergy, Is.Null);
+        }
+
+        [Test]
+        public static void TestCollisionalEnergy_NullWhenInvalidHcdEnergy()
+        {
+            var protein = new Protein("PEPTIDE", "TestProtein");
+            var digestionParams = new DigestionParams();
+            var peptide = new PeptideWithSetModifications(protein, digestionParams, 1, 7,
+                CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0);
+
+            double mass = 12.0 + peptide.MonoisotopicMass.ToMz(1);
+            var scan = new Ms2ScanWithSpecificMass(
+                new MsDataScan(new MzSpectrum(new double[,] { }), 0, 0, true, Polarity.Positive,
+                    0, new MzLibUtil.MzRange(0, 0), "", MZAnalyzerType.FTICR, 0, null, null, "",
+                    hcdEnergy: "N/A"),
+                mass, 1, "", new CommonParameters());
+
+            var mfi = new List<MatchedFragmentIon>();
+            var psm = new PeptideSpectralMatch(peptide, 0, 10, 0, scan, new CommonParameters(), mfi);
+
+            Assert.That(psm.CollisionalEnergy, Is.Null);
+        }
+
+        [Test]
+        public static void TestCollisionalEnergy_ColumnInOutputWhenFlagSet()
+        {
+            var protein = new Protein("PEPTIDE", "TestProtein");
+            var digestionParams = new DigestionParams();
+            var peptide = new PeptideWithSetModifications(protein, digestionParams, 1, 7,
+                CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0);
+
+            double mass = 12.0 + peptide.MonoisotopicMass.ToMz(1);
+            var scan = new Ms2ScanWithSpecificMass(
+                new MsDataScan(new MzSpectrum(new double[,] { }), 0, 0, true, Polarity.Positive,
+                    0, new MzLibUtil.MzRange(0, 0), "", MZAnalyzerType.FTICR, 0, null, null, "",
+                    hcdEnergy: "28"),
+                mass, 1, "", new CommonParameters());
+
+            var mfi = new List<MatchedFragmentIon>();
+            var psm = new PeptideSpectralMatch(peptide, 0, 10, 0, scan, new CommonParameters(), mfi);
+
+            var headerSplits = SpectralMatch.GetTabSeparatedHeader(includeCollisionalEnergyColumn: true).Split('\t');
+            var psmString = psm.ToString(new Dictionary<string, int>(), includeCollisionalEnergyColumn: true);
+            var psmSplits = psmString.Split('\t');
+
+            var collisionEnergyIndex = headerSplits.IndexOf(SpectrumMatchFromTsvHeader.CollisionEnergy);
+            Assert.That(collisionEnergyIndex, Is.GreaterThanOrEqualTo(0));
+            Assert.That(psmSplits[collisionEnergyIndex], Is.EqualTo("28.00"));
+        }
+
+        [Test]
+        public static void TestCollisionalEnergy_ColumnNotIncludedByDefault()
+        {
+            var protein = new Protein("PEPTIDE", "TestProtein");
+            var digestionParams = new DigestionParams();
+            var peptide = new PeptideWithSetModifications(protein, digestionParams, 1, 7,
+                CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0);
+
+            double mass = 12.0 + peptide.MonoisotopicMass.ToMz(1);
+            var scan = new Ms2ScanWithSpecificMass(
+                new MsDataScan(new MzSpectrum(new double[,] { }), 0, 0, true, Polarity.Positive,
+                    0, new MzLibUtil.MzRange(0, 0), "", MZAnalyzerType.FTICR, 0, null, null, "",
+                    hcdEnergy: "28"),
+                mass, 1, "", new CommonParameters());
+
+            var mfi = new List<MatchedFragmentIon>();
+            var psm = new PeptideSpectralMatch(peptide, 0, 10, 0, scan, new CommonParameters(), mfi);
+
+            var headerDefault = SpectralMatch.GetTabSeparatedHeader().Split('\t');
+            var headerWithCol = SpectralMatch.GetTabSeparatedHeader(includeCollisionalEnergyColumn: true).Split('\t');
+
+            Assert.That(headerDefault, Does.Not.Contain(SpectrumMatchFromTsvHeader.CollisionEnergy));
+            Assert.That(headerWithCol, Does.Contain(SpectrumMatchFromTsvHeader.CollisionEnergy));
+        }
+
+        [Test]
+        public static void TestCollisionalEnergy_WritesNotAvailable_WhenMissing()
+        {
+            var protein = new Protein("PEPTIDE", "TestProtein");
+            var digestionParams = new DigestionParams();
+            var peptide = new PeptideWithSetModifications(protein, digestionParams, 1, 7,
+                CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0);
+
+            double mass = 12.0 + peptide.MonoisotopicMass.ToMz(1);
+            var scan = new Ms2ScanWithSpecificMass(
+                new MsDataScan(new MzSpectrum(new double[,] { }), 0, 0, true, Polarity.Positive,
+                    0, new MzLibUtil.MzRange(0, 0), "", MZAnalyzerType.FTICR, 0, null, null, ""),
+                mass, 1, "", new CommonParameters());
+
+            var mfi = new List<MatchedFragmentIon>();
+            var psm = new PeptideSpectralMatch(peptide, 0, 10, 0, scan, new CommonParameters(), mfi);
+
+            var headerSplits = SpectralMatch.GetTabSeparatedHeader(includeCollisionalEnergyColumn: true).Split('\t');
+            var psmString = psm.ToString(new Dictionary<string, int>(), includeCollisionalEnergyColumn: true);
+            var psmSplits = psmString.Split('\t');
+
+            var collisionEnergyIndex = headerSplits.IndexOf(SpectrumMatchFromTsvHeader.CollisionEnergy);
+            Assert.That(collisionEnergyIndex, Is.GreaterThanOrEqualTo(0));
+            Assert.That(psmSplits[collisionEnergyIndex], Is.EqualTo("N/A"));
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
## Motivation

Burke requested the ability to read collisional energy values from MetaMorpheus PSM TSV output. The mzLib reading side was already implemented in PR #1031 (SpectrumMatchFromTsv.CollisionEnergy, SpectrumMatchFromTsvHeader.CollisionEnergy). This PR implements the **writing** side in MetaMorpheus and exposes the field as a sorting/grouping property in MetaDraw data visualization.

## Summary of Changes

### PSM TSV output (SpectralMatch.cs, PsmTsvWriter.cs, MetaMorpheusTask.cs)
- Added `public double? CollisionalEnergy` property on SpectralMatch, parsed from MsDataScan.HcdEnergy (string) at scan load time
- Conditionally writes a Collision Energy column in .psmtsv files when at least one scan has energy data (same conditional pattern as 1/K0)
- N/A written for PSMs whose scan lacked energy data

### MetaDraw data visualization (MetaDrawSettings.cs, PlotModelStat.cs)
- Added Collision Energy to the GroupingProperties array in the Data Visualization tab
- GetGroupKeyFromPsm maps it to psm.CollisionEnergy?.ToString() or N/A when missing

## Tests
- PsmTsvWriterTests.cs: 6 new tests (parsing, null handling, column presence)
- MetaDrawTest.cs: added TestCase for Collision Energy grouping
- All tests pass, 0 failures

## Migration
None required. Conditional column means existing downstream parsers are unaffected.