### PR TITLE
fix(glyco): name the missing GraphCheck precondition instead of throwing NullReference

### DIFF
--- a/MetaMorpheus/EngineLayer/GlycoSearch/LocalizationGraph.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/LocalizationGraph.cs
@@ -137,7 +137,23 @@ namespace EngineLayer.GlycoSearch
             var unlocalFragments = GlycoPeptides.GetUnlocalFragment(products, modPos_index, localizationGraph.ModBox);
             var noLocalScore = CalculateCost(theScan, productTolerance, unlocalFragments);
             localizationGraph.NoLocalCost = noLocalScore;
-            localizationGraph.TotalScore = localizationGraph.array[modPos.Count - 1][localizationGraph.ChildModBoxes.Length - 1].maxCost + noLocalScore;
+
+            // The terminal node is only populated when the peptide's candidate-site motifs can actually
+            // accommodate every modification in the box. GlycoSearchEngine guarantees that by calling
+            // GraphCheck before building the graph, so this never fires in a search. It fires when the graph
+            // is driven directly -- from a test, or from new calling code -- without that precondition, and
+            // without this check the symptom is a bare NullReferenceException on the line below rather than
+            // anything that names the cause.
+            var terminalNode = localizationGraph.array[modPos.Count - 1][localizationGraph.ChildModBoxes.Length - 1];
+            if (terminalNode == null)
+            {
+                throw new MetaMorpheusException(
+                    $"Localization graph has no reachable terminal node for a modification box of {localizationGraph.ModBox.NumberOfMods} " +
+                    $"modification(s) over {modPos.Count} candidate site(s). The candidate-site motifs cannot accommodate the box; " +
+                    "callers must screen with GlycoSearchEngine.GraphCheck before localizing.");
+            }
+
+            localizationGraph.TotalScore = terminalNode.maxCost + noLocalScore;
         }
 
         /// <summary>

--- a/MetaMorpheus/Test/TestOGlyco.cs
+++ b/MetaMorpheus/Test/TestOGlyco.cs
@@ -43,6 +43,39 @@ namespace Test
             Assert.That(OGlycanBoxes.Count(), Is.EqualTo(2924));
         }
 
+        /// <summary>
+        /// A peptide whose candidate sites cannot accommodate every modification in the box leaves the
+        /// graph's terminal node unreachable. GlycoSearchEngine screens that out with GraphCheck, so this
+        /// only arises when the graph is driven directly, and it should say so rather than throwing a bare
+        /// NullReferenceException.
+        /// </summary>
+        [Test]
+        public static void OGlycoTest_LocalizeOGlycan_TooFewSitesForBox_ThrowsDescriptive()
+        {
+            // One candidate site, a box carrying two glycans: the terminal node can never be reached.
+            var glycanBox = OGlycanBoxes.First(p => p.NumberOfMods == 2);
+            var childBoxes = GlycanBox.BuildChildOGlycanBoxes(glycanBox.NumberOfMods, glycanBox.ModIds).ToArray();
+
+            var protein = new Protein("AAASAAAK", "onesite");
+            var peptide = protein.Digest(new DigestionParams(), new List<Modification>(), new List<Modification>()).First();
+            var products = new List<Product>();
+            peptide.Fragment(DissociationType.ETD, FragmentationTerminus.Both, products);
+
+            var modPos = GlycoSpectralMatch.GetPossibleModSites(peptide, new string[] { "S", "T" });
+            Assert.That(modPos.Count, Is.EqualTo(1), "Test peptide should offer exactly one candidate site.");
+
+            var commonParameters = new CommonParameters(dissociationType: DissociationType.ETD, trimMsMsPeaks: false);
+            string spectraFile = Path.Combine(TestContext.CurrentContext.TestDirectory, @"GlycoTestData\2019_09_16_StcEmix_35trig_EThcD25_rep1_9906.mgf");
+            var file = new MyFileManager(true).LoadFile(spectraFile, commonParameters);
+            var scan = MetaMorpheusTask.GetMs2Scans(file, spectraFile, commonParameters).First();
+
+            var localizationGraph = new LocalizationGraph(modPos, glycanBox, childBoxes, -1);
+
+            var exception = Assert.Throws<MetaMorpheusException>(() =>
+                LocalizationGraph.LocalizeOGlycan(localizationGraph, scan, commonParameters.ProductMassTolerance, products));
+            Assert.That(exception.Message, Does.Contain("GraphCheck"));
+        }
+
         [Test]
         public static void GlycoTest_GlycanLoading()
         {


### PR DESCRIPTION
## The problem

`LocalizationGraph.LocalizeOGlycan` finishes by reading the graph's terminal node:

https://github.com/smith-chem-wisc/MetaMorpheus/blob/3b9f634ec/MetaMorpheus/EngineLayer/GlycoSearch/LocalizationGraph.cs#L140

```csharp
localizationGraph.TotalScore = localizationGraph.array[modPos.Count - 1][localizationGraph.ChildModBoxes.Length - 1].maxCost + noLocalScore;
```

That node is only populated when the peptide's candidate-site motifs can actually accommodate every modification in the box. `GlycoSearchEngine` guarantees it by screening with `GraphCheck` before building the graph, so **in a search this is always safe and this PR changes nothing.**

It is not safe when the graph is driven directly. A peptide offering one candidate site against a two-glycan box leaves the terminal node null, and the symptom is a bare `NullReferenceException` pointing at an array index — nothing that names the missing precondition:

```
System.NullReferenceException : Object reference not set to an instance of an object.
   at EngineLayer.GlycoSearch.LocalizationGraph.LocalizeOGlycan(...) in LocalizationGraph.cs:line 140
```

I hit this writing a harness that builds localization graphs outside the engine, and it cost real time to trace back to the unstated `GraphCheck` requirement. `LocalizationGraph` is otherwise pleasantly standalone — its unit tests already construct graphs by hand — so directly-driven use is a reasonable thing to do and likely to recur.

## The change

Read the terminal node once, and if it is null throw `MetaMorpheusException` naming the box size, the candidate-site count, and the precondition:

> Localization graph has no reachable terminal node for a modification box of 2 modification(s) over 1 candidate site(s). The candidate-site motifs cannot accommodate the box; callers must screen with `GlycoSearchEngine.GraphCheck` before localizing.

Twelve lines including the comment, all after the scoring work. No behavioural change on any input that reaches this line today.

`MetaMorpheusException` is the repo's fault type here rather than an `ArgumentException` because it is what `EngineCrashed` already reports on for engine-layer faults.

## Test

`OGlycoTest_LocalizeOGlycan_TooFewSitesForBox_ThrowsDescriptive` — one candidate site against a two-glycan box, asserting `MetaMorpheusException` and that the message names `GraphCheck`. Fails with `NullReferenceException` before this change.

## Verification

Against `master` at `3b9f634ec`, `--filter "FullyQualifiedName~Glyco"`:

| | Passed | Failed |
|---|---|---|
| `master` | 86 | 5 |
| this branch | **87** | 5 |

Same five failures, which are pre-existing on `master` and unrelated — they are the shared-state ordering bug fixed by #2698.

## Alternative considered

Returning a zero `TotalScore` instead of throwing. Rejected: an unreachable terminal node means the caller asked for something structurally impossible, and silently scoring it zero would let a mis-specified graph flow into results looking merely unconvincing rather than invalid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xa43sN3mQ96uLmpSNcWj9h
