### PR TITLE
Hotfix: remove unused ThermoFisher.CommonCore.Data.Business using in DIAEngine

### DIFF
--- a/MetaMorpheus/EngineLayer/DIA/DIAEngine.cs
+++ b/MetaMorpheus/EngineLayer/DIA/DIAEngine.cs
@@ -12,7 +12,6 @@ using System.Collections.Concurrent;
 using EngineLayer.Util;
 using Omics;
 using FlashLFQ;
-using ThermoFisher.CommonCore.Data.Business;
 using Readers;
 
 namespace EngineLayer.DIA


### PR DESCRIPTION
**Hotfix.**

`EngineLayer/DIA/DIAEngine.cs` carried a `using ThermoFisher.CommonCore.Data.Business;` directive that was added incidentally during the recent Thermo file reader DLL update. Nothing in `DIAEngine.cs` references anything from that namespace, so the using is dead — but it couples the file to the `ThermoFisher.CommonCore.Data.Business` assembly, which broke after the reader DLL was updated.

Deleting the single unused line removes the stray dependency and restores a clean build. No behavior change; verified `EngineLayer` builds with 0 errors.

Smallest possible fix: one line deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)