### PR TITLE
fix(test): register glyco test glycan databases by full path (5 red glyco tests)

### DIFF
--- a/MetaMorpheus/Test/GlycoSearchEngineTest.cs
+++ b/MetaMorpheus/Test/GlycoSearchEngineTest.cs
@@ -21,6 +21,29 @@ namespace Test
     [TestFixture]
     public class GlycoSearchEngineTest
     {
+        /// <summary>
+        /// Registers a glycan database that ships in GlycoTestData with the global path list that
+        /// GlycoSearchEngine resolves against.
+        /// <para>
+        /// GlycoSearchEngine looks a database up as
+        /// <c>GlobalVariables.NGlycanDatabasePaths.First(p =&gt; Path.GetFileName(p) == name)</c>, so whatever
+        /// is registered here has to be a path that actually resolves. Start-up only registers the contents
+        /// of Glycan_Mods, which does not include the GlycoTestData databases, so a bare file name added
+        /// here becomes the only match for those and is then resolved relative to the working directory.
+        /// That fails, and because GlobalVariables is static and never reset between fixtures it fails in
+        /// whichever later test needs the database, not in the test that registered it.
+        /// </para>
+        /// </summary>
+        private static void RegisterGlycoTestDataGlycanDatabase(List<string> glycanDatabasePaths, string fileName)
+        {
+            if (glycanDatabasePaths.Any(p => Path.GetFileName(p) == fileName))
+            {
+                return;
+            }
+
+            glycanDatabasePaths.Add(Path.Combine(TestContext.CurrentContext.TestDirectory, "GlycoTestData", fileName));
+        }
+
         [Test]
         public void CreateGsm_WithWideProductTolerance_ScanInfo_p_IsCappedToOne() 
         {
@@ -30,8 +53,8 @@ namespace Test
             // ensure glycan DB paths used by GlycoSearchEngine ctor are registered (filenames must match ctor arguments)
             string oglycanPath = "OGlycan.gdb";
             string nglycanPath = "NGlycan_ForNoSearch.gdb";
-            if (!GlobalVariables.OGlycanDatabasePaths.Contains(oglycanPath)) GlobalVariables.OGlycanDatabasePaths.Add(oglycanPath);
-            if (!GlobalVariables.NGlycanDatabasePaths.Contains(nglycanPath)) GlobalVariables.NGlycanDatabasePaths.Add(nglycanPath);
+            RegisterGlycoTestDataGlycanDatabase(GlobalVariables.OGlycanDatabasePaths, oglycanPath);
+            RegisterGlycoTestDataGlycanDatabase(GlobalVariables.NGlycanDatabasePaths, nglycanPath);
 
             // Load the test MGF file and get MS2 scans
             string spectraFile = Path.Combine(TestContext.CurrentContext.TestDirectory, @"GlycoTestData\2019_09_16_StcEmix_35trig_EThcD25_rep1_9906.mgf");
@@ -308,15 +331,8 @@ namespace Test
                 // GlycoSearchEngine expects these DB names to exist in global path lists.
                 string oglycanPath = "OGlycan.gdb";
                 string nglycanPath = "NGlycan_ForNoSearch.gdb";
-                if (!GlobalVariables.OGlycanDatabasePaths.Contains(oglycanPath))
-                {
-                    GlobalVariables.OGlycanDatabasePaths.Add(oglycanPath);
-                }
-
-                if (!GlobalVariables.NGlycanDatabasePaths.Contains(nglycanPath))
-                {
-                    GlobalVariables.NGlycanDatabasePaths.Add(nglycanPath);
-                }
+                RegisterGlycoTestDataGlycanDatabase(GlobalVariables.OGlycanDatabasePaths, oglycanPath);
+                RegisterGlycoTestDataGlycanDatabase(GlobalVariables.NGlycanDatabasePaths, nglycanPath);
 
                 // Use a calibratable mzML for calibration.
                 string rawFile = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\SmallCalibratible_Yeast.mzML");


### PR DESCRIPTION
Fixes #2697.

## Before / after

`dotnet test MetaMorpheus/Test/Test.csproj -c Debug --filter "FullyQualifiedName~Glyco"`, against `master` at `3b9f634ec`:

| | Passed | Failed |
|---|---|---|
| `master` | 86 | 5 |
| this branch | **91** | **0** |

The five — `NandO_GlycoSearch_onlyN`, `NandO_GlycoSearch_onlyO`, `NandO_GlycoSearch_onlyO_Run2`, `NandO_GlycoSearchIndividualFileFolderOutputTest`, `GlycoTest_WritingSummary` — each **passed when run individually** and failed only in the suite, which is what pointed at shared state rather than at the tests themselves.

## Cause

`GlycoSearchEngine` resolves a glycan database by file name against the global list ([`GlycoSearchEngine.cs:81`](https://github.com/smith-chem-wisc/MetaMorpheus/blob/3b9f634ec/MetaMorpheus/EngineLayer/GlycoSearch/GlycoSearchEngine.cs#L81)):

```csharp
GlobalVariables.NGlycanDatabasePaths.First(p => System.IO.Path.GetFileName(p) == _nglycanDatabase)
```

so entries have to be paths that actually resolve.

`GlobalVariables.SetUpGlobalVariables()` registers only the contents of `Glycan_Mods`, which does not include `NGlycan_ForNoSearch.gdb` — that ships in `GlycoTestData`. `TestNOGlyco.cs` registers it by full path, correctly. `GlycoSearchEngineTest.cs` registered it by **bare file name**, in two places.

`GlobalVariables` is static and is never reset between fixtures, and `GlycoSearchEngineTest` sorts ahead of `TestNOGlyco`, so the bare name went in first and became the only match. It then resolved against the working directory:

```
System.IO.FileNotFoundException : Could not find file
'...\Test\bin\Debug\net8.0-windows\NGlycan_ForNoSearch.gdb'.
```

`GlycoSearchEngineTest` itself never tripped on this — it constructs the engine with `GlycoSearchType.OGlycanSearch` and never dereferences the N-glycan entry. It only left the landmine.

The `Contains` guard could not stop the bad add either: it compares a bare file name against a list of full paths, so it never matches an existing entry.

## Change

One test file. Both registration sites now go through a helper that adds the full `GlycoTestData` path and guards on **file name** rather than exact string equality, matching what `TestNOGlyco.cs` and `TestOGlyco.cs` already do. No production code is touched, and no test's intent changes.

## Not addressed here, deliberately

Both are noted on #2697:

- `OGlycanDatabasePaths` / `NGlycanDatabasePaths` are mutable statics that tests append to and never clean up, so this class of ordering bug stays easy to reintroduce. A reset between fixtures, or a shared helper that owns registration, would close the class rather than this instance. That is a wider change and wants its own review.
- `TestNOGlyco.cs` adds the same path unguarded in four places, accumulating duplicates within a run. Harmless today because the path is correct.

Worth noting for anyone touching glyco search: four of the five tests this unblocks are `NandO_*`, i.e. `N_O_GlycanSearch` — the mode carrying the `// search both N-glycan and O-glycan is still not tested and build completely yet` comment at `GlycoSearchEngine.cs:76`. Its tests were red in any full-suite run, which is not a good state for a mode people are starting to build on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xa43sN3mQ96uLmpSNcWj9h
