### PR TITLE
test(ci): run external-service tests in a non-blocking job that skips on outage

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -27,11 +27,36 @@ jobs:
         run: dotnet add ./MetaMorpheus/Test/Test.csproj package coverlet.collector -v 6.0.2
         
       - name: Run unit tests with coverage
-        run: dotnet test .\MetaMorpheus\Test\Test.csproj --configuration Release --verbosity normal --collect:"XPlat Code Coverage"
-        
+        # Exclude live external-service tests (UniProt, etc.) from the required run; they run in the
+        # separate, non-blocking external-service-tests job below.
+        run: dotnet test .\MetaMorpheus\Test\Test.csproj --configuration Release --verbosity normal --filter "Category!=ExternalService" --collect:"XPlat Code Coverage"
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
           flags: unittests
+
+  # Runs tests that depend on live external web services (UniProt, ...). Kept separate and
+  # intentionally NOT a required status check, so a third-party outage never blocks a PR. The tests
+  # self-classify: an outage is reported as Skipped (Assert.Ignore) and only a genuine contract
+  # break fails this job. Do NOT add this job to branch-protection required checks.
+  external-service-tests:
+    name: External-service tests (non-blocking)
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.204
+      - name: Restore dependencies
+        run: dotnet restore ./MetaMorpheus/MetaMorpheus.sln
+
+      - name: Build
+        run: dotnet build --no-restore ./MetaMorpheus/MetaMorpheus.sln --configuration Release
+
+      - name: Run external-service tests
+        run: dotnet test .\MetaMorpheus\Test\Test.csproj --configuration Release --no-build --verbosity normal --filter "Category=ExternalService"

--- a/MetaMorpheus/Test/ExternalServiceTestHelper.cs
+++ b/MetaMorpheus/Test/ExternalServiceTestHelper.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Test
+{
+    /// <summary>
+    /// Support for tests that exercise a live external web service (UniProt, Koina, PRIDE, ...).
+    /// Such tests carry <c>[Category("ExternalService")]</c> so CI can run them in a dedicated,
+    /// non-blocking job (see .github/workflows/Test.yml) instead of the required unit-test run.
+    ///
+    /// The hard part is telling two failures apart:
+    ///   * the service is unavailable (down, rate-limited, 5xx, timeout) - NOT our bug, so the
+    ///     test should be <b>skipped</b> ("we tried, the service is down, don't worry"); versus
+    ///   * the service answered but the contract is broken (our URL is wrong, the response no
+    ///     longer parses, an expected value is missing) - that is a real regression and must FAIL.
+    ///
+    /// <see cref="RunAsync"/> wraps a test body and converts availability failures into
+    /// <see cref="Assert.Ignore(string)"/> (reported as Skipped) while letting genuine assertion
+    /// failures propagate. A test signals "unavailable" from inside the body either by letting a
+    /// transport exception bubble up or by calling <see cref="ThrowIfUnavailable"/> on the response.
+    /// </summary>
+    public static class ExternalServiceTestHelper
+    {
+        /// <summary>
+        /// Runs <paramref name="testBody"/>; if the external service proves unavailable, marks the
+        /// test Skipped (via Assert.Ignore) instead of Failed. Real assertion failures propagate.
+        /// </summary>
+        public static async Task RunAsync(string serviceName, Func<Task> testBody)
+        {
+            try
+            {
+                await testBody();
+            }
+            catch (ExternalServiceUnavailableException e)
+            {
+                Skip(serviceName, $"unavailable ({e.Message})");
+            }
+            catch (HttpRequestException e)
+            {
+                Skip(serviceName, $"unavailable ({e.Message})");
+            }
+            catch (TaskCanceledException)
+            {
+                Skip(serviceName, "timed out");
+            }
+            catch (SocketException e)
+            {
+                Skip(serviceName, $"unreachable ({e.Message})");
+            }
+        }
+
+        /// <summary>
+        /// Records the skip reason on both the console/CI log (via TestContext.Progress, which is
+        /// flushed immediately regardless of verbosity) and the NUnit test result, then skips the
+        /// test. This is what surfaces the "we tried, the service is down, don't worry" message.
+        /// </summary>
+        private static void Skip(string serviceName, string reason)
+        {
+            string message = $"Skipping external-service test: {serviceName} {reason}. " +
+                             "This is a third-party availability problem, not a code failure.";
+            TestContext.Progress.WriteLine(message);
+            Assert.Ignore(message);
+        }
+
+        /// <summary>
+        /// Probes an external service's health/readiness URL and skips the calling test (or, from a
+        /// [OneTimeSetUp], the whole fixture) if it is unreachable. Use this for tests whose service
+        /// call is buried deep in production code and cannot easily route through <see cref="RunAsync"/>.
+        /// </summary>
+        public static void EnsureReachable(string serviceName, string healthUrl)
+        {
+            try
+            {
+                using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(20) };
+                var response = client.GetAsync(healthUrl).GetAwaiter().GetResult();
+                ThrowIfUnavailable(response);
+                if (!response.IsSuccessStatusCode)
+                {
+                    throw new ExternalServiceUnavailableException($"health check returned HTTP {(int)response.StatusCode}");
+                }
+            }
+            catch (ExternalServiceUnavailableException e)
+            {
+                Skip(serviceName, $"unavailable ({e.Message})");
+            }
+            catch (HttpRequestException e)
+            {
+                Skip(serviceName, $"unavailable ({e.Message})");
+            }
+            catch (TaskCanceledException)
+            {
+                Skip(serviceName, "timed out");
+            }
+            catch (SocketException e)
+            {
+                Skip(serviceName, $"unreachable ({e.Message})");
+            }
+        }
+
+        /// <summary>
+        /// Classifies an HTTP response as a service-availability problem and, if so, throws
+        /// <see cref="ExternalServiceUnavailableException"/> so <see cref="RunAsync"/> skips the test.
+        /// Catches transport-level status codes (408/429/5xx) and known error bodies that some
+        /// services (e.g. UniProt's streaming endpoint) return with an HTTP 200.
+        /// </summary>
+        public static void ThrowIfUnavailable(HttpResponseMessage response, string bodyText = null)
+        {
+            int status = (int)response.StatusCode;
+            if (status == 408 || status == 429 || status >= 500)
+            {
+                throw new ExternalServiceUnavailableException($"HTTP {status} {response.ReasonPhrase}");
+            }
+
+            // Some services answer 200 but stream an error message in the body.
+            if (!string.IsNullOrWhiteSpace(bodyText) &&
+                bodyText.Contains("Error encountered when streaming data", StringComparison.OrdinalIgnoreCase))
+            {
+                throw new ExternalServiceUnavailableException("service returned an error body instead of data");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Marker exception meaning "the external service is unavailable" (as opposed to a real bug).
+    /// <see cref="ExternalServiceTestHelper.RunAsync"/> turns this into a skipped test.
+    /// </summary>
+    public class ExternalServiceUnavailableException : Exception
+    {
+        public ExternalServiceUnavailableException(string message) : base(message) { }
+    }
+}

--- a/MetaMorpheus/Test/GuiTests/GuiFunctionsTest.cs
+++ b/MetaMorpheus/Test/GuiTests/GuiFunctionsTest.cs
@@ -94,56 +94,60 @@ namespace Test.GuiTests
         }
 
         // Live canary for the UniProt REST download used by the "Download UniProt Database" GUI.
-        // Marked [Explicit] (and Category "UniProt") so it never runs in an unfiltered `dotnet test`
-        // pass - i.e. it stays out of CI, exactly like the [Category("Koina")] network tests - and
-        // only fires when a developer selects it deliberately. Run it to confirm that
-        // rest.uniprot.org is reachable, that GetUniProtHtmlQueryString still yields a working URL,
-        // and that ProteinDbLoader can parse the response. The assertion is intentionally loose
-        // (proteins parsed > 0) so a UniProt content revision does not turn this into a red herring;
-        // its job is to detect that the pipeline is *working*, not to pin an exact entry count.
+        // Tagged [Category("ExternalService")] (+ "UniProt") so it runs in the dedicated, non-blocking
+        // external-service CI job rather than the required unit-test run. It confirms rest.uniprot.org
+        // is reachable, that GetUniProtHtmlQueryString still yields a working URL, and that
+        // ProteinDbLoader can parse the response. Via ExternalServiceTestHelper.RunAsync, a UniProt
+        // outage (transport error, 5xx, or the HTTP-200 "Error encountered when streaming data" body)
+        // is reported as Skipped rather than Failed - "we tried, UniProt was down, don't worry" - while
+        // a genuine contract break (nothing parses, URL rejected) still fails. The assertion is
+        // intentionally loose (proteins parsed > 0) so a UniProt content revision is not a red herring.
         // UP000001207 = Bacillus phage phi29 (small reference proteome).
-        [Test, Explicit]
+        [Test]
+        [Category("ExternalService")]
         [Category("UniProt")]
-        [TestCase("UP000001207", true, false, true, true)]   // reviewed, XML, compressed
-        [TestCase("UP000001207", false, false, false, false)] // all, FASTA, uncompressed
-        public static async Task UniProtDownloadCanary(string proteomeID, bool reviewed, bool isoforms, bool xmlFormat, bool compressed)
-        {
-            var proteomeURL = DownloadUniProtDatabaseFunctions.GetUniProtHtmlQueryString(proteomeID, reviewed,
-                isoforms, xmlFormat, compressed);
-
-            var extension = (xmlFormat ? ".xml" : ".fasta") + (compressed ? ".gz" : "");
-            var filePath = Path.Combine(TestContext.CurrentContext.TestDirectory, $@"DatabaseTests\uniprot_canary{extension}");
-
-            HttpClientHandler handler = new HttpClientHandler(); // without this, the download is very slow
-            handler.Proxy = null;
-            handler.UseProxy = false;
-
-            using var client = new HttpClient(handler); // client for using the REST Api
-            var response = await client.GetAsync(proteomeURL);
-
-            using (var file = File.Create(filePath)) // saves the file
+        [TestCase("UP000001207", true, false, true, false)]   // reviewed, XML
+        [TestCase("UP000001207", false, false, false, false)] // all, FASTA
+        public static Task UniProtDownloadCanary(string proteomeID, bool reviewed, bool isoforms, bool xmlFormat, bool compressed) =>
+            ExternalServiceTestHelper.RunAsync("UniProt", async () =>
             {
-                var content = await response.Content.ReadAsStreamAsync();
-                await content.CopyToAsync(file);
-            }
+                var proteomeURL = DownloadUniProtDatabaseFunctions.GetUniProtHtmlQueryString(proteomeID, reviewed,
+                    isoforms, xmlFormat, compressed);
 
-            List<Protein> reader;
-            if (xmlFormat)
-            {
-                reader = ProteinDbLoader.LoadProteinXML(proteinDbLocation: filePath, generateTargets: true, decoyType: DecoyType.Reverse,
-                    allKnownModifications: null, isContaminant: false, modTypesToExclude: null, out _, maxHeterozygousVariants: 0);
-            }
-            else
-            {
-                reader = ProteinDbLoader.LoadProteinFasta(filePath, generateTargets: true, decoyType: DecoyType.Reverse,
-                    isContaminant: false, out _);
-            }
+                var extension = (xmlFormat ? ".xml" : ".fasta") + (compressed ? ".gz" : "");
+                var filePath = Path.Combine(TestContext.CurrentContext.TestDirectory, $@"DatabaseTests\uniprot_canary{extension}");
 
-            File.Delete(filePath);
+                HttpClientHandler handler = new HttpClientHandler(); // without this, the download is very slow
+                handler.Proxy = null;
+                handler.UseProxy = false;
 
-            Assert.That(reader.Count, Is.GreaterThan(0),
-                "UniProt returned no parseable proteins - the REST endpoint may be down or the query URL/format has changed.");
-        }
+                using var client = new HttpClient(handler); // client for using the REST Api
+                var response = await client.GetAsync(proteomeURL);
+
+                var bytes = await response.Content.ReadAsByteArrayAsync();
+                // Sniff a text prefix (harmless on gzipped payloads) so a service outage is skipped, not failed.
+                var textPreview = System.Text.Encoding.UTF8.GetString(bytes, 0, Math.Min(bytes.Length, 512));
+                ExternalServiceTestHelper.ThrowIfUnavailable(response, textPreview);
+
+                File.WriteAllBytes(filePath, bytes); // saves the file
+
+                List<Protein> reader;
+                if (xmlFormat)
+                {
+                    reader = ProteinDbLoader.LoadProteinXML(proteinDbLocation: filePath, generateTargets: true, decoyType: DecoyType.Reverse,
+                        allKnownModifications: null, isContaminant: false, modTypesToExclude: null, out _, maxHeterozygousVariants: 0);
+                }
+                else
+                {
+                    reader = ProteinDbLoader.LoadProteinFasta(filePath, generateTargets: true, decoyType: DecoyType.Reverse,
+                        isContaminant: false, out _);
+                }
+
+                File.Delete(filePath);
+
+                Assert.That(reader.Count, Is.GreaterThan(0),
+                    "UniProt returned no parseable proteins - the REST endpoint may be down or the query URL/format has changed.");
+            });
 
         [Test]
         public static void TestFileLoadingWithDuplicateFiles()


### PR DESCRIPTION
Establishes a shared convention for tests that call a **live external web service** (UniProt now; Koina/PRIDE next) so that a third-party outage can never block a PR, while a genuine breakage still fails loudly. Companion PR in mzLib: **smith-chem-wisc/mzLib#1090**.

## Background
Some tests must hit a live service — e.g. the "Download UniProt Database" flow queries `rest.uniprot.org`. Those tests are valuable (they catch a changed URL or a broken parser), but the internet misbehaves. This is not hypothetical: **#2681** was filed because UniProt's `/stream` endpoint began returning an HTTP-200 *error body*, which reddened **every open mzLib PR** (see *Interaction with mzLib CI*). #2681 parked the live call behind `[Explicit]` as a stopgap; this PR replaces that with a durable pattern.

## The idea: tell "their outage" apart from "our bug"
A live-service test can go red two ways, and they deserve opposite treatment:

| Cause | Right outcome |
|---|---|
| Service down / rate-limited / 5xx / timeout / error body | **Skip** — "we tried, it's down, don't worry" |
| Service answered but the contract is broken (URL rejected, nothing parses) | **Fail** — real regression |

`[Explicit]` can't make that distinction — it just hides the test, losing the "our bug" signal too.

## What this PR does
- **`ExternalServiceTestHelper`** — `RunAsync(service, body)` wraps a test body; availability failures (transport exception, 408/429/5xx, or a service's HTTP-200 error body such as UniProt's `"Error encountered when streaming data"`) become `Assert.Ignore` (**Skipped**) with a plain-English reason written to the CI log; genuine assertion failures propagate and **fail**. Also `EnsureReachable` (health-probe form) and `ThrowIfUnavailable` (response classifier).
- **`GuiFunctionsTest.UniProtDownloadCanary`** — converted from `[Explicit]` to `[Category("ExternalService")]` + the helper. It confirms UniProt is reachable, that `GetUniProtHtmlQueryString` yields a working URL, and that `ProteinDbLoader` parses the response (asserting `> 0` proteins, so a UniProt *content* revision isn't a false alarm). The offline URL-string and local-fixture tests from #2681 are unchanged and stay in the required run.
- **`Test.yml`** — the required unit-test run now filters `Category!=ExternalService`; a new **non-blocking** `external-service-tests` job runs `Category=ExternalService`.

## Example usage — adding a new external-service test
**Form 1 — wrap the call** (best when the test issues the request itself):
```csharp
[Test]
[Category("ExternalService")]      // routes it to the non-blocking job
[Category("PRIDE")]                // the specific service, for granular runs
public static Task PrideProjectIsReachable() =>
    ExternalServiceTestHelper.RunAsync("PRIDE", async () =>
    {
        using var client = new HttpClient();
        var response = await client.GetAsync("https://www.ebi.ac.uk/pride/ws/archive/v2/projects/PXD000001");
        ExternalServiceTestHelper.ThrowIfUnavailable(response);   // 5xx/429/error-body -> Skipped
        var json = await response.Content.ReadAsStringAsync();
        Assert.That(json, Does.Contain("PXD000001"));             // contract check -> a real Fail
    });
```

**Form 2 — probe once per fixture** (best when the service call is buried in production code you can't wrap):
```csharp
[TestFixture]
[Category("ExternalService")]
[Category("PRIDE")]
public class MyPrideTests
{
    [OneTimeSetUp]
    public void EnsureUp() =>
        ExternalServiceTestHelper.EnsureReachable("PRIDE", "https://www.ebi.ac.uk/pride/ws/archive/v2/health");
        // if PRIDE is unreachable, the whole fixture is Skipped with a reason instead of failing

    [Test] public void SomethingThatCallsPrideDeepInside() { /* ... */ }
}
```

## What a skip looks like in the log
```
Skipping external-service test: UniProt unavailable (service returned an error body instead of data). This is a third-party availability problem, not a code failure.
...
Skipped: 2
```
Verified locally: with UniProt currently down, the external-service job is **green with 2 skips**; the required run passes **26** with the canary excluded.

## Interaction with mzLib CI  (important)
mzLib's CI has an `integration` job that packs the PR's mzLib, **clones this repo at master, and runs its entire test suite**. That is why a broken UniProt test on MetaMorpheus master reddens *every* mzLib PR — the failure is unrelated to the mzLib diff. Two consequences:
1. Because the canary now **skips** (not fails) on an outage, it can no longer redden mzLib PRs even though that integration run applies no category filter.
2. The companion **mzLib#1090** additionally adds `--filter "Category!=ExternalService"` to that integration run, so MetaMorpheus's external-service tests are skipped there entirely, and applies the same convention to mzLib's Koina tests.

Either PR can merge first; both orderings are safe (today the canary is `[Explicit]`, i.e. already excluded, until this PR lands).

## For maintainers
Please leave the **`external-service-tests`** job **out** of branch-protection required checks so it stays informational (green normally, Skipped during an outage, red only on a genuine contract break).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
