### PR TITLE
Install TorchSharp/libtorch .dll depenencies so Chronologer RT prediction works

### DIFF
--- a/MetaMorpheus/MetaMorpheusSetup/Product.wxs
+++ b/MetaMorpheus/MetaMorpheusSetup/Product.wxs
@@ -499,6 +499,46 @@
 	  <Component Id="src_SQLite.Interop.dll" Guid="A918BB3C-0720-469E-900B-27FA93B7BB86">
 		<File Id="src_SQLite.Interop.dll" Name="SQLite.Interop.dll" Source="$(var.GUI_TargetDir)runtimes\win-x64\native\SQLite.Interop.dll" />
 	  </Component>
+      <!--TorchSharp/libtorch natives required by Chronologer retention time prediction during PEP.-->
+      <!--The managed TorchSharp.dll P/Invokes LibTorchSharp, which in turn pulls in the libtorch stack.-->
+      <!--CMD.deps.json probes runtimes\win-x64\native, so these must land here or PEP throws DllNotFoundException.-->
+      <Component Id="src_LibTorchSharp.dll" Guid="9BA2F494-3C28-4276-A8FC-B14399E4BDE7">
+        <File Id="src_LibTorchSharp.dll" Name="LibTorchSharp.dll" Source="$(var.GUI_TargetDir)runtimes\win-x64\native\LibTorchSharp.dll" />
+      </Component>
+      <Component Id="src_torch_cpu.dll" Guid="757479C9-7B0B-4873-802B-0D2BC9AA9379">
+        <File Id="src_torch_cpu.dll" Name="torch_cpu.dll" Source="$(var.GUI_TargetDir)runtimes\win-x64\native\torch_cpu.dll" />
+      </Component>
+      <Component Id="src_torch.dll" Guid="C1C621CB-87FD-41B8-A367-D540C8EB5CF6">
+        <File Id="src_torch.dll" Name="torch.dll" Source="$(var.GUI_TargetDir)runtimes\win-x64\native\torch.dll" />
+      </Component>
+      <Component Id="src_torch_global_deps.dll" Guid="F077F9E2-D56E-460E-BAAA-3762E4B0C37A">
+        <File Id="src_torch_global_deps.dll" Name="torch_global_deps.dll" Source="$(var.GUI_TargetDir)runtimes\win-x64\native\torch_global_deps.dll" />
+      </Component>
+      <Component Id="src_c10.dll" Guid="BDA4715C-9201-4ECA-91FD-DD717D80FEDC">
+        <File Id="src_c10.dll" Name="c10.dll" Source="$(var.GUI_TargetDir)runtimes\win-x64\native\c10.dll" />
+      </Component>
+      <Component Id="src_fbgemm.dll" Guid="B93DD689-FB38-4E76-A32F-35D9220530ED">
+        <File Id="src_fbgemm.dll" Name="fbgemm.dll" Source="$(var.GUI_TargetDir)runtimes\win-x64\native\fbgemm.dll" />
+      </Component>
+      <Component Id="src_asmjit.dll" Guid="270B2CC7-3268-4190-A2C2-035EAA49A704">
+        <File Id="src_asmjit.dll" Name="asmjit.dll" Source="$(var.GUI_TargetDir)runtimes\win-x64\native\asmjit.dll" />
+      </Component>
+      <Component Id="src_uv.dll" Guid="CBE55EAF-154D-4014-8C69-C454C715339E">
+        <File Id="src_uv.dll" Name="uv.dll" Source="$(var.GUI_TargetDir)runtimes\win-x64\native\uv.dll" />
+      </Component>
+      <Component Id="src_libiomp5md.dll" Guid="A0375978-1255-4937-B3DE-77A653EBBEA3">
+        <File Id="src_libiomp5md.dll" Name="libiomp5md.dll" Source="$(var.GUI_TargetDir)runtimes\win-x64\native\libiomp5md.dll" />
+      </Component>
+      <Component Id="src_libiompstubs5md.dll" Guid="EA4924B2-F518-44AF-B6B0-B2835F9BAAF4">
+        <File Id="src_libiompstubs5md.dll" Name="libiompstubs5md.dll" Source="$(var.GUI_TargetDir)runtimes\win-x64\native\libiompstubs5md.dll" />
+      </Component>
+      <!--Native backing library for the managed SkiaSharp.dll, which ships but has no native pair.-->
+      <Component Id="src_libSkiaSharp.dll" Guid="08B9E210-A08C-457F-9618-7D7DBEFE233A">
+        <File Id="src_libSkiaSharp.dll" Name="libSkiaSharp.dll" Source="$(var.GUI_TargetDir)runtimes\win-x64\native\libSkiaSharp.dll" />
+      </Component>
+      <Component Id="src_sni.dll" Guid="67D93F86-AC5E-4D0C-9900-FDCEEE35881C">
+        <File Id="src_sni.dll" Name="sni.dll" Source="$(var.GUI_TargetDir)runtimes\win-x64\native\sni.dll" />
+      </Component>
     </ComponentGroup>
   </Fragment>
 


### PR DESCRIPTION
Product.wxs uses DoNotHarvest, so every shipped file must be listed by hand. The managed TorchSharp.dll was listed but its native dependencies never were, so any MSI-installed MetaMorpheus threw System.DllNotFoundException: Unable to load DLL 'LibTorchSharp' when Chronologer retention time prediction ran during PEP. The installed CMD.deps.json already resolves these to runtimes/win-x64/native.

Adds the 12 missing natives to the WinNativeMathComponents group: LibTorchSharp, torch_cpu, torch, torch_global_deps, c10, fbgemm, asmjit, uv, libiomp5md and libiompstubs5md for the libtorch stack, plus libSkiaSharp (the native pair for the already-shipped managed SkiaSharp.dll) and sni.dll.

Tradeoff: this grows the MSI by roughly 250 MB, almost all of it torch_cpu.dll at ~238 MB. **This is a 10x increase in the size of the installer**. 