### PR TITLE
fix(glyco): select localization scan by activation, not scan order

### DIFF
--- a/MetaMorpheus/EngineLayer/GlycoSearch/GlycoSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/GlycoSearchEngine.cs
@@ -445,7 +445,7 @@ namespace EngineLayer.GlycoSearch
             //For HCD-pd-ETD or CD-pd-EThcD type of data, we generate the different rpoducts.
             if (theScan.ChildScans.Count > 0 && GlycoPeptides.DissociationTypeContainETD(CommonParameters.MS2ChildScanDissociationType, CommonParameters.CustomIons))
             {
-                localizationScan = theScan.ChildScans.First();
+                localizationScan = GetLocalizationScan(theScan);
                 // For the localization scan, if it is from ion trap, we will use a wider tolerance for the localization.
                 toleranceForLocalizationScan = localizationScan.TheScan.MzAnalyzer == MZAnalyzerType.IonTrap2D ||
                     localizationScan.TheScan.MzAnalyzer == MZAnalyzerType.IonTrap3D ? CommonParameters.ProductMassTolerance_LowRes : CommonParameters.ProductMassTolerance;
@@ -512,6 +512,43 @@ namespace EngineLayer.GlycoSearch
                     possibleMatches.Add(psmGlyco);
                 }
             }
+        }
+
+        /// <summary>
+        /// Chooses which child scan is used as the localization spectrum.
+        /// Glycosite localization is scored with c/zDot ions, so it is only meaningful against an
+        /// electron-based child scan. The child scans of a precursor are ordered by scan number, so
+        /// simply taking the first one selects the lowest-numbered child whatever its activation. On an
+        /// acquisition that places more than one activation on the same precursor (for example
+        /// HCD-ETciD-CID) that can select the collision-based child and score c/zDot theoretical ions
+        /// against a spectrum which cannot contain them.
+        /// The child scan header is consulted first, and the previous first-child behavior is kept as the
+        /// fallback when no child reports a usable activation. Files with a single child scan, which is
+        /// every acquisition shape this method was originally written for, are unaffected either way.
+        /// </summary>
+        /// <param name="theScan">The parent scan whose children are candidates. Must have at least one child.</param>
+        /// <returns>The child scan to localize against.</returns>
+        private Ms2ScanWithSpecificMass GetLocalizationScan(Ms2ScanWithSpecificMass theScan)
+        {
+            foreach (var childScan in theScan.ChildScans)
+            {
+                DissociationType? childDissociationType = childScan.TheScan.DissociationType;
+
+                // An absent or Autodetect header carries no activation information, so it cannot be trusted here.
+                if (childDissociationType == null || childDissociationType == DissociationType.Autodetect)
+                {
+                    continue;
+                }
+
+                if (GlycoPeptides.DissociationTypeContainETD(childDissociationType.Value, CommonParameters.CustomIons))
+                {
+                    return childScan;
+                }
+            }
+
+            // No child advertised an electron-based activation. Preserve the historical behavior rather than
+            // dropping localization, because the declared MS2ChildScanDissociationType already asserted ETD.
+            return theScan.ChildScans.First();
         }
 
         private void FindNGlycan(Ms2ScanWithSpecificMass theScan, int scanIndex, int scoreCutOff, PeptideWithSetModifications theScanBestPeptide, int ind, double possibleGlycanMassLow, double[] oxoniumIonIntensities, ref List<GlycoSpectralMatch> possibleMatches)

--- a/MetaMorpheus/Test/GlycoSearchEngineTest.cs
+++ b/MetaMorpheus/Test/GlycoSearchEngineTest.cs
@@ -73,8 +73,109 @@ namespace Test
             Assert.That(result.ScanInfo_p, Is.EqualTo(1), "P value should be capped at 1 when product mass tolerance is very wide.");
         }
 
+        /// <summary>
+        /// Builds a minimal centroided MS2 scan carrying a specific activation in its header.
+        /// </summary>
+        private static Ms2ScanWithSpecificMass MakeChildScan(int oneBasedScanNumber, DissociationType? dissociationType, CommonParameters commonParameters)
+        {
+            var mzLibScan = new MsDataScan(new MzSpectrum(new double[] { 1 }, new double[] { 1 }, false), oneBasedScanNumber, 2, true,
+                Polarity.Positive, double.NaN, null, null, MZAnalyzerType.Orbitrap, double.NaN, null, null, "scan=" + oneBasedScanNumber,
+                double.NaN, null, null, double.NaN, null, dissociationType, 1, null);
+
+            return new Ms2ScanWithSpecificMass(mzLibScan, 1, 1, null, commonParameters);
+        }
+
+        /// <summary>
+        /// Creates a GlycoSearchEngine with no scans, only so that private instance members can be exercised.
+        /// </summary>
+        private static GlycoSearchEngine MakeEngineForLocalizationScanSelection(CommonParameters commonParameters)
+        {
+            string oglycanPath = "OGlycan.gdb";
+            string nglycanPath = "NGlycan_ForNoSearch.gdb";
+            if (!GlobalVariables.OGlycanDatabasePaths.Contains(oglycanPath)) GlobalVariables.OGlycanDatabasePaths.Add(oglycanPath);
+            if (!GlobalVariables.NGlycanDatabasePaths.Contains(nglycanPath)) GlobalVariables.NGlycanDatabasePaths.Add(nglycanPath);
+
+            return new GlycoSearchEngine(new List<GlycoSpectralMatch>[0], new Ms2ScanWithSpecificMass[0],
+                new List<PeptideWithSetModifications>(), null, null, 0, commonParameters, null, oglycanPath, nglycanPath,
+                glycoSearchType: GlycoSearchType.OGlycanSearch, 30, 3, false, null);
+        }
+
+        private static Ms2ScanWithSpecificMass InvokeGetLocalizationScan(GlycoSearchEngine engine, Ms2ScanWithSpecificMass parentScan)
+        {
+            var method = typeof(GlycoSearchEngine).GetMethod("GetLocalizationScan", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.That(method, Is.Not.Null, "Unable to find private GetLocalizationScan method via reflection.");
+            return (Ms2ScanWithSpecificMass)method.Invoke(engine, new object[] { parentScan });
+        }
+
+        /// <summary>
+        /// On a multi-activation acquisition (for example HCD-ETciD-CID) the electron-based child is not
+        /// necessarily the lowest-numbered one. Localization is scored with c/zDot ions, so the child must be
+        /// chosen by its activation rather than by scan order.
+        /// </summary>
         [Test]
-        public static void TestLowResToleranceConstruction_Default() 
+        public static void GetLocalizationScan_PrefersElectronBasedChild_NotTheFirstChild()
+        {
+            var commonParameters = new CommonParameters(dissociationType: DissociationType.HCD,
+                ms2childScanDissociationType: DissociationType.EThcD, trimMsMsPeaks: false);
+            var engine = MakeEngineForLocalizationScanSelection(commonParameters);
+
+            var collisionChild = MakeChildScan(2, DissociationType.CID, commonParameters);
+            var electronChild = MakeChildScan(3, DissociationType.EThcD, commonParameters);
+
+            var parentScan = MakeChildScan(1, DissociationType.HCD, commonParameters);
+            parentScan.ChildScans = new List<Ms2ScanWithSpecificMass> { collisionChild, electronChild };
+
+            var localizationScan = InvokeGetLocalizationScan(engine, parentScan);
+
+            Assert.That(localizationScan.OneBasedScanNumber, Is.EqualTo(electronChild.OneBasedScanNumber),
+                "The EThcD child should be selected for localization even though the CID child comes first.");
+        }
+
+        /// <summary>
+        /// The single-child acquisitions this code was written for must behave exactly as before.
+        /// </summary>
+        [Test]
+        public static void GetLocalizationScan_SingleElectronBasedChild_IsUnchanged()
+        {
+            var commonParameters = new CommonParameters(dissociationType: DissociationType.HCD,
+                ms2childScanDissociationType: DissociationType.EThcD, trimMsMsPeaks: false);
+            var engine = MakeEngineForLocalizationScanSelection(commonParameters);
+
+            var electronChild = MakeChildScan(2, DissociationType.EThcD, commonParameters);
+
+            var parentScan = MakeChildScan(1, DissociationType.HCD, commonParameters);
+            parentScan.ChildScans = new List<Ms2ScanWithSpecificMass> { electronChild };
+
+            var localizationScan = InvokeGetLocalizationScan(engine, parentScan);
+
+            Assert.That(localizationScan.OneBasedScanNumber, Is.EqualTo(electronChild.OneBasedScanNumber));
+        }
+
+        /// <summary>
+        /// When no child scan header reports a usable activation there is nothing better to go on, so the
+        /// historical first-child behavior is kept rather than dropping localization entirely.
+        /// </summary>
+        [Test]
+        public static void GetLocalizationScan_NoResolvableChildActivation_FallsBackToFirstChild()
+        {
+            var commonParameters = new CommonParameters(dissociationType: DissociationType.HCD,
+                ms2childScanDissociationType: DissociationType.EThcD, trimMsMsPeaks: false);
+            var engine = MakeEngineForLocalizationScanSelection(commonParameters);
+
+            var unknownChild = MakeChildScan(2, null, commonParameters);
+            var autodetectChild = MakeChildScan(3, DissociationType.Autodetect, commonParameters);
+
+            var parentScan = MakeChildScan(1, DissociationType.HCD, commonParameters);
+            parentScan.ChildScans = new List<Ms2ScanWithSpecificMass> { unknownChild, autodetectChild };
+
+            var localizationScan = InvokeGetLocalizationScan(engine, parentScan);
+
+            Assert.That(localizationScan.OneBasedScanNumber, Is.EqualTo(unknownChild.OneBasedScanNumber),
+                "With no resolvable child activation the first child should still be used.");
+        }
+
+        [Test]
+        public static void TestLowResToleranceConstruction_Default()
         {
             var commonParameters = new CommonParameters();
             Assert.That(commonParameters.ProductMassTolerance_LowRes, Is.Not.Null, "Low-Res tolerance should be initialized by default.");

--- a/MetaMorpheus/Test/GlycoSearchEngineTest.cs
+++ b/MetaMorpheus/Test/GlycoSearchEngineTest.cs
@@ -87,16 +87,13 @@ namespace Test
 
         /// <summary>
         /// Creates a GlycoSearchEngine with no scans, only so that private instance members can be exercised.
+        /// Uses OGlycan.gdb, which GlobalVariables already registers from Glycan_Mods at start-up, so this
+        /// helper does not mutate the static glycan database path lists.
         /// </summary>
         private static GlycoSearchEngine MakeEngineForLocalizationScanSelection(CommonParameters commonParameters)
         {
-            string oglycanPath = "OGlycan.gdb";
-            string nglycanPath = "NGlycan_ForNoSearch.gdb";
-            if (!GlobalVariables.OGlycanDatabasePaths.Contains(oglycanPath)) GlobalVariables.OGlycanDatabasePaths.Add(oglycanPath);
-            if (!GlobalVariables.NGlycanDatabasePaths.Contains(nglycanPath)) GlobalVariables.NGlycanDatabasePaths.Add(nglycanPath);
-
             return new GlycoSearchEngine(new List<GlycoSpectralMatch>[0], new Ms2ScanWithSpecificMass[0],
-                new List<PeptideWithSetModifications>(), null, null, 0, commonParameters, null, oglycanPath, nglycanPath,
+                new List<PeptideWithSetModifications>(), null, null, 0, commonParameters, null, "OGlycan.gdb", null,
                 glycoSearchType: GlycoSearchType.OGlycanSearch, 30, 3, false, null);
         }
 


### PR DESCRIPTION
Implements **Stage 2** of #2692, and only Stage 2.

## The problem

Glycosite localization is scored with c/zDot ions, so it is only meaningful against an electron-based child scan. `FindOGlycan` selected that scan by position:

```csharp
if (theScan.ChildScans.Count > 0 && GlycoPeptides.DissociationTypeContainETD(CommonParameters.MS2ChildScanDissociationType, CommonParameters.CustomIons))
{
    localizationScan = theScan.ChildScans.First();
```

`ChildScans` is populated in scan-number order, so `First()` is the lowest-numbered child **whatever its activation**. With a single child that is always the right scan, which is why this has held up for every acquisition shape the method was written for (`HCD-pd-ETD`, `HCD-pd-EThcD` — both named in the comment above it).

With two children of different types it is right only if the acquisition happens to order the electron scan first. When it does not:

- the collision-based child is selected as the localization spectrum, while the very next line generates `DissociationType.ETD` products — **c/zDot theoretical ions scored against a spectrum that cannot contain them**;
- the low-resolution tolerance branch immediately below inherits the same wrong scan, so an ion-trap ETD child sitting at index 1 also loses its wider tolerance.

Note the guard tests `CommonParameters.MS2ChildScanDissociationType` — the single, globally declared child type — rather than anything about the scan actually chosen.

## The change

Consult each child scan's own header and prefer the first child whose activation is electron-based. An absent or `Autodetect` header carries no activation information, so it is skipped rather than trusted.

When no child advertises a usable activation, fall back to the previous `First()` behavior rather than dropping localization — the declared `MS2ChildScanDissociationType` has already asserted ETD, and silently degrading identifications toward Level 3 would be worse than the status quo.

**Single-child acquisitions take the same path as before either way**, so `HCD-pd-ETD` and `HCD-pd-EThcD` data are unaffected.

## Tests

Three new tests in `GlycoSearchEngineTest`, following that file's existing reflection pattern for private instance members:

- `GetLocalizationScan_PrefersElectronBasedChild_NotTheFirstChild` — a CID child at scan 2 and an EThcD child at scan 3; the EThcD child is selected. Fails before this change.
- `GetLocalizationScan_SingleElectronBasedChild_IsUnchanged` — the regression guard for the shapes this code already supported.
- `GetLocalizationScan_NoResolvableChildActivation_FallsBackToFirstChild` — null and `Autodetect` headers.

## Verification

Built and tested against `master` at `3b9f634ec`.

- The three new tests pass.
- `--filter "FullyQualifiedName~Glyco"`: **86 passed / 5 failed** on unmodified `master`, and **89 passed / 5 failed** with this branch. Same five, so this change breaks nothing and adds three.

### Heads-up: five glyco tests are already red on master

Unrelated to this PR, but found while establishing the baseline and worth surfacing: `NandO_GlycoSearch_onlyN`, `NandO_GlycoSearch_onlyO`, `NandO_GlycoSearch_onlyO_Run2`, `NandO_GlycoSearchIndividualFileFolderOutputTest`, and `GlycoTest_WritingSummary` fail on unmodified `master` when the glyco suite is run together.

`NandO_GlycoSearch_onlyN` **passes when run in isolation**, so these look order-dependent rather than genuinely broken — the static mutable glycan state (`GlycanBox.GlobalOGlycans` / `GlobalNGlycans` / `OGlycanBoxes`, populated in the `GlycoSearchEngine` constructor) is the obvious suspect. Happy to file that separately.

## Scope

Deliberately narrow. The remaining stages of #2692 — resolving each child against its own activation for fragment generation, so a CID child contributes b/y evidence rather than being forced through one declared type, plus the parameter and UI work — are follow-ons and are better reviewed on their own.

Touches `GlycoSearchEngine` (adds one private method, changes one line in `FindOGlycan`); no existing member's behavior or signature is otherwise altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xa43sN3mQ96uLmpSNcWj9h
