### PR TITLE
mzLib 1.0.584: ETD and ECD no longer produce y ions

### DIFF
--- a/MetaMorpheus/CMD/CMD.csproj
+++ b/MetaMorpheus/CMD/CMD.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.583" />
+    <PackageReference Include="mzLib" Version="1.0.584" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />
     <PackageReference Include="System.Data.SQLite" Version="1.0.118" />

--- a/MetaMorpheus/EngineLayer/EngineLayer.csproj
+++ b/MetaMorpheus/EngineLayer/EngineLayer.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.583" />
+    <PackageReference Include="mzLib" Version="1.0.584" />
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />

--- a/MetaMorpheus/EngineLayer/GlycoSearch/GlycoPeptides.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/GlycoPeptides.cs
@@ -379,47 +379,6 @@ namespace EngineLayer.GlycoSearch
 
 
         /// <summary>
-        /// Generate the new fragment list, we add the glycan mass to the c ions and z ions from the peptide fragment list
-        /// </summary>
-        /// <param name="products"></param>
-        /// <param name="keyValuePair"></param>
-        /// <param name="OGlycanBoxes"></param>
-        /// <param name="FragmentBinsPerDalton"></param>
-        /// <returns></returns>
-        public static int[] GetFragmentHash(List<Product> products, Tuple<int, int[]> keyValuePair, GlycanBox[] OGlycanBoxes, int FragmentBinsPerDalton)
-        {
-            double[] newFragments = products.OrderBy(p=>p.ProductType).ThenBy(p=>p.FragmentNumber).Select(p => p.NeutralMass).ToArray(); // store the fragment mass in the order of c1, c2, c3, y1, y2, y3, z1, z2, z3
-            var len = products.Count / 3;
-            if (keyValuePair.Item2!=null)
-            {
-                for (int i = 0; i < keyValuePair.Item2.Length; i++) // we want to add the glycan mass to the c ions and z ions that contain the glycan.
-                {                                                   // y ions didn't change in EThcD for O-glyco, so we just need to deal with c ions and z ions.
-                    var j = keyValuePair.Item2[i];
-                    while (j <= len + 1) // for c ions
-                    {
-                        newFragments[j - 2] += (double)GlycanBox.GlobalOGlycans[OGlycanBoxes[keyValuePair.Item1].ModIds[i]].Mass/1E5;
-                        j++;
-                    }
-                    j = keyValuePair.Item2[i]; // reset the j to the position of the glycan
-                    while (j >= 3)             // for z ions
-                    {
-                        newFragments[len * 3 - j + 2] += (double)GlycanBox.GlobalOGlycans[OGlycanBoxes[keyValuePair.Item1].ModIds[i]].Mass/1E5;
-                        j--;
-                    }
-                }
-            }
-
-
-            int[] fragmentHash = new int[products.Count]; // store the fragment mass in the order of c1, c2, c3, y1, y2, y3, z1, z2, z3 and with the umit of FragmentBinsPerDalton
-            for (int i = 0; i < products.Count; i++)
-            {
-                fragmentHash[i] = (int)Math.Round(newFragments[i] * FragmentBinsPerDalton);
-            }
-            return fragmentHash;
-        }
-
- 
-        /// <summary>
         /// Generate the fragment list with the specific childBox located on specific modPos. At here, the ModInd is the index for modPos. Not used in the current version.
         /// </summary>
         /// <param name="products"></param>

--- a/MetaMorpheus/GUI/GUI.csproj
+++ b/MetaMorpheus/GUI/GUI.csproj
@@ -63,7 +63,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.583" />
+    <PackageReference Include="mzLib" Version="1.0.584" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0" />

--- a/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
+++ b/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="itext7" Version="8.0.5" />
     <PackageReference Include="itext7.bouncy-castle-adapter" Version="8.0.5" />
-    <PackageReference Include="mzLib" Version="1.0.583" />
+    <PackageReference Include="mzLib" Version="1.0.584" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.0.0" />
     <PackageReference Include="Svg" Version="3.4.7" />
   </ItemGroup>

--- a/MetaMorpheus/TaskLayer/TaskLayer.csproj
+++ b/MetaMorpheus/TaskLayer/TaskLayer.csproj
@@ -21,7 +21,7 @@
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="Microsoft.NETCore.App" Version="2.2.8" />
-    <PackageReference Include="mzLib" Version="1.0.583" />
+    <PackageReference Include="mzLib" Version="1.0.584" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />

--- a/MetaMorpheus/Test/Test.csproj
+++ b/MetaMorpheus/Test/Test.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.583" />
+    <PackageReference Include="mzLib" Version="1.0.584" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />

--- a/MetaMorpheus/Test/TestNOGlyco.cs
+++ b/MetaMorpheus/Test/TestNOGlyco.cs
@@ -205,7 +205,7 @@ namespace Test
             Assert.That(errors2.Count == 0);// if we cannot find the file, we will get an error message
             Assert.That(Psms.Count == 1);
             Assert.That(Psms.First().FullSequence == "AAT[O-linked glycosylation:N1 on T]VGSLAGQPLQER");
-            Assert.That(Psms.First().Score, Is.EqualTo(23.2).Within(0.1));
+            Assert.That(Psms.First().Score, Is.EqualTo(20.2).Within(0.1));
             Directory.Delete(outputFolder, true);
         }
 

--- a/MetaMorpheus/Test/TestOGlyco.cs
+++ b/MetaMorpheus/Test/TestOGlyco.cs
@@ -395,7 +395,7 @@ namespace Test
             var fragments_etd = GlycoPeptides.OGlyGetTheoreticalFragments(DissociationType.ETD, new List<ProductType>(), peptide, peptideWithMod);
 
 
-            Assert.That(fragments_etd.Count == 22);
+            Assert.That(fragments_etd.Count, Is.EqualTo(15)); // 7 c + 8 zDot (incl. the full-length zDot8); ETD no longer produces a y series
             Assert.That(fragments_etd.Last().Annotation == "zDot8");
             Assert.That(fragments_etd.Last().NeutralMass > 1824);
 
@@ -407,7 +407,7 @@ namespace Test
         }
 
         [Test]
-        public static void OGlycoTest_FragmentIonsHash()
+        public static void OGlycoTest_ModifiedFragmentsIncludeNeutralLosses()
         {
             //Get glycanBox
             var glycanBox = OGlycanBoxes[22]; // GlycanBox : [N1A1 on T], [N1 on S]
@@ -425,30 +425,7 @@ namespace Test
             var fragmentsMod_hcd = new List<Product>();
                 peptideWithMod.Fragment(DissociationType.HCD, FragmentationTerminus.Both, fragmentsMod_hcd); 
             Assert.That(fragments_hcd.Count() == 20);
-            Assert.That(fragmentsMod_hcd.Count() == 61); //The Fragments also contain neutral loss ions. 
-
-            var frag_ments_etd = new List<Product>();
-                peptide.Fragment(DissociationType.ETD, FragmentationTerminus.Both, frag_ments_etd);
-            var fragmentsMod_etd = new List<Product>();
-                peptideWithMod.Fragment(DissociationType.ETD, FragmentationTerminus.Both, fragmentsMod_etd);
-
-            //Tuple<int, int[]> keyValuePair represents: <glycanBoxId, glycanModPositions> 
-            Tuple<int, int[]> keyValuePairs = new Tuple<int, int[]>(22, modPos.ToArray());
-
-            var fragments_etd_origin = GlycoPeptides.GetFragmentHash(frag_ments_etd, new Tuple<int, int[]>(0, null), OGlycanBoxes, 1000);
-
-            var fragmentsHash_etd = GlycoPeptides.GetFragmentHash(frag_ments_etd, keyValuePairs, OGlycanBoxes, 1000);
-
-            var fragmentsMod_etd_origin = GlycoPeptides.GetFragmentHash(fragmentsMod_etd, new Tuple<int, int[]>(0, null), OGlycanBoxes, 1000);
-
-            var overlap = fragmentsHash_etd.Intersect(fragments_etd_origin).Count();
-
-            Assert.That(overlap == 14);
-
-            var overlap2 = fragmentsHash_etd.Intersect(fragmentsMod_etd_origin).Count();
-
-            //ETD didn't change y ions.
-            Assert.That(overlap2 == 23);
+            Assert.That(fragmentsMod_hcd.Count() == 61); //The Fragments also contain neutral loss ions.
         }
 
         [Test]

--- a/MetaMorpheus/Test/XLTest.cs
+++ b/MetaMorpheus/Test/XLTest.cs
@@ -1494,9 +1494,9 @@ namespace Test
 
             // test child scan (ETD)
             Assert.That(csm.ChildMatchedFragmentIons.First().Key == 3);
-            Assert.That(csm.ChildMatchedFragmentIons.First().Value.Count == 21);
+            Assert.That(csm.ChildMatchedFragmentIons.First().Value.Count, Is.EqualTo(15));
             Assert.That(csm.BetaPeptide.ChildMatchedFragmentIons.First().Key == 3);
-            Assert.That(csm.BetaPeptide.ChildMatchedFragmentIons.First().Value.Count == 25);
+            Assert.That(csm.BetaPeptide.ChildMatchedFragmentIons.First().Value.Count, Is.EqualTo(18));
 
             // write results to TSV
             csm.SetFdrValues(1, 0, 0, 0, 0, 0, 0, 0);
@@ -1507,11 +1507,11 @@ namespace Test
 
             Assert.That(psmFromTsv.ChildScanMatchedIons.Count, Is.EqualTo(1));
             Assert.That(psmFromTsv.ChildScanMatchedIons.First().Key, Is.EqualTo(3));
-            Assert.That(psmFromTsv.ChildScanMatchedIons.First().Value.Count, Is.EqualTo(21));
+            Assert.That(psmFromTsv.ChildScanMatchedIons.First().Value.Count, Is.EqualTo(15));
 
             Assert.That(psmFromTsv.BetaPeptideChildScanMatchedIons.Count, Is.EqualTo(1));
             Assert.That(psmFromTsv.BetaPeptideChildScanMatchedIons.First().Key, Is.EqualTo(3));
-            Assert.That(psmFromTsv.BetaPeptideChildScanMatchedIons.First().Value.Count, Is.EqualTo(25));
+            Assert.That(psmFromTsv.BetaPeptideChildScanMatchedIons.First().Value.Count, Is.EqualTo(18));
             // Race condition causes the order of accessions to differ 
             //Assert.That(psmFromTsv.BetaPeptideProteinAccession, Is.EqualTo("BSA|BSA2"));
             Assert.That(psmFromTsv.BetaPeptideProteinAccession, Does.Contain("BSA"));


### PR DESCRIPTION
Consumes [mzLib #1114](https://github.com/smith-chem-wisc/mzLib/pull/1114), which removed `ProductType.y` from the ETD and ECD product sets (they are now exactly `{ c, zDot }`) and dropped the ETD/ECD arm of `GetWaterAndAmmoniaLossProductTypesFromDissociation`. `EThcD` is deliberately unchanged.

That change turns four MetaMorpheus tests red in mzLib's `integration` job, which builds MM master against mzLib master. This PR bumps the pin and fixes them.

## Dependency — resolved

This PR previously could not go green on its own: it pins mzLib 1.0.584, and the newest published package was 1.0.583, which sat 9 commits behind #1114. Every CI job failed at restore with `NU1102: Unable to find package mzLib with version (>= 1.0.584)` — nothing in the diff was ever the cause.

**mzLib 1.0.584 has now been released** from `smith-chem-wisc/mzLib@master` (`e3220d6a`), which carries #1114 along with #1127 (arm64 packaging), #1126 (UniProt retrieval) and #1125 (FlashLFQ scratch dir). MM's arm64 counterpart #2701 is already on master, so the pin is consistent in both directions.

## Verification

Before the release was cut, the exact 1.0.584 payload was built and packed locally from `e3220d6a` and MetaMorpheus was restored, built and tested against it, with this branch merged up to master:

- full solution builds `Release`, 0 errors;
- full suite under CI's own filter (`Category!=ExternalService`): **1723 passed, 1 skipped, 0 failed** (1724 total);
- the glyco and crosslink fixtures this PR re-baselines (`TestOGlyco`, `TestNOGlyco`, `XLTest`, `GlycoSearchEngineTest`): 100/100 passed.

Master has since merged three glyco fixes (#2696 localization-scan selection, #2698 glycan-database paths, #2699 precondition message). Those are merged in here and the re-baselined numbers below still hold unchanged against them.

## Re-baselined expectations

Originally measured against a local mzLib build of `f6b0f0d1` (#1114's merge commit, chosen deliberately *before* #1127 so the numbers isolate the y-ion removal), and re-confirmed against the released 1.0.584. The search score reproduces the CI failure to 15 digits (`20.207304008910487`).

| test | assertion | was | now |
|---|---|---|---|
| `NandO_GlycoSearch_onlyO_Run2` | `Psms.First().Score` | 23.2 | **20.2** |
| `OGlycoTest_FragmentIons2` | `fragments_etd.Count` | 22 | **15** |
| `TestMixedMs2Ms2` | `ChildMatchedFragmentIons` | 21 | **15** |
| `TestMixedMs2Ms2` | `BetaPeptide.ChildMatchedFragmentIons` | 25 | **18** |
| `TestMixedMs2Ms2` | `ChildScanMatchedIons` (TSV round-trip) | 21 | **15** |
| `TestMixedMs2Ms2` | `BetaPeptideChildScanMatchedIons` (TSV round-trip) | 25 | **18** |

Only three of these were in the reported failure list — NUnit stops a test at its first failed assertion, so the rest were queued behind them. `TestMixedMs2Ms2` asserts its child-scan counts twice, once on the CSM and again after the TSV round-trip; both copies had to move.

`OGlycoTest_FragmentIons2`'s 15 is the one number that is analytically derivable rather than empirical: `TVYLGASK` is 8 residues, giving 7 c + 8 zDot (the extra being the full-length z•), and the 7 y ions are gone.

The direction of every change is correct rather than regressive — ETD genuinely does not produce y ions, so the glyco and crosslink ETD paths had been matching and scoring ions that cannot exist. These are re-baselines, not bug reports.

## Removed: `GlycoPeptides.GetFragmentHash` and `OGlycoTest_FragmentIonsHash`

`GetFragmentHash` had a latent bug that #1114 exposed:

```csharp
var len = products.Count / 3;   // "ETD emits c, y and z-dot"
...
newFragments[len * 3 - j + 2] += glycanMass;
```

`len` is meant to be *ions per series*, and the `/ 3` hardcoded the assumption that ETD emits three of them. With `{ c, zDot }` a 20-product ETD set gives `len = 6` instead of 10, which **skips the c-ion loop entirely** (its guard is `while (j <= len + 1)`, and for a glycan at position 9, `9 <= 7` is false, so the glycan mass is never added to any c ion) and **writes the z-ion shift into the wrong slots**, indexing as though the array were 30 long when it is 20. Its test's `overlap == 14` / `overlap2 == 23` would therefore have been re-baselined onto meaningless output.

Rather than repair arithmetic nothing depends on, both are deleted: **`GetFragmentHash` has no production callers.** Its only references anywhere in the repo were the three calls inside its own test. The Release build passes with the method gone, which confirms it.

The two HCD assertions in that test (`fragments_hcd.Count() == 20`, `fragmentsMod_hcd.Count() == 61`) are *not* about the hash — they pin that the default `Fragment` method emits glycan neutral-loss ions for an O-glycopeptide, which is still true and still worth covering. They are kept, and the trimmed test is renamed `OGlycoTest_ModifiedFragmentsIncludeNeutralLosses` to match what it now actually asserts.

## A comment that became false

```csharp
//ETD didn't change y ions.
```

That comment sat above one of the deleted hash assertions and was a claim about ETD fragmentation that #1114 falsifies. It went with the deletion rather than being left standing.

## Assertion style

The counts above were written `Assert.That(x == n)`, whose failure message is `Expected: True / But was: False` — it does not report the actual value, which is precisely what you need when a number moves upstream. The ones whose numbers this PR is already changing are converted to `Assert.That(x, Is.EqualTo(n))`. Scoped strictly to lines the diff already owns; no file-wide sweep.

## Not addressed (follow-ups)

- **The N-glyco ETD path also loses its y ions** (`GlycoSearchEngine.cs:547-549`) but no test exercises N-glyco under ETD — the N-glyco tomls are all EThcD/HCD. Silent behaviour change with no coverage.
- `GlycoPeptides.cs:234` and `:251` filter `ProductType.y` out of the ETD product list. Those are now no-ops. Harmless, and left in place so the intent survives if y ever returns.
- `CrosslinkSearchEngine.DissociationTypeGenerateSameTypeOfIons` treats ETD and ECD as equivalent. That stays correct only because #1114 changed both rows identically — worth knowing if they ever diverge.

