### PR TITLE
Build CMD, EngineLayer and TaskLayer architecture-neutral so the CLI runs on arm64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,9 +5,15 @@ name: Build
 
 on:
   push:
-    branches: [ "master" ] 
+    branches: [ "master" ]
   pull_request:
     branches: [ "master" ]
+
+# Mirrors InstallRunAndArtifact.yml so the SDK version and target framework are declared in one place
+# per workflow rather than repeated inline.
+env:
+  DOTNET_VERSION: 8.0.204
+  DOTNET_FRAMEWORK: net8.0
 
 jobs:
   build:
@@ -30,8 +36,46 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 8.0.204
+          dotnet-version: ${{ env.DOTNET_VERSION }}
       - name: Restore dependencies
         run: dotnet restore ./MetaMorpheus/MetaMorpheus.sln
       - name: Build
         run: dotnet build --no-restore ./MetaMorpheus/MetaMorpheus.sln --configuration ${{ matrix.configuration }}
+
+      # Guards issues #2503/#2504. An assembly built with PlatformTarget=x64 has AMD64 in its PE header and
+      # an arm64 .NET runtime refuses to load it. Building on an arm64 host does NOT catch this - cross
+      # compiling an x64-stamped IL assembly is legal and the stamp only bites at load time - so assert on
+      # the header directly. Architecture-neutral IL reads as "PE32 ... Intel 80386"; x64-stamped reads as
+      # "PE32+ ... x86-64". Runs on the Unix legs only, where `file` is available; IL is host-independent,
+      # so checking on one platform is sufficient.
+      - name: Assert CLI assemblies are architecture-neutral
+        if: runner.os != 'Windows'
+        run: |
+          set -euo pipefail
+          status=0
+          for project in CMD EngineLayer TaskLayer; do
+            asm="$project/bin/Release/${{ env.DOTNET_FRAMEWORK }}/$project.dll"
+            path="./MetaMorpheus/$asm"
+            if [ ! -f "$path" ]; then
+              echo "::error::expected assembly not found: $path"
+              status=1
+              continue
+            fi
+            desc=$(file -b "$path")
+            if echo "$desc" | grep -q 'x86-64'; then
+              echo "::error file=$asm::architecture-specific assembly ($desc). Remove PlatformTarget from this project - an x64 stamp cannot be loaded on arm64 (issues #2503, #2504). Note PlatformTarget must be left unset rather than set to AnyCPU, which Microsoft.ML rejects at build time."
+              status=1
+            else
+              echo "ok: $asm -> $desc"
+            fi
+          done
+          exit $status
+
+      # Non-blocking for now: this still fails on 'Omics, Version=...' because the mzLib package ships
+      # x64-stamped assemblies too (see smith-chem-wisc/mzLib#1127). Once an architecture-neutral mzLib
+      # release is consumed, drop continue-on-error so arm64 load regressions become a hard failure.
+      # TODO(#2503): make this step required after the mzLib bump lands.
+      - name: Smoke test on arm64 (non-blocking until mzLib ships architecture-neutral)
+        if: matrix.os == 'macos-latest'
+        continue-on-error: true
+        run: dotnet ./MetaMorpheus/CMD/bin/Release/${{ env.DOTNET_FRAMEWORK }}/CMD.dll --test -o "${{ runner.temp }}/arm64-smoke"

--- a/MetaMorpheus/CMD/CMD.csproj
+++ b/MetaMorpheus/CMD/CMD.csproj
@@ -10,13 +10,14 @@
     <ApplicationIcon></ApplicationIcon>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
+  <!-- PlatformTarget is deliberately left unset so the assembly is architecture-neutral (MSIL) and can be
+       loaded by an arm64 .NET runtime as well as an x64 one. Setting it to x64 stamps AMD64 into the PE
+       header, and CoreCLR on Apple Silicon then refuses the assembly with
+       "FileLoadException: Could not load file or assembly 'CMD'" (issues #2503, #2504).
+       Note that Microsoft.ML's _CheckForUnsupportedPlatformTarget guard rejects an explicit 'AnyCPU' but
+       explicitly permits an empty PlatformTarget for portable .NET Core apps, so this must stay unset
+       rather than being changed to AnyCPU. On .NET Core an architecture-neutral app still runs 64-bit on a
+       64-bit runtime, so nothing is lost on x64. -->
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />

--- a/MetaMorpheus/EngineLayer/EngineLayer.csproj
+++ b/MetaMorpheus/EngineLayer/EngineLayer.csproj
@@ -8,13 +8,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
+  <!-- Left architecture-neutral (no PlatformTarget) so the CLI can run on arm64; see CMD.csproj. -->
 
   <ItemGroup>
     <None Remove="Mods\RnaMods.txt" />

--- a/MetaMorpheus/TaskLayer/TaskLayer.csproj
+++ b/MetaMorpheus/TaskLayer/TaskLayer.csproj
@@ -7,13 +7,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
+  <!-- Left architecture-neutral (no PlatformTarget) so the CLI can run on arm64; see CMD.csproj. -->
 
   <ItemGroup>
     <PackageReference Include="MathNet.Numerics" Version="5.0.0" />


### PR DESCRIPTION
🤖 Addresses the MetaMorpheus half of #2503 and #2504. Both issues report the same error, on Apple Silicon:

```
System.IO.FileLoadException: Could not load file or assembly
'CMD, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null'.
```

## Root cause

`CMD`, `EngineLayer` and `TaskLayer` each set `<PlatformTarget>x64</PlatformTarget>`. That stamps AMD64 into the assembly's PE header, and CoreCLR on arm64 refuses to load such an assembly — the loader surfaces it as the `FileLoadException` above.

Reproduced by running the shipped `MetaMorpheus_CommandLine` release under a native arm64 .NET 8 runtime on an M-series Mac, giving the reporters' error verbatim. Confirmed to be architecture rather than versioning: the same assembly loads under an x64 runtime and fails under arm64, while `AssemblyName.GetAssemblyName` reports the expected version in both cases.

`file` makes the difference visible:

| | header |
|---|---|
| `PlatformTarget=x64` | `PE32+ executable (DLL) x86-64 Mono/.Net assembly` |
| `PlatformTarget` unset | `PE32 executable (DLL) Intel 80386 Mono/.Net assembly` (MSIL, architecture-neutral) |

## The change

Remove `PlatformTarget` from those three projects.

Two things worth knowing for review:

- **It must be left unset, not set to `AnyCPU`.** `Microsoft.ML`'s `_CheckForUnsupportedPlatformTarget` target errors on any explicit `PlatformTarget` that isn't `x64`/`x86`, but deliberately exempts an *empty* `PlatformTarget` for portable .NET Core apps. Setting `AnyCPU` fails the build with "Microsoft.ML currently supports 'x64' and 'x86' processor architectures".
- **x64 users are unaffected.** On .NET Core an architecture-neutral app still runs 64-bit on a 64-bit runtime. Verified by running the resulting build under an x64 runtime.

`GUI` and `Test` still set `PlatformTarget=x64` and are deliberately left alone — they are Windows-only and feed the x64 WiX installer. `GuiFunctions` sets it for `Release` only (there is no `Debug` group), and is likewise untouched. Note `GUI/GUI_h05aw1sq_wpftmp.csproj` is an accidentally-committed WPF temp project that also sets x64; pre-existing and out of scope here, but it will show up if you grep to verify the above.

## This is necessary but not sufficient on its own

The mzLib NuGet package also ships x64-stamped assemblies, because `mzLib.nuspec` packages them out of `bin/x64/Release/`. With only this change, an arm64 run gets past `CMD` and into MetaMorpheus code, then fails on `Omics, Version=1.0.583.0` with the same error shape.

To confirm the diagnosis is complete, I rebuilt mzLib's assemblies architecture-neutral locally and dropped them in. On native arm64 that combination gives:

- `CMD.dll --test` completes the full Calibration → GPTMD → Search pipeline, exit code 0, 89 target PSMs and 47 protein groups at 1% FDR
- the conda recipe's own smoke test, `metamorpheus -g -o .`, succeeds

So closing #2503/#2504 fully also needs an mzLib release built architecture-neutral, and then an `osx-arm64` build in the conda-forge feedstock (which currently has none, for this reason).

Note the remaining x64 files in a published output — `baf2sql_c`, `timsdata`, `isodeclib`, `isogenmass`, `msvcp110`, `svml_dispmd`, `vcomp110`, `ThermoFisher.CommonCore.MassPrecisionEstimator` — are *native* Windows/x64 libraries. They do not block startup or an mzML search, but Bruker/Thermo/IsoDec paths specifically would still not work on arm64.

## Verification

- `dotnet build MetaMorpheus/MetaMorpheus.sln -c UbuntuMac -p:EnableWindowsTargeting=true` — succeeds, 0 errors
- `dotnet publish MetaMorpheus/CMD/CMD.csproj -c Release` — produces `PE32` MSIL assemblies with no command-line override
- resulting build runs correctly under both an x64 and an arm64 .NET 8 runtime

**CI coverage (corrected).** An earlier version of this description claimed existing CI would cover the change. It would not, and that is why the bug survived: `build.yml`'s `macos-latest` leg is arm64 and is green *today* with `PlatformTarget=x64` in place, because it only runs `dotnet build` — cross-compiling an x64-stamped IL assembly on an arm64 host is legal, and the stamp only bites at load time. Every job that executes MetaMorpheus is `windows-latest`.

So this PR adds two steps to `build.yml`:

- **`Assert CLI assemblies are architecture-neutral`** — required, green today. Reads the PE header of the three assemblies via `file` on the Unix legs and fails if any is `x86-64`, naming the project. Guards the regression class without depending on the mzLib fix. Verified in both directions.
- **`Smoke test on arm64`** — executes `CMD.dll --test` on the macos leg, `continue-on-error: true` with a `TODO(#2503)` to become required once an architecture-neutral mzLib is consumed.

The Windows test suite has not been run locally for this change (it needs `Microsoft.WindowsDesktop.App`), but `Test.csproj` keeps `PlatformTarget=x64` and its Thermo `.raw` fixtures are exercised on `windows-latest`, so CI covers the mixed x64-host/neutral-dependency combination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
