### PR TITLE
Scaffold unresolved (average-mass) precursor selection

### DIFF
--- a/MetaMorpheus/CMD/CMD.csproj
+++ b/MetaMorpheus/CMD/CMD.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/MetaMorpheus/CMD/CMD.csproj
+++ b/MetaMorpheus/CMD/CMD.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.579" />
+    <PackageReference Include="mzLib" Version="9.9.25" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.118" />

--- a/MetaMorpheus/CMD/CMD.csproj
+++ b/MetaMorpheus/CMD/CMD.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="9.9.25" />
+    <PackageReference Include="mzLib" Version="9.9.26" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.118" />

--- a/MetaMorpheus/EngineLayer/Calibration/DataPointAcquisitionEngine.cs
+++ b/MetaMorpheus/EngineLayer/Calibration/DataPointAcquisitionEngine.cs
@@ -113,7 +113,8 @@ namespace EngineLayer.Calibration
                 numMs1MassChargeCombinationsConsidered,
                 numMs1MassChargeCombinationsThatAreIgnoredBecauseOfTooManyPeaks,
                 numMs2MassChargeCombinationsConsidered,
-                numMs2MassChargeCombinationsThatAreIgnoredBecauseOfTooManyPeaks
+                numMs2MassChargeCombinationsThatAreIgnoredBecauseOfTooManyPeaks,
+                CommonParameters.PrecursorMassMatchMode
             );
         }
 

--- a/MetaMorpheus/EngineLayer/Calibration/DataPointAquisitionResults.cs
+++ b/MetaMorpheus/EngineLayer/Calibration/DataPointAquisitionResults.cs
@@ -35,7 +35,21 @@ namespace EngineLayer.Calibration
             var ms1PpmRange = Ms1List.Select(b => (b.ExperimentalMz - b.TheoreticalMz) / b.TheoreticalMz).ToArray();
             var ms2PpmRange = Ms2List.Select(b => (b.ExperimentalMz - b.TheoreticalMz) / b.TheoreticalMz).ToArray();
 
-            var precursorErrors = psms.Select(p => (p.ScanPrecursorMass - p.BioPolymerWithSetModsMonoisotopicMass.Value) / p.BioPolymerWithSetModsMonoisotopicMass.Value * 1e6).ToList();
+            // Use the neutron-modulo residual of the precursor mass error, not the raw difference. The
+            // raw (ScanPrecursorMass - peptideMonoisotopic) difference includes whole-neutron offsets when
+            // the deconvoluted monoisotopic peak is off by an isotope - common, and intentional, under
+            // most-abundant precursor matching (PrecursorMassMatchMode.MostAbundant), where candidates are
+            // matched on the apex and the reported monoisotopic can be +/-1-2 neutrons away. Those integer
+            // offsets are isotope-assignment errors, not the instrument m/z calibration error; including
+            // them inflated the IQR and made calibration write runaway precursor tolerances (e.g. 1940 ppm).
+            // Stripping the nearest-neutron component yields the true sub-ppm drift and is a no-op for
+            // monoisotopic-matched PSMs (whose difference is already << 1 neutron).
+            var precursorErrors = psms.Select(p =>
+            {
+                double deltaDa = p.ScanPrecursorMass - p.BioPolymerWithSetModsMonoisotopicMass.Value;
+                double residualDa = deltaDa - Math.Round(deltaDa / Constants.C13MinusC12) * Constants.C13MinusC12;
+                return residualDa / p.BioPolymerWithSetModsMonoisotopicMass.Value * 1e6;
+            }).ToList();
             PsmPrecursorIqrPpmError = precursorErrors.InterquartileRange();
             PsmPrecursorMedianPpmError = precursorErrors.Median();
 

--- a/MetaMorpheus/EngineLayer/Calibration/DataPointAquisitionResults.cs
+++ b/MetaMorpheus/EngineLayer/Calibration/DataPointAquisitionResults.cs
@@ -21,7 +21,8 @@ namespace EngineLayer.Calibration
             int numMs1MassChargeCombinationsConsidered,
             int numMs1MassChargeCombinationsThatAreIgnoredBecauseOfTooManyPeaks,
             int numMs2MassChargeCombinationsConsidered,
-            int numMs2MassChargeCombinationsThatAreIgnoredBecauseOfTooManyPeaks)
+            int numMs2MassChargeCombinationsThatAreIgnoredBecauseOfTooManyPeaks,
+            PrecursorMassMatchMode precursorMassMatchMode = PrecursorMassMatchMode.Monoisotopic)
             : base(dataPointAcquisitionEngine)
         {
             Psms = psms;
@@ -35,20 +36,24 @@ namespace EngineLayer.Calibration
             var ms1PpmRange = Ms1List.Select(b => (b.ExperimentalMz - b.TheoreticalMz) / b.TheoreticalMz).ToArray();
             var ms2PpmRange = Ms2List.Select(b => (b.ExperimentalMz - b.TheoreticalMz) / b.TheoreticalMz).ToArray();
 
-            // Use the neutron-modulo residual of the precursor mass error, not the raw difference. The
-            // raw (ScanPrecursorMass - peptideMonoisotopic) difference includes whole-neutron offsets when
-            // the deconvoluted monoisotopic peak is off by an isotope - common, and intentional, under
-            // most-abundant precursor matching (PrecursorMassMatchMode.MostAbundant), where candidates are
-            // matched on the apex and the reported monoisotopic can be +/-1-2 neutrons away. Those integer
-            // offsets are isotope-assignment errors, not the instrument m/z calibration error; including
-            // them inflated the IQR and made calibration write runaway precursor tolerances (e.g. 1940 ppm).
-            // Stripping the nearest-neutron component yields the true sub-ppm drift and is a no-op for
-            // monoisotopic-matched PSMs (whose difference is already << 1 neutron).
+            // In most-abundant mode only, use the neutron-modulo residual of the precursor mass error
+            // instead of the raw difference. Most-abundant matching admits PSMs whose deconvoluted
+            // monoisotopic peak is off by +/-1-2 neutrons (the apex notch set), so the raw
+            // (ScanPrecursorMass - peptideMonoisotopic) difference carries whole-neutron offsets that are
+            // isotope-assignment errors, not instrument m/z drift; left in, they inflate the IQR and make
+            // calibration write runaway precursor tolerances (e.g. 1940 ppm). In default Monoisotopic mode
+            // the raw difference is used unchanged - baseline calibration behavior is preserved exactly.
+            bool stripNeutronOffsets = precursorMassMatchMode == PrecursorMassMatchMode.MostAbundant;
             var precursorErrors = psms.Select(p =>
             {
                 double deltaDa = p.ScanPrecursorMass - p.BioPolymerWithSetModsMonoisotopicMass.Value;
-                double residualDa = deltaDa - Math.Round(deltaDa / Constants.C13MinusC12) * Constants.C13MinusC12;
-                return residualDa / p.BioPolymerWithSetModsMonoisotopicMass.Value * 1e6;
+                if (stripNeutronOffsets)
+                {
+                    // AwayFromZero so the nearest-neutron assignment at an exact half-neutron boundary is
+                    // parity-independent (default banker's rounding would snap to the even integer).
+                    deltaDa -= Math.Round(deltaDa / Constants.C13MinusC12, MidpointRounding.AwayFromZero) * Constants.C13MinusC12;
+                }
+                return deltaDa / p.BioPolymerWithSetModsMonoisotopicMass.Value * 1e6;
             }).ToList();
             PsmPrecursorIqrPpmError = precursorErrors.InterquartileRange();
             PsmPrecursorMedianPpmError = precursorErrors.Median();

--- a/MetaMorpheus/EngineLayer/ClassicSearch/ClassicSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/ClassicSearch/ClassicSearchEngine.cs
@@ -40,7 +40,10 @@ namespace EngineLayer.ClassicSearch
         {
             SpectralMatches = globalPsms;
             ArrayOfSortedMS2Scans = arrayOfSortedMS2Scans;
-            MyScanPrecursorMasses = arrayOfSortedMS2Scans.Select(b => b.PrecursorMass).ToArray();
+            // PrecursorMassToMatch is the candidate-selection mass (equals PrecursorMass in
+            // monoisotopic mode; the most-abundant/average observed mass in most-abundant mode).
+            // The scans are sorted by this same quantity, keeping the binary search valid.
+            MyScanPrecursorMasses = arrayOfSortedMS2Scans.Select(b => b.PrecursorMassToMatch).ToArray();
             VariableModifications = variableModifications;
             FixedModifications = fixedModifications;
             SilacLabels = silacLabels;

--- a/MetaMorpheus/EngineLayer/CommonParameters.cs
+++ b/MetaMorpheus/EngineLayer/CommonParameters.cs
@@ -62,7 +62,8 @@ namespace EngineLayer
             DeconvolutionParameters productDeconParams = null,
             bool useMostAbundantPrecursorIntensity = true,
             DIAparameters diaParameters = null,
-            IFragmentationParams fragmentationParams = null)
+            IFragmentationParams fragmentationParams = null,
+            PrecursorMassMatchMode precursorMassMatchMode = PrecursorMassMatchMode.Monoisotopic)
 
         {
             TaskDescriptor = taskDescriptor;
@@ -94,6 +95,7 @@ namespace EngineLayer
             MS2ChildScanDissociationType = ms2childScanDissociationType;
             MS3ChildScanDissociationType = ms3childScanDissociationType;
             UseMostAbundantPrecursorIntensity = useMostAbundantPrecursorIntensity;
+            PrecursorMassMatchMode = precursorMassMatchMode;
             AssumeOrphanPeaksAreZ1Fragments = assumeOrphanPeaksAreZ1Fragments;
             MaxHeterozygousVariants = maxHeterozygousVariants;
             MinVariantDepth = minVariantDepth;
@@ -204,6 +206,12 @@ namespace EngineLayer
         public DissociationType MS3ChildScanDissociationType { get; set; }
 
         public bool UseMostAbundantPrecursorIntensity { get; set; }
+
+        /// <summary>
+        /// Which precursor mass is used to select theoretical proteoform candidates during search.
+        /// Defaults to <see cref="EngineLayer.PrecursorMassMatchMode.Monoisotopic"/>.
+        /// </summary>
+        public PrecursorMassMatchMode PrecursorMassMatchMode { get; set; }
         public DIAparameters? DIAparameters { get; set; } //only for DIA analysis involving pseudo ms2 scan generation
         public IFragmentationParams FragmentationParameters { get; set; }
 
@@ -278,7 +286,8 @@ namespace EngineLayer
                                 ProductDeconvolutionParameters,
                                 UseMostAbundantPrecursorIntensity,
                                 DIAparameters,
-                                FragmentationParameters);
+                                FragmentationParameters,
+                                PrecursorMassMatchMode);
         }
 
         public void SetCustomProductTypes()

--- a/MetaMorpheus/EngineLayer/EngineLayer.csproj
+++ b/MetaMorpheus/EngineLayer/EngineLayer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>

--- a/MetaMorpheus/EngineLayer/EngineLayer.csproj
+++ b/MetaMorpheus/EngineLayer/EngineLayer.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.579" />
+    <PackageReference Include="mzLib" Version="9.9.25" />
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/MetaMorpheus/EngineLayer/EngineLayer.csproj
+++ b/MetaMorpheus/EngineLayer/EngineLayer.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="9.9.25" />
+    <PackageReference Include="mzLib" Version="9.9.26" />
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/MetaMorpheus/EngineLayer/ModernSearch/ModernSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/ModernSearch/ModernSearchEngine.cs
@@ -100,7 +100,7 @@ namespace EngineLayer.ModernSearch
             // note that this is the OPPOSITE of the classic search (which calculates experimental masses from theoretical values)	
             // this is just PRELIMINARY precursor-mass filtering	
             // additional checks are made later to ensure that the theoretical precursor mass is acceptable
-            List<AllowedIntervalWithNotch> notches = MassDiffAcceptor.GetAllowedPrecursorMassIntervalsFromObservedMass(scan.PrecursorMass).ToList();
+            List<AllowedIntervalWithNotch> notches = MassDiffAcceptor.GetAllowedPrecursorMassIntervalsFromObservedMass(scan.PrecursorMassToMatch).ToList();
             double lowestMassPeptideToLookFor = notches.Min(p => p.Minimum);
             double highestMassPeptideToLookFor = notches.Max(p => p.Maximum);
 
@@ -305,7 +305,7 @@ namespace EngineLayer.ModernSearch
                     // at least one fragment in the scan will get fine-scored.
 
                     // add possible search results to the list of id's (only once)
-                    if (scoringTable[peptideId] == 0 && MassDiffAcceptor.Accepts(scan.PrecursorMass, PeptideIndex[peptideId].MonoisotopicMass) >= 0)
+                    if (scoringTable[peptideId] == 0 && MassDiffAcceptor.Accepts(scan.PrecursorMassToMatch, PeptideIndex[peptideId].MonoisotopicMass) >= 0)
                     {
                         peptidesPossiblyObserved.Add(peptideId);
                     }
@@ -324,7 +324,7 @@ namespace EngineLayer.ModernSearch
 
                     // if the peptide has met the score cutoff, add it to the list of peptides 
                     // possibly observed so it can be re-scored with the "fine scoring" algorithm
-                    if (score == byteScoreCutoff && MassDiffAcceptor.Accepts(scan.PrecursorMass, PeptideIndex[peptideId].MonoisotopicMass) >= 0)
+                    if (score == byteScoreCutoff && MassDiffAcceptor.Accepts(scan.PrecursorMassToMatch, PeptideIndex[peptideId].MonoisotopicMass) >= 0)
                     {
                         peptidesPossiblyObserved.Add(peptideId);
                     }

--- a/MetaMorpheus/EngineLayer/ModernSearch/ModernSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/ModernSearch/ModernSearchEngine.cs
@@ -345,7 +345,10 @@ namespace EngineLayer.ModernSearch
             List<MatchedFragmentIon> matchedIons = MatchFragmentIons(scan, peptideTheorProducts, CommonParameters);
 
             double thisScore = CalculatePeptideScore(scan.TheScan, matchedIons);
-            int notch = MassDiffAcceptor.Accepts(scan.PrecursorMass, peptide.MonoisotopicMass);
+            // Use PrecursorMassToMatch (the candidate-selection mass) so the final notch is consistent
+            // with the coarse selection above; in most-abundant mode this is the apex mass, not the
+            // monoisotopic PrecursorMass. PrecursorMass still drives fragment math / error reporting.
+            int notch = MassDiffAcceptor.Accepts(scan.PrecursorMassToMatch, peptide.MonoisotopicMass);
 
             bool meetsScoreCutoff = thisScore >= CommonParameters.ScoreCutoff;
             bool scoreImprovement = PeptideSpectralMatches[scanIndex] == null || (thisScore - PeptideSpectralMatches[scanIndex].RunnerUpScore) > -SpectralMatch.ToleranceForScoreDifferentiation;

--- a/MetaMorpheus/EngineLayer/Ms2ScanWithSpecificMass.cs
+++ b/MetaMorpheus/EngineLayer/Ms2ScanWithSpecificMass.cs
@@ -10,11 +10,17 @@ namespace EngineLayer
     public class Ms2ScanWithSpecificMass
     {
         public Ms2ScanWithSpecificMass(MsDataScan mzLibScan, double precursorMonoisotopicPeakMz, int precursorCharge, string fullFilePath, CommonParameters commonParam,
-            IsotopicEnvelope[] neutralExperimentalFragments = null, double? precursorIntensity = null, int? envelopePeakCount = null, double? precursorFractionalIntensity = null)
+            IsotopicEnvelope[] neutralExperimentalFragments = null, double? precursorIntensity = null, int? envelopePeakCount = null, double? precursorFractionalIntensity = null,
+            double? precursorMassToMatch = null)
         {
             PrecursorMonoisotopicPeakMz = precursorMonoisotopicPeakMz;
             PrecursorCharge = precursorCharge;
             PrecursorMass = PrecursorMonoisotopicPeakMz.ToMass(precursorCharge);
+            // Mass used for candidate selection by the MassDiffAcceptor. Defaults to the monoisotopic
+            // PrecursorMass; in most-abundant mode the caller passes the envelope's most-abundant (or,
+            // for unresolved species, average) observed mass. PrecursorMass itself is left unchanged
+            // because it still drives fragment-bin math and precursor mass-error reporting.
+            PrecursorMassToMatch = precursorMassToMatch ?? PrecursorMass;
             PrecursorIntensity = precursorIntensity ?? 1;
             PrecursorEnvelopePeakCount = envelopePeakCount ?? 1;
             PrecursorFractionalIntensity = precursorFractionalIntensity ?? -1;
@@ -41,6 +47,13 @@ namespace EngineLayer
         public MsDataScan TheScan { get; }
         public double PrecursorMonoisotopicPeakMz { get; }
         public double PrecursorMass { get; }
+
+        /// <summary>
+        /// The precursor mass used to select theoretical candidates via the <see cref="EngineLayer.MassDiffAcceptor"/>.
+        /// Equals <see cref="PrecursorMass"/> in monoisotopic mode; in most-abundant mode it is the
+        /// envelope's most-abundant (or average, if unresolved) observed neutral mass.
+        /// </summary>
+        public double PrecursorMassToMatch { get; }
         public int PrecursorCharge { get; }
         public double PrecursorIntensity { get; }
         public int PrecursorEnvelopePeakCount { get; }

--- a/MetaMorpheus/EngineLayer/PrecursorSearchModes/MostAbundantDotMassDiffAcceptor.cs
+++ b/MetaMorpheus/EngineLayer/PrecursorSearchModes/MostAbundantDotMassDiffAcceptor.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Chemistry;
+using MassSpectrometry;
+using MzLibUtil;
+
+namespace EngineLayer
+{
+    /// <summary>
+    /// Most-abundant-peak analogue of <see cref="DotMassDiffAcceptor"/>, for searches that allow a set
+    /// of discrete mass shifts (e.g. G-PTM-D modification masses). For each acceptable shift <c>s</c>,
+    /// a candidate is accepted when the observed most-abundant mass matches the theoretical apex of the
+    /// shifted candidate—<c>(peptideMono + s) + averagineOffset(peptideMono + s)</c>—within a ±k
+    /// neutron apex tolerance (k ∈ [−<see cref="MaxApexOffsetNeutrons"/> .. +]). This composes the
+    /// shift set with the most-abundant apex matching and the apex-misprediction notch set described in
+    /// <see cref="MostAbundantMassDiffAcceptor"/>.
+    /// </summary>
+    /// <remarks>
+    /// The returned notch identifies the mass <em>shift</em> (same encoding as
+    /// <see cref="DotMassDiffAcceptor"/>, round(shiftDa · NotchScalar)); the ±k apex intervals for a
+    /// given shift all share that shift's notch, since they represent the same modification differing
+    /// only by apex misprediction. <see cref="MassDiffAcceptor.NumNotches"/> therefore equals the number
+    /// of shifts, preserving per-shift FDR grouping. Downstream G-PTM-D mod assignment recomputes the
+    /// modification from the monoisotopic precursor mass, so it is unaffected by this acceptor.
+    /// </remarks>
+    public class MostAbundantDotMassDiffAcceptor : MassDiffAcceptor
+    {
+        private readonly Tolerance Tolerance;
+        private readonly AverageResidue Averagine;
+        private readonly double[] SortedMassShifts;
+        private readonly int[] ShiftNotches;
+        public int MaxApexOffsetNeutrons { get; }
+        private readonly int[] ApexOffsetsInNeutrons;
+
+        public MostAbundantDotMassDiffAcceptor(string fileNameAddition, IEnumerable<double> acceptableMassShifts,
+            Tolerance tol, AverageResidue averagine, int maxApexOffsetNeutrons = 2) : base(fileNameAddition)
+        {
+            Tolerance = tol;
+            Averagine = averagine;
+            SortedMassShifts = acceptableMassShifts.OrderBy(Math.Abs).ThenBy(p => p < 0).ToArray();
+            ShiftNotches = SortedMassShifts.Select(s => (int)Math.Round(s * NotchScalar)).ToArray();
+            MaxApexOffsetNeutrons = maxApexOffsetNeutrons;
+
+            var offsets = new List<int> { 0 };
+            for (int k = 1; k <= maxApexOffsetNeutrons; k++) { offsets.Add(-k); offsets.Add(k); }
+            ApexOffsetsInNeutrons = offsets.ToArray();
+
+            NumNotches = SortedMassShifts.Length;
+        }
+
+        public override int Accepts(double scanPrecursorMass, double peptideMass)
+        {
+            for (int j = 0; j < SortedMassShifts.Length; j++)
+            {
+                double shiftedMono = peptideMass + SortedMassShifts[j];
+                double apex = shiftedMono + Averagine.GetMostAbundantOffset(shiftedMono);
+                foreach (int k in ApexOffsetsInNeutrons)
+                {
+                    if (Tolerance.Within(scanPrecursorMass, apex + k * Constants.C13MinusC12))
+                    {
+                        return ShiftNotches[j];
+                    }
+                }
+            }
+            return -1;
+        }
+
+        public override IEnumerable<AllowedIntervalWithNotch> GetAllowedPrecursorMassIntervalsFromTheoreticalMass(double peptideMonoisotopicMass)
+        {
+            for (int j = 0; j < SortedMassShifts.Length; j++)
+            {
+                double shiftedMono = peptideMonoisotopicMass + SortedMassShifts[j];
+                double apex = shiftedMono + Averagine.GetMostAbundantOffset(shiftedMono);
+                foreach (int k in ApexOffsetsInNeutrons)
+                {
+                    double mass = apex + k * Constants.C13MinusC12;
+                    yield return new AllowedIntervalWithNotch(Tolerance.GetMinimumValue(mass), Tolerance.GetMaximumValue(mass), ShiftNotches[j]);
+                }
+            }
+        }
+
+        public override IEnumerable<AllowedIntervalWithNotch> GetAllowedPrecursorMassIntervalsFromObservedMass(double peptideMonoisotopicMass)
+        {
+            // Indexed (ModernSearch) path; documented near-boundary caveat as in MostAbundantMassDiffAcceptor.
+            // GPTMD uses the theory-driven ClassicSearch path, so this is not its primary path.
+            double monoApprox = peptideMonoisotopicMass - Averagine.GetMostAbundantOffset(peptideMonoisotopicMass);
+            for (int j = 0; j < SortedMassShifts.Length; j++)
+            {
+                foreach (int k in ApexOffsetsInNeutrons)
+                {
+                    double mass = monoApprox - SortedMassShifts[j] - k * Constants.C13MinusC12;
+                    yield return new AllowedIntervalWithNotch(Tolerance.GetMinimumValue(mass), Tolerance.GetMaximumValue(mass), ShiftNotches[j]);
+                }
+            }
+        }
+
+        public override string ToString() => FileNameAddition + " mostAbundantDot ±" + MaxApexOffsetNeutrons + " apex " + Tolerance + " " + string.Join(",", SortedMassShifts);
+
+        public override string ToProseString() => Tolerance + " around the most abundant isotopic peak of " + string.Join(", ", SortedMassShifts) + " Da shifts (±" + MaxApexOffsetNeutrons + " isotope apex tolerance)";
+    }
+}

--- a/MetaMorpheus/EngineLayer/PrecursorSearchModes/MostAbundantDotMassDiffAcceptor.cs
+++ b/MetaMorpheus/EngineLayer/PrecursorSearchModes/MostAbundantDotMassDiffAcceptor.cs
@@ -49,12 +49,17 @@ namespace EngineLayer
             NumNotches = SortedMassShifts.Length;
         }
 
+        // The averagine most-abundant offset for a monoisotopic mass: the model's diff-to-monoisotopic
+        // at the nearest mass bin. (Composes the existing AverageResidue API.)
+        private double ApexOffset(double monoisotopicMass)
+            => Averagine.GetDiffToMonoisotopic(Averagine.GetMostIntenseMassIndex(monoisotopicMass));
+
         public override int Accepts(double scanPrecursorMass, double peptideMass)
         {
             for (int j = 0; j < SortedMassShifts.Length; j++)
             {
                 double shiftedMono = peptideMass + SortedMassShifts[j];
-                double apex = shiftedMono + Averagine.GetMostAbundantOffset(shiftedMono);
+                double apex = shiftedMono + ApexOffset(shiftedMono);
                 foreach (int k in ApexOffsetsInNeutrons)
                 {
                     if (Tolerance.Within(scanPrecursorMass, apex + k * Constants.C13MinusC12))
@@ -71,7 +76,7 @@ namespace EngineLayer
             for (int j = 0; j < SortedMassShifts.Length; j++)
             {
                 double shiftedMono = peptideMonoisotopicMass + SortedMassShifts[j];
-                double apex = shiftedMono + Averagine.GetMostAbundantOffset(shiftedMono);
+                double apex = shiftedMono + ApexOffset(shiftedMono);
                 foreach (int k in ApexOffsetsInNeutrons)
                 {
                     double mass = apex + k * Constants.C13MinusC12;
@@ -84,7 +89,7 @@ namespace EngineLayer
         {
             // Indexed (ModernSearch) path; documented near-boundary caveat as in MostAbundantMassDiffAcceptor.
             // GPTMD uses the theory-driven ClassicSearch path, so this is not its primary path.
-            double monoApprox = peptideMonoisotopicMass - Averagine.GetMostAbundantOffset(peptideMonoisotopicMass);
+            double monoApprox = peptideMonoisotopicMass - ApexOffset(peptideMonoisotopicMass);
             for (int j = 0; j < SortedMassShifts.Length; j++)
             {
                 foreach (int k in ApexOffsetsInNeutrons)

--- a/MetaMorpheus/EngineLayer/PrecursorSearchModes/MostAbundantDotMassDiffAcceptor.cs
+++ b/MetaMorpheus/EngineLayer/PrecursorSearchModes/MostAbundantDotMassDiffAcceptor.cs
@@ -50,9 +50,11 @@ namespace EngineLayer
         }
 
         // The averagine most-abundant offset for a monoisotopic mass: the model's diff-to-monoisotopic
-        // at the nearest mass bin. (Composes the existing AverageResidue API.)
+        // at the nearest mass bin. (Composes the existing AverageResidue API.) Guards against a large
+        // negative shift pushing the shifted mass to/below zero (the averagine model is undefined there),
+        // in which case the shift simply won't match rather than indexing the model out of range.
         private double ApexOffset(double monoisotopicMass)
-            => Averagine.GetDiffToMonoisotopic(Averagine.GetMostIntenseMassIndex(monoisotopicMass));
+            => monoisotopicMass <= 0 ? 0 : Averagine.GetDiffToMonoisotopic(Averagine.GetMostIntenseMassIndex(monoisotopicMass));
 
         public override int Accepts(double scanPrecursorMass, double peptideMass)
         {
@@ -85,11 +87,11 @@ namespace EngineLayer
             }
         }
 
-        public override IEnumerable<AllowedIntervalWithNotch> GetAllowedPrecursorMassIntervalsFromObservedMass(double peptideMonoisotopicMass)
+        public override IEnumerable<AllowedIntervalWithNotch> GetAllowedPrecursorMassIntervalsFromObservedMass(double observedMostAbundantMass)
         {
             // Indexed (ModernSearch) path; documented near-boundary caveat as in MostAbundantMassDiffAcceptor.
             // GPTMD uses the theory-driven ClassicSearch path, so this is not its primary path.
-            double monoApprox = peptideMonoisotopicMass - ApexOffset(peptideMonoisotopicMass);
+            double monoApprox = observedMostAbundantMass - ApexOffset(observedMostAbundantMass);
             for (int j = 0; j < SortedMassShifts.Length; j++)
             {
                 foreach (int k in ApexOffsetsInNeutrons)

--- a/MetaMorpheus/EngineLayer/PrecursorSearchModes/MostAbundantMassDiffAcceptor.cs
+++ b/MetaMorpheus/EngineLayer/PrecursorSearchModes/MostAbundantMassDiffAcceptor.cs
@@ -25,8 +25,12 @@ namespace EngineLayer
     /// each match at tight ppm (and FDR controlled per-notch), this acceptor emits a small set of
     /// notches at <c>apex + k·C13</c> for k in [−<see cref="MaxApexOffsetNeutrons"/> ..
     /// +<see cref="MaxApexOffsetNeutrons"/>]. k = 0 is the confident on-apex match; nonzero k are the
-    /// apex-misprediction cases. Notch integers follow the existing DotMassDiffAcceptor convention
-    /// (round(shiftDa · NotchScalar)) so they never collide with the −1 "not accepted" sentinel.
+    /// apex-misprediction cases. Each k maps to a contiguous non-negative notch index (its 0-based
+    /// position in the apex-offset set), so notches are distinct per k, are always ≥ 0 (a negative
+    /// notch would be read as "not accepted" by a <c>notch >= 0</c> guard, e.g. in ModernSearch), and
+    /// never collide with the −1 "not accepted" sentinel. <see cref="MassDiffAcceptor.NumNotches"/> is
+    /// the count of these indices. Per-notch FDR groups PSMs by notch value, so any distinct encoding
+    /// works equally; the contiguous form is just the safe, sign-free choice.
     ///
     /// The scan-side mass is the envelope's most-abundant observed neutral mass (PrecursorMassToMatch).
     /// Isotopically unresolved species would supply an average mass and need
@@ -61,13 +65,15 @@ namespace EngineLayer
             NumNotches = ApexOffsetsInNeutrons.Length;
         }
 
-        private static int NotchFor(int k) => (int)Math.Round(k * Constants.C13MinusC12 * NotchScalar);
+        // Contiguous, non-negative notch id for an apex offset k: its position in the ordered offset
+        // set ({0, -1, 1, -2, 2}). Distinct per k, never negative, never the -1 "not accepted" sentinel.
+        private int NotchFor(int k) => Array.IndexOf(ApexOffsetsInNeutrons, k);
 
         // The averagine most-abundant offset for a monoisotopic mass: the model's diff-to-monoisotopic
         // at the nearest mass bin. (Composes the existing AverageResidue API rather than relying on a
         // dedicated mzLib method.)
         private double ApexOffset(double monoisotopicMass)
-            => Averagine.GetDiffToMonoisotopic(Averagine.GetMostIntenseMassIndex(monoisotopicMass));
+            => monoisotopicMass <= 0 ? 0 : Averagine.GetDiffToMonoisotopic(Averagine.GetMostIntenseMassIndex(monoisotopicMass));
 
         public override int Accepts(double scanPrecursorMass, double peptideMass)
         {
@@ -92,14 +98,14 @@ namespace EngineLayer
             }
         }
 
-        public override IEnumerable<AllowedIntervalWithNotch> GetAllowedPrecursorMassIntervalsFromObservedMass(double peptideMonoisotopicMass)
+        public override IEnumerable<AllowedIntervalWithNotch> GetAllowedPrecursorMassIntervalsFromObservedMass(double observedMostAbundantMass)
         {
             // Indexed (ModernSearch) path: convert the observed most-abundant mass back to candidate
             // monoisotopic windows by subtracting the offset evaluated near the observed mass, for each
             // apex-offset notch. Top-down uses the exact theory-driven ClassicSearch path; this
             // observed-side conversion carries a small near-boundary ambiguity and is only exercised by
             // indexed bottom-up search, which this mode does not target.
-            double monoApprox = peptideMonoisotopicMass - ApexOffset(peptideMonoisotopicMass);
+            double monoApprox = observedMostAbundantMass - ApexOffset(observedMostAbundantMass);
             foreach (int k in ApexOffsetsInNeutrons)
             {
                 double mass = monoApprox - k * Constants.C13MinusC12;

--- a/MetaMorpheus/EngineLayer/PrecursorSearchModes/MostAbundantMassDiffAcceptor.cs
+++ b/MetaMorpheus/EngineLayer/PrecursorSearchModes/MostAbundantMassDiffAcceptor.cs
@@ -33,9 +33,9 @@ namespace EngineLayer
     /// works equally; the contiguous form is just the safe, sign-free choice.
     ///
     /// The scan-side mass is the envelope's most-abundant observed neutral mass (PrecursorMassToMatch).
-    /// Isotopically unresolved species would supply an average mass and need
-    /// <see cref="AverageResidue.GetAverageOffset"/>; that path is deferred to v2 with the unresolved
-    /// charge-determination algorithm, so all envelopes are currently resolved.
+    /// Isotopically unresolved species would instead supply an average (centroid) mass and an
+    /// averagine average offset; that path is future work (the unresolved charge-determination
+    /// algorithm), so all envelopes here are resolved and matched on the most-abundant peak.
     /// </remarks>
     public class MostAbundantMassDiffAcceptor : MassDiffAcceptor
     {

--- a/MetaMorpheus/EngineLayer/PrecursorSearchModes/MostAbundantMassDiffAcceptor.cs
+++ b/MetaMorpheus/EngineLayer/PrecursorSearchModes/MostAbundantMassDiffAcceptor.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using Chemistry;
 using MassSpectrometry;
 using MzLibUtil;
 
@@ -13,62 +15,100 @@ namespace EngineLayer
     /// monoisotopic off-by-N errors that arise when the true monoisotopic peak is undetectable.
     ///
     /// Used when <see cref="CommonParameters.PrecursorMassMatchMode"/> is
-    /// <see cref="PrecursorMassMatchMode.MostAbundant"/>. A single notch (0) is returned: this
-    /// acceptor replaces the missed-monoisotopic notches, which exist precisely to paper over the
-    /// off-by-N problem this mode solves directly.
+    /// <see cref="PrecursorMassMatchMode.MostAbundant"/>.
     /// </summary>
     /// <remarks>
-    /// The scan-side mass supplied to <see cref="Accepts"/> /
-    /// <see cref="GetAllowedPrecursorMassIntervalsFromObservedMass"/> is expected to be the envelope's
-    /// most-abundant observed neutral mass (set on the scan as PrecursorMassToMatch). Isotopically
-    /// unresolved species would instead supply an average mass and require
-    /// <see cref="AverageResidue.GetAverageOffset"/>; that path is deferred to v2 along with the
-    /// unresolved charge-determination algorithm, so all envelopes are currently resolved.
+    /// The averagine offset predicts which isotopologue is tallest, but for real proteoforms the
+    /// experimental apex can differ from the averagine prediction by ±1–2 neutrons (validated on
+    /// yeast top-down data: a single tight-ppm point at the predicted apex under-identifies badly,
+    /// because one neutron is ~67 ppm at 15 kDa). To tolerate that apex misprediction while keeping
+    /// each match at tight ppm (and FDR controlled per-notch), this acceptor emits a small set of
+    /// notches at <c>apex + k·C13</c> for k in [−<see cref="MaxApexOffsetNeutrons"/> ..
+    /// +<see cref="MaxApexOffsetNeutrons"/>]. k = 0 is the confident on-apex match; nonzero k are the
+    /// apex-misprediction cases. Notch integers follow the existing DotMassDiffAcceptor convention
+    /// (round(shiftDa · NotchScalar)) so they never collide with the −1 "not accepted" sentinel.
+    ///
+    /// The scan-side mass is the envelope's most-abundant observed neutral mass (PrecursorMassToMatch).
+    /// Isotopically unresolved species would supply an average mass and need
+    /// <see cref="AverageResidue.GetAverageOffset"/>; that path is deferred to v2 with the unresolved
+    /// charge-determination algorithm, so all envelopes are currently resolved.
     /// </remarks>
     public class MostAbundantMassDiffAcceptor : MassDiffAcceptor
     {
         private readonly Tolerance Tolerance;
         private readonly AverageResidue Averagine;
 
-        public MostAbundantMassDiffAcceptor(string fileNameAddition, Tolerance tol, AverageResidue averagine)
+        /// <summary>Maximum apex misprediction, in neutrons, tolerated on either side of the averagine-predicted apex.</summary>
+        public int MaxApexOffsetNeutrons { get; }
+
+        // k values ordered by ascending |k| (then sign) so the on-apex (k = 0) match is preferred.
+        private readonly int[] ApexOffsetsInNeutrons;
+
+        public MostAbundantMassDiffAcceptor(string fileNameAddition, Tolerance tol, AverageResidue averagine, int maxApexOffsetNeutrons = 2)
             : base(fileNameAddition)
         {
             Tolerance = tol;
             Averagine = averagine;
-            NumNotches = 1;
+            MaxApexOffsetNeutrons = maxApexOffsetNeutrons;
+
+            var offsets = new List<int> { 0 };
+            for (int k = 1; k <= maxApexOffsetNeutrons; k++)
+            {
+                offsets.Add(-k);
+                offsets.Add(k);
+            }
+            ApexOffsetsInNeutrons = offsets.ToArray();
+            NumNotches = ApexOffsetsInNeutrons.Length;
         }
+
+        private static int NotchFor(int k) => (int)Math.Round(k * Constants.C13MinusC12 * NotchScalar);
 
         public override int Accepts(double scanPrecursorMass, double peptideMass)
         {
-            double theoreticalMostAbundantMass = peptideMass + Averagine.GetMostAbundantOffset(peptideMass);
-            return Tolerance.Within(scanPrecursorMass, theoreticalMostAbundantMass) ? 0 : -1;
+            double apex = peptideMass + Averagine.GetMostAbundantOffset(peptideMass);
+            foreach (int k in ApexOffsetsInNeutrons) // ordered to prefer k = 0
+            {
+                if (Tolerance.Within(scanPrecursorMass, apex + k * Constants.C13MinusC12))
+                {
+                    return NotchFor(k);
+                }
+            }
+            return -1;
         }
 
         public override IEnumerable<AllowedIntervalWithNotch> GetAllowedPrecursorMassIntervalsFromTheoreticalMass(double peptideMonoisotopicMass)
         {
-            double mass = peptideMonoisotopicMass + Averagine.GetMostAbundantOffset(peptideMonoisotopicMass);
-            yield return new AllowedIntervalWithNotch(Tolerance.GetMinimumValue(mass), Tolerance.GetMaximumValue(mass), 0);
+            double apex = peptideMonoisotopicMass + Averagine.GetMostAbundantOffset(peptideMonoisotopicMass);
+            foreach (int k in ApexOffsetsInNeutrons)
+            {
+                double mass = apex + k * Constants.C13MinusC12;
+                yield return new AllowedIntervalWithNotch(Tolerance.GetMinimumValue(mass), Tolerance.GetMaximumValue(mass), NotchFor(k));
+            }
         }
 
         public override IEnumerable<AllowedIntervalWithNotch> GetAllowedPrecursorMassIntervalsFromObservedMass(double peptideMonoisotopicMass)
         {
-            // Indexed (ModernSearch) path: convert the observed most-abundant mass back to a candidate
-            // monoisotopic window by subtracting the offset evaluated near the observed mass. Top-down
-            // uses the theory-driven ClassicSearch path (GetAllowed...FromTheoreticalMass), which is
-            // exact; this observed-side conversion carries a small near-boundary ambiguity and is only
-            // exercised by indexed bottom-up search, which this mode does not target.
-            double mass = peptideMonoisotopicMass - Averagine.GetMostAbundantOffset(peptideMonoisotopicMass);
-            yield return new AllowedIntervalWithNotch(Tolerance.GetMinimumValue(mass), Tolerance.GetMaximumValue(mass), 0);
+            // Indexed (ModernSearch) path: convert the observed most-abundant mass back to candidate
+            // monoisotopic windows by subtracting the offset evaluated near the observed mass, for each
+            // apex-offset notch. Top-down uses the exact theory-driven ClassicSearch path; this
+            // observed-side conversion carries a small near-boundary ambiguity and is only exercised by
+            // indexed bottom-up search, which this mode does not target.
+            double monoApprox = peptideMonoisotopicMass - Averagine.GetMostAbundantOffset(peptideMonoisotopicMass);
+            foreach (int k in ApexOffsetsInNeutrons)
+            {
+                double mass = monoApprox - k * Constants.C13MinusC12;
+                yield return new AllowedIntervalWithNotch(Tolerance.GetMinimumValue(mass), Tolerance.GetMaximumValue(mass), NotchFor(k));
+            }
         }
 
         public override string ToString()
         {
-            return FileNameAddition + " mostAbundant " + Tolerance;
+            return FileNameAddition + " mostAbundant ±" + MaxApexOffsetNeutrons + " apex " + Tolerance;
         }
 
         public override string ToProseString()
         {
-            return Tolerance + " around the most abundant isotopic peak";
+            return Tolerance + " around the most abundant isotopic peak (±" + MaxApexOffsetNeutrons + " isotope apex tolerance)";
         }
     }
 }

--- a/MetaMorpheus/EngineLayer/PrecursorSearchModes/MostAbundantMassDiffAcceptor.cs
+++ b/MetaMorpheus/EngineLayer/PrecursorSearchModes/MostAbundantMassDiffAcceptor.cs
@@ -63,9 +63,15 @@ namespace EngineLayer
 
         private static int NotchFor(int k) => (int)Math.Round(k * Constants.C13MinusC12 * NotchScalar);
 
+        // The averagine most-abundant offset for a monoisotopic mass: the model's diff-to-monoisotopic
+        // at the nearest mass bin. (Composes the existing AverageResidue API rather than relying on a
+        // dedicated mzLib method.)
+        private double ApexOffset(double monoisotopicMass)
+            => Averagine.GetDiffToMonoisotopic(Averagine.GetMostIntenseMassIndex(monoisotopicMass));
+
         public override int Accepts(double scanPrecursorMass, double peptideMass)
         {
-            double apex = peptideMass + Averagine.GetMostAbundantOffset(peptideMass);
+            double apex = peptideMass + ApexOffset(peptideMass);
             foreach (int k in ApexOffsetsInNeutrons) // ordered to prefer k = 0
             {
                 if (Tolerance.Within(scanPrecursorMass, apex + k * Constants.C13MinusC12))
@@ -78,7 +84,7 @@ namespace EngineLayer
 
         public override IEnumerable<AllowedIntervalWithNotch> GetAllowedPrecursorMassIntervalsFromTheoreticalMass(double peptideMonoisotopicMass)
         {
-            double apex = peptideMonoisotopicMass + Averagine.GetMostAbundantOffset(peptideMonoisotopicMass);
+            double apex = peptideMonoisotopicMass + ApexOffset(peptideMonoisotopicMass);
             foreach (int k in ApexOffsetsInNeutrons)
             {
                 double mass = apex + k * Constants.C13MinusC12;
@@ -93,7 +99,7 @@ namespace EngineLayer
             // apex-offset notch. Top-down uses the exact theory-driven ClassicSearch path; this
             // observed-side conversion carries a small near-boundary ambiguity and is only exercised by
             // indexed bottom-up search, which this mode does not target.
-            double monoApprox = peptideMonoisotopicMass - Averagine.GetMostAbundantOffset(peptideMonoisotopicMass);
+            double monoApprox = peptideMonoisotopicMass - ApexOffset(peptideMonoisotopicMass);
             foreach (int k in ApexOffsetsInNeutrons)
             {
                 double mass = monoApprox - k * Constants.C13MinusC12;

--- a/MetaMorpheus/EngineLayer/PrecursorSearchModes/MostAbundantMassDiffAcceptor.cs
+++ b/MetaMorpheus/EngineLayer/PrecursorSearchModes/MostAbundantMassDiffAcceptor.cs
@@ -1,0 +1,74 @@
+using System.Collections.Generic;
+using MassSpectrometry;
+using MzLibUtil;
+
+namespace EngineLayer
+{
+    /// <summary>
+    /// Selects theoretical candidates by matching the observed most-abundant isotopic peak mass
+    /// against each candidate's theoretical most-abundant mass (Strategy B). The theoretical
+    /// most-abundant mass is the candidate's exact monoisotopic mass plus an averagine-derived,
+    /// mass-dependent offset (roughly an integer number of neutrons). Because the same physical
+    /// (most-abundant) peak is compared on both the observed and theoretical sides, this avoids the
+    /// monoisotopic off-by-N errors that arise when the true monoisotopic peak is undetectable.
+    ///
+    /// Used when <see cref="CommonParameters.PrecursorMassMatchMode"/> is
+    /// <see cref="PrecursorMassMatchMode.MostAbundant"/>. A single notch (0) is returned: this
+    /// acceptor replaces the missed-monoisotopic notches, which exist precisely to paper over the
+    /// off-by-N problem this mode solves directly.
+    /// </summary>
+    /// <remarks>
+    /// The scan-side mass supplied to <see cref="Accepts"/> /
+    /// <see cref="GetAllowedPrecursorMassIntervalsFromObservedMass"/> is expected to be the envelope's
+    /// most-abundant observed neutral mass (set on the scan as PrecursorMassToMatch). Isotopically
+    /// unresolved species would instead supply an average mass and require
+    /// <see cref="AverageResidue.GetAverageOffset"/>; that path is deferred to v2 along with the
+    /// unresolved charge-determination algorithm, so all envelopes are currently resolved.
+    /// </remarks>
+    public class MostAbundantMassDiffAcceptor : MassDiffAcceptor
+    {
+        private readonly Tolerance Tolerance;
+        private readonly AverageResidue Averagine;
+
+        public MostAbundantMassDiffAcceptor(string fileNameAddition, Tolerance tol, AverageResidue averagine)
+            : base(fileNameAddition)
+        {
+            Tolerance = tol;
+            Averagine = averagine;
+            NumNotches = 1;
+        }
+
+        public override int Accepts(double scanPrecursorMass, double peptideMass)
+        {
+            double theoreticalMostAbundantMass = peptideMass + Averagine.GetMostAbundantOffset(peptideMass);
+            return Tolerance.Within(scanPrecursorMass, theoreticalMostAbundantMass) ? 0 : -1;
+        }
+
+        public override IEnumerable<AllowedIntervalWithNotch> GetAllowedPrecursorMassIntervalsFromTheoreticalMass(double peptideMonoisotopicMass)
+        {
+            double mass = peptideMonoisotopicMass + Averagine.GetMostAbundantOffset(peptideMonoisotopicMass);
+            yield return new AllowedIntervalWithNotch(Tolerance.GetMinimumValue(mass), Tolerance.GetMaximumValue(mass), 0);
+        }
+
+        public override IEnumerable<AllowedIntervalWithNotch> GetAllowedPrecursorMassIntervalsFromObservedMass(double peptideMonoisotopicMass)
+        {
+            // Indexed (ModernSearch) path: convert the observed most-abundant mass back to a candidate
+            // monoisotopic window by subtracting the offset evaluated near the observed mass. Top-down
+            // uses the theory-driven ClassicSearch path (GetAllowed...FromTheoreticalMass), which is
+            // exact; this observed-side conversion carries a small near-boundary ambiguity and is only
+            // exercised by indexed bottom-up search, which this mode does not target.
+            double mass = peptideMonoisotopicMass - Averagine.GetMostAbundantOffset(peptideMonoisotopicMass);
+            yield return new AllowedIntervalWithNotch(Tolerance.GetMinimumValue(mass), Tolerance.GetMaximumValue(mass), 0);
+        }
+
+        public override string ToString()
+        {
+            return FileNameAddition + " mostAbundant " + Tolerance;
+        }
+
+        public override string ToProseString()
+        {
+            return Tolerance + " around the most abundant isotopic peak";
+        }
+    }
+}

--- a/MetaMorpheus/EngineLayer/PrecursorSearchModes/PrecursorMassMatchMode.cs
+++ b/MetaMorpheus/EngineLayer/PrecursorSearchModes/PrecursorMassMatchMode.cs
@@ -1,0 +1,21 @@
+namespace EngineLayer
+{
+    /// <summary>
+    /// Selects which precursor mass is used to choose theoretical proteoform candidates during search.
+    /// </summary>
+    public enum PrecursorMassMatchMode
+    {
+        /// <summary>
+        /// Match candidates by the monoisotopic precursor mass (the historical default). For high-mass
+        /// proteoforms the monoisotopic peak is often undetectable, which can produce off-by-N errors.
+        /// </summary>
+        Monoisotopic,
+
+        /// <summary>
+        /// Match candidates by the most abundant observed isotopic peak (or, for isotopically
+        /// unresolved high-mass species, the centroid/average mass). This is the experimentally most
+        /// detectable peak in each charge envelope and avoids monoisotopic off-by-N errors.
+        /// </summary>
+        MostAbundant
+    }
+}

--- a/MetaMorpheus/GUI/GUI.csproj
+++ b/MetaMorpheus/GUI/GUI.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>

--- a/MetaMorpheus/GUI/GUI.csproj
+++ b/MetaMorpheus/GUI/GUI.csproj
@@ -63,7 +63,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="9.9.25" />
+    <PackageReference Include="mzLib" Version="9.9.26" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0" />

--- a/MetaMorpheus/GUI/GUI.csproj
+++ b/MetaMorpheus/GUI/GUI.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -63,7 +63,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.579" />
+    <PackageReference Include="mzLib" Version="9.9.25" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0" />

--- a/MetaMorpheus/GUI/TaskWindows/GPTMDTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/GPTMDTaskWindow.xaml.cs
@@ -210,7 +210,8 @@ namespace MetaMorpheusGUI
 
             foreach (var filter in FilterOptions)
             {
-                filter.IsSelected = TheTask.GptmdParameters.GptmdFilters.Any(f => f.GetType() == filter.Filter.GetType());
+                filter.IsSelected = TheTask.GptmdParameters.GptmdFilters.Any(f => f.GetType() == filter.Filter.GetType())
+                    || (TheTask.GptmdParameters.GptmdFilterTypes?.Contains(filter.Filter.GetType().Name) ?? false);
             }
         }
 
@@ -584,6 +585,8 @@ namespace MetaMorpheusGUI
                 TheTask.GptmdParameters.ListOfModsGptmd.AddRange(heh.Children.Where(b => b.Use).Select(b => (b.Parent.DisplayName, b.ModName)));
             }
             TheTask.GptmdParameters.GptmdFilters = FilterOptions.Where(f => f.IsSelected).Select(f => f.Filter).ToList();
+            // Also persist the selection in toml-serializable form so it survives a save/load round-trip and CMD runs.
+            TheTask.GptmdParameters.GptmdFilterTypes = FilterOptions.Where(f => f.IsSelected).Select(f => f.Filter.GetType().Name).ToList();
             TheTask.GptmdParameters.WriteDecoys = WriteDecoysCheckBox.IsChecked.Value;
             TheTask.CommonParameters = commonParamsToSave;
 

--- a/MetaMorpheus/GUI/TaskWindows/GPTMDTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/GPTMDTaskWindow.xaml.cs
@@ -210,7 +210,7 @@ namespace MetaMorpheusGUI
 
             foreach (var filter in FilterOptions)
             {
-                filter.IsSelected = TheTask.GptmdParameters.GptmdFilters.Any(f => f.GetType() == filter.Filter.GetType())
+                filter.IsSelected = (TheTask.GptmdParameters.GptmdFilters?.Any(f => f.GetType() == filter.Filter.GetType()) ?? false)
                     || (TheTask.GptmdParameters.GptmdFilterTypes?.Contains(filter.Filter.GetType().Name) ?? false);
             }
         }

--- a/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
+++ b/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>

--- a/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
+++ b/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="itext7" Version="8.0.5" />
     <PackageReference Include="itext7.bouncy-castle-adapter" Version="8.0.5" />
-    <PackageReference Include="mzLib" Version="9.9.25" />
+    <PackageReference Include="mzLib" Version="9.9.26" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.0.0" />
     <PackageReference Include="Svg" Version="3.4.7" />
   </ItemGroup>

--- a/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
+++ b/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="itext7" Version="8.0.5" />
     <PackageReference Include="itext7.bouncy-castle-adapter" Version="8.0.5" />
-    <PackageReference Include="mzLib" Version="1.0.579" />
+    <PackageReference Include="mzLib" Version="9.9.25" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.0.0" />
     <PackageReference Include="Svg" Version="3.4.7" />
   </ItemGroup>

--- a/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationTask.cs
+++ b/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationTask.cs
@@ -198,8 +198,15 @@ namespace TaskLayer
             // consistent with the scan's most-abundant PrecursorMassToMatch. The calibration error
             // itself is recomputed per-isotope from the identified peptide's theoretical distribution
             // (DataPointAcquisitionEngine) and is independent of the precursor-matching convention.
+            // The apex acceptor only works when PrecursorMassToMatch is the deconvoluted most-abundant
+            // mass. Calibration runs with precursor deconvolution off (see ctor), in which case
+            // PrecursorMassToMatch falls back to the monoisotopic mass; matching that against the
+            // averagine apex would mismatch by the full offset (hundreds of ppm at high mass) and find
+            // almost nothing. So only use the apex acceptor when deconvolution is actually on; otherwise
+            // fall back to the standard zero-centered (monoisotopic) acceptor.
             MassDiffAcceptor searchMode;
-            if (combinedParameters.PrecursorMassMatchMode == PrecursorMassMatchMode.MostAbundant)
+            if (combinedParameters.PrecursorMassMatchMode == PrecursorMassMatchMode.MostAbundant
+                && combinedParameters.DoPrecursorDeconvolution)
             {
                 searchMode = new MostAbundantMassDiffAcceptor("mostAbundant", combinedParameters.PrecursorMassTolerance,
                     combinedParameters.PrecursorDeconvolutionParameters?.AverageResidueModel ?? new Averagine());
@@ -420,11 +427,16 @@ namespace TaskLayer
             double newPrecursorPpmTolerance = Math.Round(PrecursorMultiplierForToml * acquisitionResults.PsmPrecursorIqrPpmError + Math.Abs(acquisitionResults.PsmPrecursorMedianPpmError), 1);
             double newProductPpmTolerance = Math.Round(ProductMultiplierForToml * acquisitionResults.PsmProductIqrPpmError + Math.Abs(acquisitionResults.PsmProductMedianPpmError), 1);
 
-            // Guardrail: calibration should tighten tolerances, not widen them. A pathological error
-            // distribution must never write a tolerance wider than the one we searched with, which would
-            // explode the candidate space (and memory) in downstream GPTMD/Search.
-            newPrecursorPpmTolerance = Math.Min(newPrecursorPpmTolerance, combinedParams.PrecursorMassTolerance.Value);
-            newProductPpmTolerance = Math.Min(newProductPpmTolerance, combinedParams.ProductMassTolerance.Value);
+            // Guardrail (most-abundant mode only): the neutron-misassignment error distribution can be
+            // pathologically wide there, and calibration must never write a tolerance wider than the one
+            // it searched with (that would explode the candidate space and memory in downstream
+            // GPTMD/Search). In default Monoisotopic mode the tolerance is left unclamped, preserving the
+            // historical multi-round calibration behavior.
+            if (combinedParams.PrecursorMassMatchMode == PrecursorMassMatchMode.MostAbundant)
+            {
+                newPrecursorPpmTolerance = Math.Min(newPrecursorPpmTolerance, combinedParams.PrecursorMassTolerance.Value);
+                newProductPpmTolerance = Math.Min(newProductPpmTolerance, combinedParams.ProductMassTolerance.Value);
+            }
 
             UpdateCombinedParameters(combinedParams, newPrecursorPpmTolerance, newProductPpmTolerance);
         }

--- a/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationTask.cs
+++ b/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationTask.cs
@@ -419,6 +419,13 @@ namespace TaskLayer
         {
             double newPrecursorPpmTolerance = Math.Round(PrecursorMultiplierForToml * acquisitionResults.PsmPrecursorIqrPpmError + Math.Abs(acquisitionResults.PsmPrecursorMedianPpmError), 1);
             double newProductPpmTolerance = Math.Round(ProductMultiplierForToml * acquisitionResults.PsmProductIqrPpmError + Math.Abs(acquisitionResults.PsmProductMedianPpmError), 1);
+
+            // Guardrail: calibration should tighten tolerances, not widen them. A pathological error
+            // distribution must never write a tolerance wider than the one we searched with, which would
+            // explode the candidate space (and memory) in downstream GPTMD/Search.
+            newPrecursorPpmTolerance = Math.Min(newPrecursorPpmTolerance, combinedParams.PrecursorMassTolerance.Value);
+            newProductPpmTolerance = Math.Min(newProductPpmTolerance, combinedParams.ProductMassTolerance.Value);
+
             UpdateCombinedParameters(combinedParams, newPrecursorPpmTolerance, newProductPpmTolerance);
         }
 

--- a/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationTask.cs
+++ b/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationTask.cs
@@ -194,11 +194,24 @@ namespace TaskLayer
         private DataPointAquisitionResults GetDataAcquisitionResults(MsDataFile myMsDataFile, CommonParameters combinedParameters, string originalDataFile)
         {
             string fileNameWithoutExtension = Path.GetFileNameWithoutExtension(originalDataFile);
-            MassDiffAcceptor searchMode = combinedParameters.PrecursorMassTolerance is PpmTolerance ?
-                new SinglePpmAroundZeroSearchMode(combinedParameters.PrecursorMassTolerance.Value) :
-                new SingleAbsoluteAroundZeroSearchMode(combinedParameters.PrecursorMassTolerance.Value);
+            // In most-abundant mode, find calibration PSMs with the apex acceptor so the search is
+            // consistent with the scan's most-abundant PrecursorMassToMatch. The calibration error
+            // itself is recomputed per-isotope from the identified peptide's theoretical distribution
+            // (DataPointAcquisitionEngine) and is independent of the precursor-matching convention.
+            MassDiffAcceptor searchMode;
+            if (combinedParameters.PrecursorMassMatchMode == PrecursorMassMatchMode.MostAbundant)
+            {
+                searchMode = new MostAbundantMassDiffAcceptor("mostAbundant", combinedParameters.PrecursorMassTolerance,
+                    combinedParameters.PrecursorDeconvolutionParameters?.AverageResidueModel ?? new Averagine());
+            }
+            else
+            {
+                searchMode = combinedParameters.PrecursorMassTolerance is PpmTolerance ?
+                    new SinglePpmAroundZeroSearchMode(combinedParameters.PrecursorMassTolerance.Value) :
+                    new SingleAbsoluteAroundZeroSearchMode(combinedParameters.PrecursorMassTolerance.Value);
+            }
 
-            Ms2ScanWithSpecificMass[] listOfSortedms2Scans = GetMs2Scans(myMsDataFile, originalDataFile, combinedParameters).OrderBy(b => b.PrecursorMass).ToArray();
+            Ms2ScanWithSpecificMass[] listOfSortedms2Scans = GetMs2Scans(myMsDataFile, originalDataFile, combinedParameters).OrderBy(b => b.PrecursorMassToMatch).ToArray();
             SpectralMatch[] allPsmsArray = new SpectralMatch[listOfSortedms2Scans.Length];
 
             Log("Searching with searchMode: " + searchMode, new List<string> { _taskId, "Individual Spectra Files", fileNameWithoutExtension });

--- a/MetaMorpheus/TaskLayer/GPTMDTask/GPTMDParameters.cs
+++ b/MetaMorpheus/TaskLayer/GPTMDTask/GPTMDParameters.cs
@@ -1,6 +1,7 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using EngineLayer.Gptmd;
+using Nett;
 
 namespace EngineLayer
 {
@@ -12,16 +13,60 @@ namespace EngineLayer
         public GptmdParameters()
         {
             GptmdFilters = new();
+            GptmdFilterTypes = new();
             ListOfModsGptmd = GlobalVariables.AllModsKnown.Where(b =>
                 b.ModificationType.Equals("Common Artifact")
                 || b.ModificationType.Equals("Common Biological")
-                || b.ModificationType.Equals("Metal") 
+                || b.ModificationType.Equals("Metal")
                 //|| b.ModificationType.Equals("Less Common")
             ).Select(b => (b.ModificationType, b.IdWithMotif)).ToList();
         }
 
         public List<(string, string)> ListOfModsGptmd { get; set; }
-        public List<IGptmdFilter> GptmdFilters { get; set; } 
+
+        /// <summary>
+        /// Runtime list of G-PTM-D acceptance filters (e.g. <see cref="ImprovedScoreFilter"/>). This is a
+        /// list of interface instances and cannot round-trip through the task toml; the toml-serializable
+        /// representation is <see cref="GptmdFilterTypes"/>. The GUI sets this directly for in-memory runs.
+        /// Use <see cref="GetActiveFilters"/> to obtain the effective set (this list plus any named in the toml).
+        /// </summary>
+        [TomlIgnore]
+        public List<IGptmdFilter> GptmdFilters { get; set; }
+
+        /// <summary>
+        /// Toml-serializable filter selection by type name (e.g. "ImprovedScoreFilter"). Lets headless/CMD
+        /// runs enable G-PTM-D acceptance filters that previously could only be set in the GUI. A common
+        /// choice is "ImprovedScoreFilter", which only adds a modification when it improves the match score
+        /// (greatly reducing the number of modifications added).
+        /// </summary>
+        public List<string> GptmdFilterTypes { get; set; }
+
         public bool WriteDecoys { get; set; } = true;
+
+        /// <summary>
+        /// The effective filter set: the in-memory <see cref="GptmdFilters"/> plus any filters named in
+        /// <see cref="GptmdFilterTypes"/> (deduplicated by type). Unknown names are ignored.
+        /// </summary>
+        public List<IGptmdFilter> GetActiveFilters()
+        {
+            var active = new List<IGptmdFilter>(GptmdFilters ?? new List<IGptmdFilter>());
+            foreach (var name in GptmdFilterTypes ?? new List<string>())
+            {
+                var filter = CreateFilter(name);
+                if (filter != null && active.All(f => f.GetType() != filter.GetType()))
+                    active.Add(filter);
+            }
+            return active;
+        }
+
+        /// <summary>Creates a filter instance from its type name; returns null for an unrecognized name.</summary>
+        public static IGptmdFilter CreateFilter(string typeName) => typeName switch
+        {
+            nameof(ImprovedScoreFilter) => new ImprovedScoreFilter(),
+            nameof(DualDirectionalIonCoverageFilter) => new DualDirectionalIonCoverageFilter(),
+            nameof(UniDirectionalIonCoverageFilter) => new UniDirectionalIonCoverageFilter(),
+            nameof(FlankingIonCoverageFilter) => new FlankingIonCoverageFilter(),
+            _ => null
+        };
     }
 }

--- a/MetaMorpheus/TaskLayer/GPTMDTask/GPTMDTask.cs
+++ b/MetaMorpheus/TaskLayer/GPTMDTask/GPTMDTask.cs
@@ -80,7 +80,9 @@ namespace TaskLayer
 
             // temporary search type for writing prose
             // the actual search type is technically file-specific but we don't allow file-specific notches, so it's safe to do this
-            MassDiffAcceptor tempSearchMode = new DotMassDiffAcceptor("", GetAcceptableMassShifts(fixedModifications, variableModifications, gptmdModifications, combos), CommonParameters.PrecursorMassTolerance);
+            MassDiffAcceptor tempSearchMode = CommonParameters.PrecursorMassMatchMode == PrecursorMassMatchMode.MostAbundant
+                ? new MostAbundantDotMassDiffAcceptor("", GetAcceptableMassShifts(fixedModifications, variableModifications, gptmdModifications, combos), CommonParameters.PrecursorMassTolerance, CommonParameters.PrecursorDeconvolutionParameters?.AverageResidueModel ?? new Averagine())
+                : new DotMassDiffAcceptor("", GetAcceptableMassShifts(fixedModifications, variableModifications, gptmdModifications, combos), CommonParameters.PrecursorMassTolerance);
             ProseCreatedWhileRunning.Append("precursor mass tolerance(s) = {" + tempSearchMode.ToProseString() + "}; ");
 
             ProseCreatedWhileRunning.Append("product mass tolerance = " + CommonParameters.ProductMassTolerance + ". ");
@@ -113,7 +115,9 @@ namespace TaskLayer
                 StartingDataFile(origDataFile, new List<string> { taskId, "Individual Spectra Files", origDataFile });
 
                 CommonParameters combinedParams = SetAllFileSpecificCommonParams(CommonParameters, fileSettingsList[spectraFileIndex]);
-                MassDiffAcceptor searchMode = new DotMassDiffAcceptor("", GetAcceptableMassShifts(fixedModifications, variableModifications, gptmdModifications, combos), combinedParams.PrecursorMassTolerance);
+                MassDiffAcceptor searchMode = combinedParams.PrecursorMassMatchMode == PrecursorMassMatchMode.MostAbundant
+                    ? new MostAbundantDotMassDiffAcceptor("", GetAcceptableMassShifts(fixedModifications, variableModifications, gptmdModifications, combos), combinedParams.PrecursorMassTolerance, combinedParams.PrecursorDeconvolutionParameters?.AverageResidueModel ?? new Averagine())
+                    : new DotMassDiffAcceptor("", GetAcceptableMassShifts(fixedModifications, variableModifications, gptmdModifications, combos), combinedParams.PrecursorMassTolerance);
 
                 NewCollection(Path.GetFileName(origDataFile), new List<string> { taskId, "Individual Spectra Files", origDataFile });
 
@@ -130,7 +134,7 @@ namespace TaskLayer
                     nextFileLoadingTask.Start();
                 }
                 Status("Getting ms2 scans...", new List<string> { taskId, "Individual Spectra Files", origDataFile });
-                Ms2ScanWithSpecificMass[] arrayOfMs2ScansSortedByMass = GetMs2Scans(myMsDataFile, origDataFile, combinedParams).OrderBy(b => b.PrecursorMass).ToArray();
+                Ms2ScanWithSpecificMass[] arrayOfMs2ScansSortedByMass = GetMs2Scans(myMsDataFile, origDataFile, combinedParams).OrderBy(b => b.PrecursorMassToMatch).ToArray();
                 myFileManager.DoneWithFile(origDataFile);
                 SpectralMatch[] psmArray = new SpectralMatch[arrayOfMs2ScansSortedByMass.Length];
 

--- a/MetaMorpheus/TaskLayer/GPTMDTask/GPTMDTask.cs
+++ b/MetaMorpheus/TaskLayer/GPTMDTask/GPTMDTask.cs
@@ -177,7 +177,7 @@ namespace TaskLayer
             // GPTMD doesn't work as well if you do FDR on a file-by-file basis. Presumably this is because it takes multiple files to get enough PSMs for all the different notches
             new FdrAnalysisEngine(allPsms, tempSearchMode.NumNotches, CommonParameters, this.FileSpecificParameters, new List<string> { taskId }, doPEP: false).Run();
             Dictionary<string, HashSet<Tuple<int, Modification>>> allModDictionary = new();
-            new GptmdEngine(allPsms, gptmdModifications, combos, filePathToPrecursorMassTolerance, CommonParameters, this.FileSpecificParameters, new List<string> { taskId }, allModDictionary, GptmdParameters.GptmdFilters).Run();
+            new GptmdEngine(allPsms, gptmdModifications, combos, filePathToPrecursorMassTolerance, CommonParameters, this.FileSpecificParameters, new List<string> { taskId }, allModDictionary, GptmdParameters.GetActiveFilters()).Run();
 
             //Move this text after search because proteins don't get loaded until search begins.
             ProseCreatedWhileRunning.Append("The combined search database contained " + proteinList.Count(p => !p.IsDecoy) + $" non-decoy {GlobalVariables.AnalyteType.GetBioPolymerLabel().ToLower()} entries including " + proteinList.Count(p => p.IsContaminant) + " contaminant sequences. ");

--- a/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
+++ b/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
@@ -338,9 +338,9 @@ namespace TaskLayer
                             double? precursorMassToMatch = null;
                             if (commonParameters.PrecursorMassMatchMode == PrecursorMassMatchMode.MostAbundant
                                 && precursor.Envelope != null
-                                && precursor.Envelope.MostAbundantObservedMass > 0)
+                                && precursor.Envelope.MostAbundantObservedNeutralMass > 0)
                             {
-                                precursorMassToMatch = precursor.Envelope.MostAbundantObservedMass;
+                                precursorMassToMatch = precursor.Envelope.MostAbundantObservedNeutralMass;
                             }
 
                             // assign precursor for this MS2 scan

--- a/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
+++ b/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
@@ -328,19 +328,24 @@ namespace TaskLayer
                         foreach (var precursor in precursorSet)
                         {
                             // In most-abundant mode, select candidates by the experimentally most-detectable
-                            // peak — the most abundant (tallest) isotopologue — rather than the
-                            // often-undetectable monoisotopic peak. Left null in monoisotopic mode, when no
-                            // deconvoluted envelope is available, or when the envelope reports no most-abundant
-                            // peak (the -1 sentinel, e.g. a neutral mass read from a pre-deconvoluted file), so
-                            // Ms2ScanWithSpecificMass defaults PrecursorMassToMatch to PrecursorMass from a
-                            // single source of truth. (Isotopically unresolved high-mass species, which would
-                            // match on the average/centroid mass, are future work.)
+                            // peak rather than the often-undetectable monoisotopic peak: the most abundant
+                            // (tallest) isotopologue for resolved envelopes, or the average/centroid mass for
+                            // isotopically unresolved (high-mass) envelopes. Left null in monoisotopic mode,
+                            // when no deconvoluted envelope is available, or when the envelope reports no
+                            // observed peak (the -1 sentinel), so Ms2ScanWithSpecificMass defaults
+                            // PrecursorMassToMatch to the monoisotopic PrecursorMass from a single source of truth.
+                            // NOTE: the unresolved branch is scaffolding — it selects the average observed mass,
+                            // but the average-vs-average acceptor and unresolved charge determination are not yet
+                            // built, so nothing sets Resolution.Unresolved in production today.
                             double? precursorMassToMatch = null;
                             if (commonParameters.PrecursorMassMatchMode == PrecursorMassMatchMode.MostAbundant
-                                && precursor.Envelope != null
-                                && precursor.Envelope.MostAbundantObservedMass > 0)
+                                && precursor.Envelope != null)
                             {
-                                precursorMassToMatch = precursor.Envelope.MostAbundantObservedMass;
+                                double selected = precursor.Envelope.Resolution == EnvelopeResolution.Unresolved
+                                    ? precursor.Envelope.AverageObservedMass
+                                    : precursor.Envelope.MostAbundantObservedMass;
+                                if (selected > 0)
+                                    precursorMassToMatch = selected;
                             }
 
                             // assign precursor for this MS2 scan

--- a/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
+++ b/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
@@ -327,10 +327,24 @@ namespace TaskLayer
 
                         foreach (var precursor in precursorSet)
                         {
+                            // In most-abundant mode, select candidates by the experimentally most-detectable
+                            // peak (most abundant isotopologue, or the centroid for unresolved high-mass species)
+                            // rather than the often-undetectable monoisotopic peak. Falls back to monoisotopic
+                            // when in monoisotopic mode or when no deconvoluted envelope is available.
+                            double precursorMassToMatch = precursor.MonoisotopicPeakMz.ToMass(precursor.Charge);
+                            if (commonParameters.PrecursorMassMatchMode == PrecursorMassMatchMode.MostAbundant
+                                && precursor.Envelope != null)
+                            {
+                                precursorMassToMatch = precursor.Envelope.Resolution == EnvelopeResolution.Unresolved
+                                    ? precursor.Envelope.AverageObservedMass
+                                    : precursor.Envelope.MostAbundantObservedMass;
+                            }
+
                             // assign precursor for this MS2 scan
                             var scan = new Ms2ScanWithSpecificMass(ms2scan, precursor.MonoisotopicPeakMz,
                                 precursor.Charge, fullFilePath, commonParameters, neutralExperimentalFragments,
-                                precursor.Intensity, precursor.EnvelopePeakCount, precursor.FractionalIntensity);
+                                precursor.Intensity, precursor.EnvelopePeakCount, precursor.FractionalIntensity,
+                                precursorMassToMatch: precursorMassToMatch);
 
                             // assign precursors for MS2 child scans
                             if (ms2ChildScans != null)
@@ -345,7 +359,8 @@ namespace TaskLayer
                                     }
                                     var theChildScan = new Ms2ScanWithSpecificMass(ms2ChildScan, precursor.MonoisotopicPeakMz,
                                         precursor.Charge, fullFilePath, commonParameters, childNeutralExperimentalFragments,
-                                        precursor.Intensity, precursor.EnvelopePeakCount, precursor.FractionalIntensity);
+                                        precursor.Intensity, precursor.EnvelopePeakCount, precursor.FractionalIntensity,
+                                        precursorMassToMatch: precursorMassToMatch);
                                     scan.ChildScans.Add(theChildScan);
                                 }
                             }
@@ -584,7 +599,8 @@ namespace TaskLayer
                 precursorDeconParams: commonParams.PrecursorDeconvolutionParameters,
                 productDeconParams: commonParams.ProductDeconvolutionParameters,
                 useMostAbundantPrecursorIntensity: commonParams.UseMostAbundantPrecursorIntensity,
-                fragmentationParams: commonParams.FragmentationParameters);
+                fragmentationParams: commonParams.FragmentationParameters,
+                precursorMassMatchMode: commonParams.PrecursorMassMatchMode);
 
             return returnParams;
         }
@@ -1579,7 +1595,7 @@ namespace TaskLayer
         }
 
         /// <summary>
-        /// Legacy TOML compatibility — when ProductMassTolerance_LowRes is omitted, the helper falls back to ProductMassTolerance to keep constant result.
+        /// Legacy TOML compatibility ï¿½ when ProductMassTolerance_LowRes is omitted, the helper falls back to ProductMassTolerance to keep constant result.
         /// </summary>
         /// <typeparam name="TTask"></typeparam>
         /// <param name="filePath"></param>

--- a/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
+++ b/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
@@ -329,9 +329,10 @@ namespace TaskLayer
                         {
                             // In most-abundant mode, select candidates by the experimentally most-detectable
                             // peak (most abundant isotopologue, or the centroid for unresolved high-mass species)
-                            // rather than the often-undetectable monoisotopic peak. Falls back to monoisotopic
-                            // when in monoisotopic mode or when no deconvoluted envelope is available.
-                            double precursorMassToMatch = precursor.MonoisotopicPeakMz.ToMass(precursor.Charge);
+                            // rather than the often-undetectable monoisotopic peak. Left null in monoisotopic
+                            // mode (or when no deconvoluted envelope is available) so Ms2ScanWithSpecificMass
+                            // defaults PrecursorMassToMatch to PrecursorMass from a single source of truth.
+                            double? precursorMassToMatch = null;
                             if (commonParameters.PrecursorMassMatchMode == PrecursorMassMatchMode.MostAbundant
                                 && precursor.Envelope != null)
                             {

--- a/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
+++ b/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
@@ -328,17 +328,19 @@ namespace TaskLayer
                         foreach (var precursor in precursorSet)
                         {
                             // In most-abundant mode, select candidates by the experimentally most-detectable
-                            // peak (most abundant isotopologue, or the centroid for unresolved high-mass species)
-                            // rather than the often-undetectable monoisotopic peak. Left null in monoisotopic
-                            // mode (or when no deconvoluted envelope is available) so Ms2ScanWithSpecificMass
-                            // defaults PrecursorMassToMatch to PrecursorMass from a single source of truth.
+                            // peak — the most abundant (tallest) isotopologue — rather than the
+                            // often-undetectable monoisotopic peak. Left null in monoisotopic mode, when no
+                            // deconvoluted envelope is available, or when the envelope reports no most-abundant
+                            // peak (the -1 sentinel, e.g. a neutral mass read from a pre-deconvoluted file), so
+                            // Ms2ScanWithSpecificMass defaults PrecursorMassToMatch to PrecursorMass from a
+                            // single source of truth. (Isotopically unresolved high-mass species, which would
+                            // match on the average/centroid mass, are future work.)
                             double? precursorMassToMatch = null;
                             if (commonParameters.PrecursorMassMatchMode == PrecursorMassMatchMode.MostAbundant
-                                && precursor.Envelope != null)
+                                && precursor.Envelope != null
+                                && precursor.Envelope.MostAbundantObservedMass > 0)
                             {
-                                precursorMassToMatch = precursor.Envelope.Resolution == EnvelopeResolution.Unresolved
-                                    ? precursor.Envelope.AverageObservedMass
-                                    : precursor.Envelope.MostAbundantObservedMass;
+                                precursorMassToMatch = precursor.Envelope.MostAbundantObservedMass;
                             }
 
                             // assign precursor for this MS2 scan

--- a/MetaMorpheus/TaskLayer/SearchTask/SearchTask.cs
+++ b/MetaMorpheus/TaskLayer/SearchTask/SearchTask.cs
@@ -36,8 +36,17 @@ namespace TaskLayer
 
         public SearchParameters SearchParameters { get; set; }
 
-        public static MassDiffAcceptor GetMassDiffAcceptor(Tolerance precursorMassTolerance, MassDiffAcceptorType massDiffAcceptorType, string customMdac)
+        public static MassDiffAcceptor GetMassDiffAcceptor(Tolerance precursorMassTolerance, MassDiffAcceptorType massDiffAcceptorType, string customMdac,
+            PrecursorMassMatchMode precursorMassMatchMode = PrecursorMassMatchMode.Monoisotopic, AverageResidue averagineModel = null)
         {
+            // Most-abundant mode matches candidates by their theoretical most-abundant isotopic peak,
+            // which directly solves the off-by-N problem. It replaces (rather than augments) the
+            // missed-monoisotopic notches, so it overrides the MassDiffAcceptorType selection.
+            if (precursorMassMatchMode == PrecursorMassMatchMode.MostAbundant)
+            {
+                return new MostAbundantMassDiffAcceptor("mostAbundant", precursorMassTolerance, averagineModel ?? new Averagine());
+            }
+
             switch (massDiffAcceptorType)
             {
                 case MassDiffAcceptorType.Exact:
@@ -216,7 +225,8 @@ namespace TaskLayer
 
                 CommonParameters combinedParams = SetAllFileSpecificCommonParams(CommonParameters, fileSettingsList[spectraFileIndex]);
 
-                MassDiffAcceptor massDiffAcceptor = GetMassDiffAcceptor(combinedParams.PrecursorMassTolerance, SearchParameters.MassDiffAcceptorType, SearchParameters.CustomMdac);
+                MassDiffAcceptor massDiffAcceptor = GetMassDiffAcceptor(combinedParams.PrecursorMassTolerance, SearchParameters.MassDiffAcceptorType, SearchParameters.CustomMdac,
+                    combinedParams.PrecursorMassMatchMode, combinedParams.PrecursorDeconvolutionParameters?.AverageResidueModel);
 
                 var thisId = new List<string> { taskId, "Individual Spectra Files", origDataFile };
                 NewCollection(Path.GetFileName(origDataFile), thisId);
@@ -252,7 +262,10 @@ namespace TaskLayer
                 }
 
                 Status("Getting ms2 scans...", thisId);
-                Ms2ScanWithSpecificMass[] arrayOfMs2ScansSortedByMass = GetMs2Scans(myMsDataFile, origDataFile, combinedParams).OrderBy(b => b.PrecursorMass).ToArray();
+                // Sort by the mass used for candidate selection (PrecursorMassToMatch), which equals
+                // PrecursorMass in monoisotopic mode. ClassicSearchEngine binary-searches this same
+                // mass, so the array and the search key must use the same quantity.
+                Ms2ScanWithSpecificMass[] arrayOfMs2ScansSortedByMass = GetMs2Scans(myMsDataFile, origDataFile, combinedParams).OrderBy(b => b.PrecursorMassToMatch).ToArray();
                 numMs2SpectraPerFile.Add(Path.GetFileNameWithoutExtension(origDataFile), new int[] { myMsDataFile.GetAllScansList().Count(p => p.MsnOrder == 2), arrayOfMs2ScansSortedByMass.Length });
                 myFileManager.DoneWithFile(origDataFile);
 

--- a/MetaMorpheus/TaskLayer/TaskLayer.csproj
+++ b/MetaMorpheus/TaskLayer/TaskLayer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>

--- a/MetaMorpheus/TaskLayer/TaskLayer.csproj
+++ b/MetaMorpheus/TaskLayer/TaskLayer.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.579" />
+    <PackageReference Include="mzLib" Version="9.9.25" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />

--- a/MetaMorpheus/TaskLayer/TaskLayer.csproj
+++ b/MetaMorpheus/TaskLayer/TaskLayer.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="9.9.25" />
+    <PackageReference Include="mzLib" Version="9.9.26" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />

--- a/MetaMorpheus/Test/CalibrationTests.cs
+++ b/MetaMorpheus/Test/CalibrationTests.cs
@@ -760,7 +760,9 @@ namespace Test
                 psms.Add(BuildPsmWithPrecursorMass(pep, precMass));
             }
 
-            var results = new DataPointAquisitionResults(null, psms, new List<LabeledDataPoint>(), new List<LabeledDataPoint>(), 0, 0, 0, 0);
+            // Neutron stripping is gated on most-abundant mode (default Monoisotopic keeps the raw error).
+            var results = new DataPointAquisitionResults(null, psms, new List<LabeledDataPoint>(), new List<LabeledDataPoint>(), 0, 0, 0, 0,
+                PrecursorMassMatchMode.MostAbundant);
 
             // With neutron offsets stripped, the spread reflects only the few-ppm drift — not the
             // tens-to-hundreds of ppm those ±1–2 neutron offsets would otherwise introduce.
@@ -785,7 +787,9 @@ namespace Test
             var psms = subNeutronDeltaDa.Select(d => BuildPsmWithPrecursorMass(pep, mono + d)).ToList();
             var results = new DataPointAquisitionResults(null, psms, new List<LabeledDataPoint>(), new List<LabeledDataPoint>(), 0, 0, 0, 0);
 
-            var cp = new CommonParameters(precursorMassTolerance: new PpmTolerance(5), productMassTolerance: new PpmTolerance(20));
+            // The clamp is gated on most-abundant mode, where the runaway-tolerance risk lives.
+            var cp = new CommonParameters(precursorMassTolerance: new PpmTolerance(5), productMassTolerance: new PpmTolerance(20),
+                precursorMassMatchMode: PrecursorMassMatchMode.MostAbundant);
             CalibrationTask.UpdateCombinedParameters(cp, results);
 
             Assert.That(cp.PrecursorMassTolerance.Value, Is.LessThanOrEqualTo(5.0));

--- a/MetaMorpheus/Test/CalibrationTests.cs
+++ b/MetaMorpheus/Test/CalibrationTests.cs
@@ -1,5 +1,10 @@
-﻿using EngineLayer;
+﻿using Chemistry;
+using EngineLayer;
+using EngineLayer.Calibration;
 using EngineLayer.DatabaseLoading;
+using Omics.Digestion;
+using Omics.Fragmentation;
+using Proteomics.ProteolyticDigestion;
 using FlashLFQ;
 using MassSpectrometry;
 using MzLibUtil;
@@ -718,6 +723,72 @@ namespace Test
                 "A warning should be emitted when non-protein entries are excluded from the search index");
             Assert.That(warnings.Any(w => w.Contains("Only protein sequences are supported by Modern Search")),
                 "Warning should indicate that Modern Search only supports protein sequences");
+        }
+
+        // ── Calibration precursor-tolerance robustness (most-abundant mode) ──────
+
+        private static SpectralMatch BuildPsmWithPrecursorMass(PeptideWithSetModifications pep, double precursorNeutralMass)
+        {
+            var spectrum = new MzSpectrum(new[] { precursorNeutralMass.ToMz(1) }, new[] { 1.0 }, false);
+            var scanData = new MsDataScan(spectrum, 1, 1, true, Polarity.Positive, 1.0, null, "", MZAnalyzerType.Orbitrap, 1.0, null, null, null);
+            var scan = new Ms2ScanWithSpecificMass(scanData, precursorNeutralMass.ToMz(1), 1, "file.raw", new CommonParameters());
+            var psm = new PeptideSpectralMatch(pep, 0, 10, 0, scan, new CommonParameters(), new List<MatchedFragmentIon>());
+            psm.ResolveAllAmbiguities();
+            return psm;
+        }
+
+        /// <summary>
+        /// Most-abundant precursor matching admits PSMs whose deconvoluted monoisotopic mass is ±1–2
+        /// neutrons from the peptide's monoisotopic mass (the apex notch set). The calibration precursor
+        /// error must strip those whole-neutron offsets so the tolerance estimate reflects the true
+        /// sub-ppm drift, not ~67–134 ppm/neutron spikes (which previously produced runaway tolerances).
+        /// </summary>
+        [Test]
+        public static void CalibrationPrecursorError_StripsNeutronOffsets()
+        {
+            var protein = new Protein("PEPTIDEKPEPTIDEKPEPTIDEK", "ACC");
+            var pep = new PeptideWithSetModifications(protein, new DigestionParams(), 1, protein.BaseSequence.Length,
+                CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0);
+            double mono = pep.MonoisotopicMass;
+
+            int[] neutronOffsets = { 0, 1, -1, 2, -2 };
+            double[] driftPpm = { 1, 2, 3, 2, 1 };
+            var psms = new List<SpectralMatch>();
+            for (int i = 0; i < neutronOffsets.Length; i++)
+            {
+                double precMass = mono * (1 + driftPpm[i] / 1e6) + neutronOffsets[i] * Constants.C13MinusC12;
+                psms.Add(BuildPsmWithPrecursorMass(pep, precMass));
+            }
+
+            var results = new DataPointAquisitionResults(null, psms, new List<LabeledDataPoint>(), new List<LabeledDataPoint>(), 0, 0, 0, 0);
+
+            // With neutron offsets stripped, the spread reflects only the few-ppm drift — not the
+            // tens-to-hundreds of ppm those ±1–2 neutron offsets would otherwise introduce.
+            Assert.That(results.PsmPrecursorIqrPpmError, Is.LessThan(5));
+            Assert.That(Math.Abs(results.PsmPrecursorMedianPpmError), Is.LessThan(5));
+        }
+
+        /// <summary>
+        /// Guardrail: calibration must never write a precursor tolerance wider than the one it searched
+        /// with, even if the error distribution is pathologically wide.
+        /// </summary>
+        [Test]
+        public static void Calibration_DoesNotWidenToleranceBeyondSearched()
+        {
+            var protein = new Protein("PEPTIDEKPEPTIDEKPEPTIDEK", "ACC");
+            var pep = new PeptideWithSetModifications(protein, new DigestionParams(), 1, protein.BaseSequence.Length,
+                CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0);
+            double mono = pep.MonoisotopicMass;
+
+            // Wide sub-neutron precursor-error spread → computed tolerance far exceeds the searched 5 ppm.
+            double[] subNeutronDeltaDa = { -0.05, -0.02, 0.02, 0.05 };
+            var psms = subNeutronDeltaDa.Select(d => BuildPsmWithPrecursorMass(pep, mono + d)).ToList();
+            var results = new DataPointAquisitionResults(null, psms, new List<LabeledDataPoint>(), new List<LabeledDataPoint>(), 0, 0, 0, 0);
+
+            var cp = new CommonParameters(precursorMassTolerance: new PpmTolerance(5), productMassTolerance: new PpmTolerance(20));
+            CalibrationTask.UpdateCombinedParameters(cp, results);
+
+            Assert.That(cp.PrecursorMassTolerance.Value, Is.LessThanOrEqualTo(5.0));
         }
 
     }

--- a/MetaMorpheus/Test/MostAbundantMassTest.cs
+++ b/MetaMorpheus/Test/MostAbundantMassTest.cs
@@ -190,5 +190,58 @@ namespace Test
             // Default stays Monoisotopic.
             Assert.That(new CommonParameters().PrecursorMassMatchMode, Is.EqualTo(PrecursorMassMatchMode.Monoisotopic));
         }
+
+        [Test]
+        public static void Acceptor_ObservedIntervals_RecoverCandidateMonoWindows()
+        {
+            // The indexed (ModernSearch) path: GetAllowedPrecursorMassIntervalsFromObservedMass converts
+            // an observed most-abundant mass back to candidate-monoisotopic windows, one per apex notch.
+            const double peptideMono = 20000.0;
+            var tol = new PpmTolerance(5);
+            var acceptor = new MostAbundantMassDiffAcceptor("mostAbundant", tol, Averagine, maxApexOffsetNeutrons: 2);
+
+            double observedApex = peptideMono + ApexOffset(peptideMono);
+            var intervals = acceptor.GetAllowedPrecursorMassIntervalsFromObservedMass(observedApex).ToList();
+            Assert.That(intervals.Count, Is.EqualTo(5));
+
+            // The on-apex window (notch 0) recovers the candidate's true monoisotopic mass.
+            var onApex = intervals.Find(i => i.Notch == 0);
+            Assert.That(onApex, Is.Not.Null);
+            Assert.That(onApex.Contains(peptideMono), Is.True);
+        }
+
+        [Test]
+        public static void DotAcceptor_Intervals_CoverShifts_AndRejectsFarCandidate()
+        {
+            const double peptideMono = 10000.0;
+            const double phospho = 79.96633;
+            var tol = new PpmTolerance(5);
+            var acc = new MostAbundantDotMassDiffAcceptor("g", new[] { 0.0, phospho }, tol, Averagine, maxApexOffsetNeutrons: 1);
+            int phosphoNotch = (int)Math.Round(phospho * MassDiffAcceptor.NotchScalar);
+
+            // 2 shifts × (2·1+1) apex offsets = 6 theoretical windows; the phospho apex is covered.
+            var theo = acc.GetAllowedPrecursorMassIntervalsFromTheoreticalMass(peptideMono).ToList();
+            Assert.That(theo.Count, Is.EqualTo(6));
+            double shiftedApex = (peptideMono + phospho) + ApexOffset(peptideMono + phospho);
+            Assert.That(theo.Exists(i => i.Notch == phosphoNotch && i.Contains(shiftedApex)), Is.True);
+
+            // The observed-side conversion recovers the unmodified candidate's mono under notch 0.
+            var obs = acc.GetAllowedPrecursorMassIntervalsFromObservedMass(peptideMono + ApexOffset(peptideMono)).ToList();
+            Assert.That(obs.Count, Is.EqualTo(6));
+            Assert.That(obs.Exists(i => i.Notch == 0 && i.Contains(peptideMono)), Is.True);
+
+            // A candidate far from every shifted apex is rejected.
+            Assert.That(acc.Accepts(peptideMono + 500.0, peptideMono), Is.EqualTo(-1));
+        }
+
+        [Test]
+        public static void GptmdParameters_CreateFilter_ResolvesEveryKnownName_NullOtherwise()
+        {
+            Assert.That(GptmdParameters.CreateFilter(nameof(ImprovedScoreFilter)), Is.TypeOf<ImprovedScoreFilter>());
+            Assert.That(GptmdParameters.CreateFilter(nameof(DualDirectionalIonCoverageFilter)), Is.TypeOf<DualDirectionalIonCoverageFilter>());
+            Assert.That(GptmdParameters.CreateFilter(nameof(UniDirectionalIonCoverageFilter)), Is.TypeOf<UniDirectionalIonCoverageFilter>());
+            Assert.That(GptmdParameters.CreateFilter(nameof(FlankingIonCoverageFilter)), Is.TypeOf<FlankingIonCoverageFilter>());
+            Assert.That(GptmdParameters.CreateFilter("not-a-filter"), Is.Null);
+        }
     }
 }

--- a/MetaMorpheus/Test/MostAbundantMassTest.cs
+++ b/MetaMorpheus/Test/MostAbundantMassTest.cs
@@ -19,7 +19,7 @@ namespace Test
         private static readonly AverageResidue Averagine = new Averagine();
 
         [Test]
-        public static void Acceptor_PinsExactMonoisotopic_AndRejectsOffByOne()
+        public static void Acceptor_OnApexCandidate_GetsNotchZero()
         {
             // A ~15 kDa proteoform: the observed precursor is the most abundant isotopic peak.
             const double peptideMono = 15000.0;
@@ -27,13 +27,32 @@ namespace Test
 
             var acceptor = new MostAbundantMassDiffAcceptor("mostAbundant", new PpmTolerance(5), Averagine);
 
-            // The correct monoisotopic candidate is accepted (notch 0)...
+            // The candidate whose predicted apex lands exactly on the observed peak is the on-apex
+            // match → notch 0.
             Assert.That(acceptor.Accepts(observedMostAbundant, peptideMono), Is.EqualTo(0));
+        }
 
-            // ...but candidates that are off by ±1 neutron in the monoisotopic mass are rejected,
-            // because their theoretical most-abundant peak no longer lines up with the observed one.
-            Assert.That(acceptor.Accepts(observedMostAbundant, peptideMono + Constants.C13MinusC12), Is.EqualTo(-1));
-            Assert.That(acceptor.Accepts(observedMostAbundant, peptideMono - Constants.C13MinusC12), Is.EqualTo(-1));
+        [Test]
+        public static void Acceptor_ToleratesApexMisprediction_WithinNotchSet_RejectsBeyond()
+        {
+            // The averagine apex can miss the experimental apex by ±1–2 neutrons; the notch set
+            // (default ±2) deliberately accepts those candidates (with a nonzero notch), while
+            // candidates beyond the window are rejected.
+            const double peptideMono = 15000.0;
+            double observedMostAbundant = peptideMono + Averagine.GetMostAbundantOffset(peptideMono);
+            var acceptor = new MostAbundantMassDiffAcceptor("mostAbundant", new PpmTolerance(5), Averagine, maxApexOffsetNeutrons: 2);
+
+            // ±1 and ±2 neutron apex offsets are accepted (nonzero notch, never the -1 sentinel)...
+            foreach (int k in new[] { -2, -1, 1, 2 })
+            {
+                int notch = acceptor.Accepts(observedMostAbundant, peptideMono - k * Constants.C13MinusC12);
+                Assert.That(notch, Is.GreaterThanOrEqualTo(0).Or.LessThan(-1), $"k={k} should be accepted with a notch != -1");
+            }
+
+            // ...but a +3 neutron offset (beyond the ±2 window) is rejected.
+            Assert.That(acceptor.Accepts(observedMostAbundant, peptideMono - 3 * Constants.C13MinusC12), Is.EqualTo(-1));
+
+            Assert.That(acceptor.NumNotches, Is.EqualTo(5));
         }
 
         [Test]
@@ -50,19 +69,26 @@ namespace Test
         }
 
         [Test]
-        public static void Acceptor_TheoreticalInterval_IsCenteredOnMostAbundantMass()
+        public static void Acceptor_TheoreticalIntervals_SpanApexPlusMinusTwoNeutrons()
         {
             const double peptideMono = 20000.0;
             var tol = new PpmTolerance(5);
-            var acceptor = new MostAbundantMassDiffAcceptor("mostAbundant", tol, Averagine);
+            var acceptor = new MostAbundantMassDiffAcceptor("mostAbundant", tol, Averagine, maxApexOffsetNeutrons: 2);
 
-            double expectedCenter = peptideMono + Averagine.GetMostAbundantOffset(peptideMono);
+            double apex = peptideMono + Averagine.GetMostAbundantOffset(peptideMono);
 
             var intervals = System.Linq.Enumerable.ToList(acceptor.GetAllowedPrecursorMassIntervalsFromTheoreticalMass(peptideMono));
-            Assert.That(intervals.Count, Is.EqualTo(1));
-            Assert.That(intervals[0].Notch, Is.EqualTo(0));
-            Assert.That(intervals[0].Minimum, Is.EqualTo(tol.GetMinimumValue(expectedCenter)).Within(1e-6));
-            Assert.That(intervals[0].Maximum, Is.EqualTo(tol.GetMaximumValue(expectedCenter)).Within(1e-6));
+            Assert.That(intervals.Count, Is.EqualTo(5));
+
+            // The on-apex interval (notch 0) is centered on the predicted most-abundant mass.
+            var onApex = intervals.Find(i => i.Notch == 0);
+            Assert.That(onApex, Is.Not.Null);
+            Assert.That(onApex.Minimum, Is.EqualTo(tol.GetMinimumValue(apex)).Within(1e-6));
+            Assert.That(onApex.Maximum, Is.EqualTo(tol.GetMaximumValue(apex)).Within(1e-6));
+
+            // The extreme intervals sit at apex ± 2 neutrons.
+            Assert.That(intervals.Exists(i => i.Contains(apex + 2 * Constants.C13MinusC12)), Is.True);
+            Assert.That(intervals.Exists(i => i.Contains(apex - 2 * Constants.C13MinusC12)), Is.True);
         }
 
         [Test]

--- a/MetaMorpheus/Test/MostAbundantMassTest.cs
+++ b/MetaMorpheus/Test/MostAbundantMassTest.cs
@@ -21,12 +21,15 @@ namespace Test
     {
         private static readonly AverageResidue Averagine = new Averagine();
 
+        // Averagine most-abundant offset for a monoisotopic mass (diff-to-monoisotopic at the nearest bin).
+        private static double ApexOffset(double mono) => Averagine.GetDiffToMonoisotopic(Averagine.GetMostIntenseMassIndex(mono));
+
         [Test]
         public static void Acceptor_OnApexCandidate_GetsNotchZero()
         {
             // A ~15 kDa proteoform: the observed precursor is the most abundant isotopic peak.
             const double peptideMono = 15000.0;
-            double observedMostAbundant = peptideMono + Averagine.GetMostAbundantOffset(peptideMono);
+            double observedMostAbundant = peptideMono + ApexOffset(peptideMono);
 
             var acceptor = new MostAbundantMassDiffAcceptor("mostAbundant", new PpmTolerance(5), Averagine);
 
@@ -42,7 +45,7 @@ namespace Test
             // (default ±2) deliberately accepts those candidates (with a nonzero notch), while
             // candidates beyond the window are rejected.
             const double peptideMono = 15000.0;
-            double observedMostAbundant = peptideMono + Averagine.GetMostAbundantOffset(peptideMono);
+            double observedMostAbundant = peptideMono + ApexOffset(peptideMono);
             var acceptor = new MostAbundantMassDiffAcceptor("mostAbundant", new PpmTolerance(5), Averagine, maxApexOffsetNeutrons: 2);
 
             // ±1 and ±2 neutron apex offsets are accepted (nonzero notch, never the -1 sentinel)...
@@ -78,7 +81,7 @@ namespace Test
             var tol = new PpmTolerance(5);
             var acceptor = new MostAbundantMassDiffAcceptor("mostAbundant", tol, Averagine, maxApexOffsetNeutrons: 2);
 
-            double apex = peptideMono + Averagine.GetMostAbundantOffset(peptideMono);
+            double apex = peptideMono + ApexOffset(peptideMono);
 
             var intervals = System.Linq.Enumerable.ToList(acceptor.GetAllowedPrecursorMassIntervalsFromTheoreticalMass(peptideMono));
             Assert.That(intervals.Count, Is.EqualTo(5));
@@ -137,12 +140,12 @@ namespace Test
             Assert.That(acc.NumNotches, Is.EqualTo(2));
 
             // Unmodified candidate at its apex → notch 0.
-            double obsUnmod = peptideMono + Averagine.GetMostAbundantOffset(peptideMono);
+            double obsUnmod = peptideMono + ApexOffset(peptideMono);
             Assert.That(acc.Accepts(obsUnmod, peptideMono), Is.EqualTo(0));
 
             // Phospho-shifted candidate at the apex of (peptide + phospho) → the phospho shift's notch.
             double shiftedMono = peptideMono + phospho;
-            double obsPhospho = shiftedMono + Averagine.GetMostAbundantOffset(shiftedMono);
+            double obsPhospho = shiftedMono + ApexOffset(shiftedMono);
             Assert.That(acc.Accepts(obsPhospho, peptideMono), Is.EqualTo(phosphoNotch));
 
             // A +1 neutron apex misprediction on the phospho candidate is still accepted under the same notch.

--- a/MetaMorpheus/Test/MostAbundantMassTest.cs
+++ b/MetaMorpheus/Test/MostAbundantMassTest.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Chemistry;
 using EngineLayer;
 using MassSpectrometry;
@@ -145,6 +147,27 @@ namespace Test
 
             // A +1 neutron apex misprediction on the phospho candidate is still accepted under the same notch.
             Assert.That(acc.Accepts(obsPhospho + Constants.C13MinusC12, peptideMono), Is.EqualTo(phosphoNotch));
+        }
+
+        [Test]
+        public static void GptmdFilterTypes_ResolveToActiveFilters_TomlSettable()
+        {
+            // Names (toml-serializable) resolve to filter instances; unknown names are ignored.
+            var p = new GptmdParameters
+            {
+                GptmdFilters = new List<IGptmdFilter>(),
+                GptmdFilterTypes = new List<string> { nameof(ImprovedScoreFilter), "bogus" }
+            };
+            var active = p.GetActiveFilters();
+            Assert.That(active.Any(f => f is ImprovedScoreFilter), Is.True);
+            Assert.That(active.Count, Is.EqualTo(1)); // "bogus" ignored
+
+            // In-memory (GUI) filter + named filter of same type dedupe to one.
+            p.GptmdFilters = new List<IGptmdFilter> { new ImprovedScoreFilter() };
+            Assert.That(p.GetActiveFilters().Count, Is.EqualTo(1));
+
+            // Default (no names, no in-memory filters) → no filtering, every mod added.
+            Assert.That(new GptmdParameters { GptmdFilters = new(), GptmdFilterTypes = new() }.GetActiveFilters(), Is.Empty);
         }
 
         [Test]

--- a/MetaMorpheus/Test/MostAbundantMassTest.cs
+++ b/MetaMorpheus/Test/MostAbundantMassTest.cs
@@ -1,0 +1,118 @@
+using Chemistry;
+using EngineLayer;
+using MassSpectrometry;
+using MzLibUtil;
+using Nett;
+using NUnit.Framework;
+using TaskLayer;
+
+namespace Test
+{
+    /// <summary>
+    /// Tests for "most abundant mass" precursor selection (Strategy B) on the MetaMorpheus side:
+    /// the <see cref="MostAbundantMassDiffAcceptor"/>, the <see cref="PrecursorMassMatchMode"/>
+    /// parameter plumbing, and <see cref="Ms2ScanWithSpecificMass.PrecursorMassToMatch"/>.
+    /// </summary>
+    [TestFixture]
+    public static class MostAbundantMassTest
+    {
+        private static readonly AverageResidue Averagine = new Averagine();
+
+        [Test]
+        public static void Acceptor_PinsExactMonoisotopic_AndRejectsOffByOne()
+        {
+            // A ~15 kDa proteoform: the observed precursor is the most abundant isotopic peak.
+            const double peptideMono = 15000.0;
+            double observedMostAbundant = peptideMono + Averagine.GetMostAbundantOffset(peptideMono);
+
+            var acceptor = new MostAbundantMassDiffAcceptor("mostAbundant", new PpmTolerance(5), Averagine);
+
+            // The correct monoisotopic candidate is accepted (notch 0)...
+            Assert.That(acceptor.Accepts(observedMostAbundant, peptideMono), Is.EqualTo(0));
+
+            // ...but candidates that are off by ±1 neutron in the monoisotopic mass are rejected,
+            // because their theoretical most-abundant peak no longer lines up with the observed one.
+            Assert.That(acceptor.Accepts(observedMostAbundant, peptideMono + Constants.C13MinusC12), Is.EqualTo(-1));
+            Assert.That(acceptor.Accepts(observedMostAbundant, peptideMono - Constants.C13MinusC12), Is.EqualTo(-1));
+        }
+
+        [Test]
+        public static void Acceptor_ContrastsWithOneMmNotch_WhichAcceptsOffByOne()
+        {
+            // Illustrates what most-abundant mode replaces: the OneMM notch acceptor (which operates
+            // in monoisotopic space) deliberately accepts a candidate one neutron lighter than the
+            // observed monoisotopic mass — exactly the off-by-one ambiguity this work removes.
+            const double observedMono = 15000.0;
+            var oneMm = SearchTask.GetMassDiffAcceptor(new PpmTolerance(5), MassDiffAcceptorType.OneMM, null);
+
+            Assert.That(oneMm.Accepts(observedMono, observedMono), Is.GreaterThanOrEqualTo(0));
+            Assert.That(oneMm.Accepts(observedMono, observedMono - 1.0029), Is.GreaterThanOrEqualTo(0)); // off-by-one accepted
+        }
+
+        [Test]
+        public static void Acceptor_TheoreticalInterval_IsCenteredOnMostAbundantMass()
+        {
+            const double peptideMono = 20000.0;
+            var tol = new PpmTolerance(5);
+            var acceptor = new MostAbundantMassDiffAcceptor("mostAbundant", tol, Averagine);
+
+            double expectedCenter = peptideMono + Averagine.GetMostAbundantOffset(peptideMono);
+
+            var intervals = System.Linq.Enumerable.ToList(acceptor.GetAllowedPrecursorMassIntervalsFromTheoreticalMass(peptideMono));
+            Assert.That(intervals.Count, Is.EqualTo(1));
+            Assert.That(intervals[0].Notch, Is.EqualTo(0));
+            Assert.That(intervals[0].Minimum, Is.EqualTo(tol.GetMinimumValue(expectedCenter)).Within(1e-6));
+            Assert.That(intervals[0].Maximum, Is.EqualTo(tol.GetMaximumValue(expectedCenter)).Within(1e-6));
+        }
+
+        [Test]
+        public static void SearchTask_GetMassDiffAcceptor_ReturnsMostAbundantWhenModeSet()
+        {
+            var acc = SearchTask.GetMassDiffAcceptor(new PpmTolerance(5), MassDiffAcceptorType.OneMM, null,
+                PrecursorMassMatchMode.MostAbundant, Averagine);
+            Assert.That(acc, Is.TypeOf<MostAbundantMassDiffAcceptor>());
+
+            // Default mode is unaffected.
+            var def = SearchTask.GetMassDiffAcceptor(new PpmTolerance(5), MassDiffAcceptorType.OneMM, null);
+            Assert.That(def, Is.Not.TypeOf<MostAbundantMassDiffAcceptor>());
+        }
+
+        [Test]
+        public static void Ms2Scan_PrecursorMassToMatch_DefaultsToPrecursorMass()
+        {
+            var scan = new MsDataScan(new MzSpectrum(new double[] { 1 }, new double[] { 1 }, false),
+                2, 1, true, Polarity.Positive, double.NaN, null, null, MZAnalyzerType.Orbitrap,
+                double.NaN, null, null, "scan=1", double.NaN, null, null, double.NaN, null,
+                DissociationType.AnyActivationType, 1, null);
+
+            // No precursorMassToMatch supplied → falls back to the monoisotopic PrecursorMass.
+            var defaultScan = new Ms2ScanWithSpecificMass(scan, 1500.0.ToMz(2), 2, "", new CommonParameters());
+            Assert.That(defaultScan.PrecursorMassToMatch, Is.EqualTo(defaultScan.PrecursorMass).Within(1e-9));
+
+            // Explicit precursorMassToMatch is carried through without altering PrecursorMass.
+            double matchMass = defaultScan.PrecursorMass + 5.0;
+            var mostAbundantScan = new Ms2ScanWithSpecificMass(scan, 1500.0.ToMz(2), 2, "", new CommonParameters(),
+                precursorMassToMatch: matchMass);
+            Assert.That(mostAbundantScan.PrecursorMassToMatch, Is.EqualTo(matchMass).Within(1e-9));
+            Assert.That(mostAbundantScan.PrecursorMass, Is.EqualTo(defaultScan.PrecursorMass).Within(1e-9));
+        }
+
+        [Test]
+        public static void CommonParameters_PrecursorMassMatchMode_RoundTripsAndClones()
+        {
+            var cp = new CommonParameters(precursorMassMatchMode: PrecursorMassMatchMode.MostAbundant);
+            Assert.That(cp.PrecursorMassMatchMode, Is.EqualTo(PrecursorMassMatchMode.MostAbundant));
+
+            // Clone preserves it.
+            Assert.That(cp.Clone().PrecursorMassMatchMode, Is.EqualTo(PrecursorMassMatchMode.MostAbundant));
+
+            // Toml round-trip preserves it.
+            string toml = Toml.WriteString(cp, MetaMorpheusTask.tomlConfig);
+            var restored = Toml.ReadString<CommonParameters>(toml, MetaMorpheusTask.tomlConfig);
+            Assert.That(restored.PrecursorMassMatchMode, Is.EqualTo(PrecursorMassMatchMode.MostAbundant));
+
+            // Default stays Monoisotopic.
+            Assert.That(new CommonParameters().PrecursorMassMatchMode, Is.EqualTo(PrecursorMassMatchMode.Monoisotopic));
+        }
+    }
+}

--- a/MetaMorpheus/Test/MostAbundantMassTest.cs
+++ b/MetaMorpheus/Test/MostAbundantMassTest.cs
@@ -1,3 +1,4 @@
+using System;
 using Chemistry;
 using EngineLayer;
 using MassSpectrometry;
@@ -121,6 +122,29 @@ namespace Test
                 precursorMassToMatch: matchMass);
             Assert.That(mostAbundantScan.PrecursorMassToMatch, Is.EqualTo(matchMass).Within(1e-9));
             Assert.That(mostAbundantScan.PrecursorMass, Is.EqualTo(defaultScan.PrecursorMass).Within(1e-9));
+        }
+
+        [Test]
+        public static void DotAcceptor_AcceptsShiftedCandidateAtApex_AndToleratesApex()
+        {
+            const double peptideMono = 10000.0;
+            const double phospho = 79.96633;
+            int phosphoNotch = (int)Math.Round(phospho * MassDiffAcceptor.NotchScalar);
+            var acc = new MostAbundantDotMassDiffAcceptor("g", new[] { 0.0, phospho }, new PpmTolerance(5), Averagine, 2);
+
+            Assert.That(acc.NumNotches, Is.EqualTo(2));
+
+            // Unmodified candidate at its apex → notch 0.
+            double obsUnmod = peptideMono + Averagine.GetMostAbundantOffset(peptideMono);
+            Assert.That(acc.Accepts(obsUnmod, peptideMono), Is.EqualTo(0));
+
+            // Phospho-shifted candidate at the apex of (peptide + phospho) → the phospho shift's notch.
+            double shiftedMono = peptideMono + phospho;
+            double obsPhospho = shiftedMono + Averagine.GetMostAbundantOffset(shiftedMono);
+            Assert.That(acc.Accepts(obsPhospho, peptideMono), Is.EqualTo(phosphoNotch));
+
+            // A +1 neutron apex misprediction on the phospho candidate is still accepted under the same notch.
+            Assert.That(acc.Accepts(obsPhospho + Constants.C13MinusC12, peptideMono), Is.EqualTo(phosphoNotch));
         }
 
         [Test]

--- a/MetaMorpheus/Test/Test.csproj
+++ b/MetaMorpheus/Test/Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>

--- a/MetaMorpheus/Test/Test.csproj
+++ b/MetaMorpheus/Test/Test.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="9.9.25" />
+    <PackageReference Include="mzLib" Version="9.9.26" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />

--- a/MetaMorpheus/Test/Test.csproj
+++ b/MetaMorpheus/Test/Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0-windows</TargetFramework>
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.579" />
+    <PackageReference Include="mzLib" Version="9.9.25" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />


### PR DESCRIPTION
<!-- project-of-origin -->
> **Project of origin:** `MostAbundantMass`

Future-work follow-up to #2671, **stacked on it**, and the consumer side of mzLib #1081.

Splits the isotopically-unresolved (high-mass) average-mass path out of the resolved most-abundant PR (#2671). Until #2671 merges, this diff vs `master` also shows the resolved changes; the *net new* part here is the unresolved branch in `_GetMs2Scans`: when an envelope is `EnvelopeResolution.Unresolved`, select the average/centroid observed mass instead of the most-abundant peak (same `-1` sentinel → monoisotopic fallback).

**Status: draft / scaffolding — do not merge.** Nothing sets `Resolution.Unresolved` in production yet, and the average-vs-average mass-diff acceptor and the unresolved charge-determination algorithm are not built. This branch only preserves the consumer wiring so that work is additive. Depends on mzLib #1081 (`AverageObservedMass`, `EnvelopeResolution`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
