### PR TITLE
Fix(glyco): solving the bug for the loss of GlycanIon when N-glycan is used as a variable modification.

### DIFF
--- a/MetaMorpheus/EngineLayer/GlycoSearch/Glycan.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/Glycan.cs
@@ -136,6 +136,13 @@ namespace EngineLayer
         /// List of glycan fragment ions.
         /// </summary>
         public List<GlycanIon> Ions { get; set; }
+
+        /// <summary>
+        /// True when this glycan's Y-ion fragments have been generated. Glycans loaded for the
+        /// fixed/variable-mod list (GlobalVariables.LoadGlycans, ToGenerateIons: false) have none.
+        /// </summary>
+        public bool HasIons => Ions != null && Ions.Count > 0;
+
         /// <summary>
         /// Indicates whether the glycan is a decoy.
         /// </summary>

--- a/MetaMorpheus/EngineLayer/GlycoSearch/GlycoSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/GlycoSearchEngine.cs
@@ -305,12 +305,18 @@ namespace EngineLayer.GlycoSearch
 
             var fragmentsForEachGlycoPeptide = GlycoPeptides.OGlyGetTheoreticalFragments(CommonParameters.DissociationType, CommonParameters.CustomIons, peptide, peptideWithMod);
 
-            // if the peptide contains N-glycan, we need to add the Y ion from N-glycan.
-            if (peptideWithMod.AllModsOneIsNterminus.Any(p=>p.Value.ModificationType == "N-linked glycosylation"))
+            // If the peptide contains N-glycan, we need to add the Y ion from N-glycan.
+            // At first, we only consider the mod is N-linked glycosylation and as a glycan object.
+            var nGlycans = peptideWithMod.AllModsOneIsNterminus.Values
+                .OfType<Glycan>()
+                .Where(g => g.ModificationType == "N-linked glycosylation");
+            foreach (var nGlycan in nGlycans) 
             {
-                Glycan nGlycan = peptideWithMod.AllModsOneIsNterminus.First(p =>
-                    p.Value.ModificationType == "N-linked glycosylation").Value as Glycan;
-                fragmentsForEachGlycoPeptide.AddRange(GlycoPeptides.GetGlycanYIons(theScan.PrecursorMass, nGlycan));
+                if (nGlycan.Ions != null) // guard against null Ions property
+                {
+                    fragmentsForEachGlycoPeptide.AddRange(GlycoPeptides.GetGlycanYIons(theScan.PrecursorMass, nGlycan));
+                }
+                // else: no ions → skip (dummy score); users should use NO-search for correct N-glycan ID
             }
 
             var matchedIons = MatchFragmentIons(theScan, fragmentsForEachGlycoPeptide, CommonParameters);

--- a/MetaMorpheus/EngineLayer/GlycoSearch/GlycoSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/GlycoSearchEngine.cs
@@ -310,7 +310,7 @@ namespace EngineLayer.GlycoSearch
             // excluded; correct N-glycan ID is the NO-search's job.
             var nGlycan = peptideWithMod.AllModsOneIsNterminus.Values
                 .OfType<Glycan>()
-                .FirstOrDefault(g => g.ModificationType == "N-linked glycosylation" && g.HasIons);
+                .FirstOrDefault(g => g.Type == GlycanType.N_glycan && g.HasIons);
             if (nGlycan != null)
             {
                 fragmentsForEachGlycoPeptide.AddRange(GlycoPeptides.GetGlycanYIons(theScan.PrecursorMass, nGlycan));

--- a/MetaMorpheus/EngineLayer/GlycoSearch/GlycoSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/GlycoSearchEngine.cs
@@ -305,18 +305,16 @@ namespace EngineLayer.GlycoSearch
 
             var fragmentsForEachGlycoPeptide = GlycoPeptides.OGlyGetTheoreticalFragments(CommonParameters.DissociationType, CommonParameters.CustomIons, peptide, peptideWithMod);
 
-            // If the peptide contains N-glycan, we need to add the Y ion from N-glycan.
-            // At first, we only consider the mod is N-linked glycosylation and as a glycan object.
-            var nGlycans = peptideWithMod.AllModsOneIsNterminus.Values
+            // Only Glycan-typed N-linked mods with generated Y ions contribute Y ions here.
+            // Non-Glycan annotations (DB/GPTMD) and mod-loaded glycans without ions are intentionally
+            // excluded; correct N-glycan ID is the NO-search's job.
+            var nGlycan = peptideWithMod.AllModsOneIsNterminus.Values
                 .OfType<Glycan>()
-                .Where(g => g.ModificationType == "N-linked glycosylation");
-            foreach (var nGlycan in nGlycans) 
+                .FirstOrDefault(g => g.ModificationType == "N-linked glycosylation" && g.HasIons);
+            // else: no ions → skip (dummy score); users should use NO-search for correct N-glycan ID
+            if (nGlycan != null)
             {
-                if (nGlycan.Ions != null) // guard against null Ions property
-                {
-                    fragmentsForEachGlycoPeptide.AddRange(GlycoPeptides.GetGlycanYIons(theScan.PrecursorMass, nGlycan));
-                }
-                // else: no ions → skip (dummy score); users should use NO-search for correct N-glycan ID
+                fragmentsForEachGlycoPeptide.AddRange(GlycoPeptides.GetGlycanYIons(theScan.PrecursorMass, nGlycan));
             }
 
             var matchedIons = MatchFragmentIons(theScan, fragmentsForEachGlycoPeptide, CommonParameters);

--- a/MetaMorpheus/EngineLayer/GlycoSearch/GlycoSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/GlycoSearchEngine.cs
@@ -311,7 +311,6 @@ namespace EngineLayer.GlycoSearch
             var nGlycan = peptideWithMod.AllModsOneIsNterminus.Values
                 .OfType<Glycan>()
                 .FirstOrDefault(g => g.ModificationType == "N-linked glycosylation" && g.HasIons);
-            // else: no ions → skip (dummy score); users should use NO-search for correct N-glycan ID
             if (nGlycan != null)
             {
                 fragmentsForEachGlycoPeptide.AddRange(GlycoPeptides.GetGlycanYIons(theScan.PrecursorMass, nGlycan));

--- a/MetaMorpheus/Test/GlycoTestData/NGlycan_fakeN-glycan.gdb
+++ b/MetaMorpheus/Test/GlycoTestData/NGlycan_fakeN-glycan.gdb
@@ -1,0 +1,1 @@
+HexNAc(9)Hex(9)

--- a/MetaMorpheus/Test/Test.csproj
+++ b/MetaMorpheus/Test/Test.csproj
@@ -152,6 +152,9 @@
     <None Update="GlycoTestData\leukosialin.fasta">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="GlycoTestData\NGlycan_fakeN-glycan.gdb">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="GlycoTestData\NGlycan_ForNoSearch.gdb">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/MetaMorpheus/Test/TestNOGlyco.cs
+++ b/MetaMorpheus/Test/TestNOGlyco.cs
@@ -368,11 +368,13 @@ namespace Test
             Directory.CreateDirectory(outputFolder);
 
             string fakeNGlycanDbPath = null;
-            var nGlycanModsFromNGlycan_ForNoSearch = new List<(string, string)>
-        {
-            ("N-linked glycosylation", "N1 on Nxs"),
-            ("N-linked glycosylation", "N1 on Nxt"),
-    };
+            bool addedFakeDbPath = false;
+            var nGlycanModsUnderTest = new List<(string, string)>
+            {
+                ("N-linked glycosylation", "N1 on Nxs"),
+                ("N-linked glycosylation", "N1 on Nxt"),
+            };
+            var noMods = new List<(string, string)>();
 
             try
             {
@@ -387,26 +389,26 @@ namespace Test
                     if (!GlobalVariables.NGlycanDatabasePaths.Contains(fakeNGlycanDbPath))
                     {
                         GlobalVariables.NGlycanDatabasePaths.Add(fakeNGlycanDbPath);
+                        addedFakeDbPath = true;
                     }
                 }
-                Assert.That(nGlycanModsFromNGlycan_ForNoSearch.All(mod => GlobalVariables.AllModsKnown.Any(m => m.IdWithMotif == mod.Item2)), Is.True,
+                Assert.That(nGlycanModsUnderTest.All(mod => GlobalVariables.AllModsKnown.Any(m => m.IdWithMotif == mod.Item2)), Is.True,
                     "Test setup assumption failed: expected N-glycans mod not found in AllModsKnown.");
 
                 // Confirm the "N1" mods start with null Ions — the exact state that used to NRE in
                 // GetGlycanYIons. This makes the DoesNotThrow below a real regression check.
-                foreach (var (_, nGlycanIdWithMotif) in nGlycanModsFromNGlycan_ForNoSearch)
+                foreach (var (modType, idWithMotif) in nGlycanModsUnderTest)
                 {
-                    if (GlobalVariables.AllModsKnown.First(mod => mod.IdWithMotif == nGlycanIdWithMotif) is Glycan g)
-                    {
-                        Assert.That(g.Ions, Is.Null, $"Test setup assumption failed: expected Glycan {nGlycanIdWithMotif} to have null Ions before the search.");
-                    }
+                    var mod = GlobalVariables.AllModsKnown.Single(m => m.ModificationType == modType && m.IdWithMotif == idWithMotif);
+                    Assert.That(mod, Is.InstanceOf<Glycan>(), $"setup: {idWithMotif} is not a Glycan.");
+                    Assert.That(((Glycan)mod).Ions, Is.Null, $"setup: expected {idWithMotif} null Ions before search.");
                 }
 
                 var commonParameters = new CommonParameters(
                     dissociationType: DissociationType.HCD,
                     ms2childScanDissociationType: DissociationType.EThcD,
-                    listOfModsFixed: asFixedMod ? nGlycanModsFromNGlycan_ForNoSearch : null,
-                    listOfModsVariable: asFixedMod ? null : nGlycanModsFromNGlycan_ForNoSearch);
+                    listOfModsFixed: asFixedMod ? nGlycanModsUnderTest : noMods,
+                    listOfModsVariable: asFixedMod ? noMods : nGlycanModsUnderTest);
 
                 var glycoSearchTask = new GlycoSearchTask
                 {
@@ -425,11 +427,6 @@ namespace Test
 
                 // Before the fix, this call would throw a NullReferenceException from GetGlycanYIons
                 // once a peptide candidate carrying the N-glycan fixed/variable mod reached CreateGsm.
-                //Assert.DoesNotThrow(() =>
-                //{
-                //    new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("Task", glycoSearchTask) },
-                //        new List<string> { raw }, new List<DbForTask> { db }, outputFolder).Run();
-                //});
                 new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("Task", glycoSearchTask) },
                         new List<string> { raw }, new List<DbForTask> { db }, outputFolder).Run();
 
@@ -440,9 +437,8 @@ namespace Test
                 {
                     Directory.Delete(outputFolder, true);
                 }
-
-                if (fakeNGlycanDbPath != null) // only remove if it was added
-                    GlobalVariables.NGlycanDatabasePaths.Remove(fakeNGlycanDbPath);
+                // clean up the fake N-glycan database path from GlobalVariables if it was added
+                if (addedFakeDbPath) GlobalVariables.NGlycanDatabasePaths.Remove(fakeNGlycanDbPath);
             }
         }
     }

--- a/MetaMorpheus/Test/TestNOGlyco.cs
+++ b/MetaMorpheus/Test/TestNOGlyco.cs
@@ -396,7 +396,7 @@ namespace Test
                     "Test setup assumption failed: expected N-glycans mod not found in AllModsKnown.");
 
                 // Confirm the "N1" mods start with null Ions — the exact state that used to NRE in
-                // GetGlycanYIons. This makes the DoesNotThrow below a real regression check.
+                // GetGlycanYIons. This makes the unwrapped run below a real regression check.
                 foreach (var (modType, idWithMotif) in nGlycanModsUnderTest)
                 {
                     var mod = GlobalVariables.AllModsKnown.Single(m => m.ModificationType == modType && m.IdWithMotif == idWithMotif);

--- a/MetaMorpheus/Test/TestNOGlyco.cs
+++ b/MetaMorpheus/Test/TestNOGlyco.cs
@@ -360,9 +360,9 @@ namespace Test
             // here is a crash-free run; there is nothing to check on the results (the matched N/O
             // co-glycopeptides are FDR-filtered out anyway).
             //
-            // The pre-search assertion below confirms the "N1" mods start with null Ions — i.e. the
-            // exact state that used to trigger the crash — so DoesNotThrow is meaningfully exercising
-            // the fixed path, not a trivially-safe one.
+            // The pre-search assertion below confirms the "N1" mods start with null Ions — the exact
+            // state that used to trigger the crash — so the unwrapped run below is a real regression
+            // check: any thrown exception fails the test directly (and surfaces the real stack trace).
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory,
                 $@"TESTGlycoData_{(isNOSearch ? "NO" : "O")}With{(asFixedMod ? "Fixed" : "Var")}NMod");
             Directory.CreateDirectory(outputFolder);

--- a/MetaMorpheus/Test/TestNOGlyco.cs
+++ b/MetaMorpheus/Test/TestNOGlyco.cs
@@ -342,5 +342,108 @@ namespace Test
             Assert.That(site_case3[4] == "Nxt" && site_case3[6] == "T");
             Assert.That(site_case3[14] == "S");
         }
+
+        [Test]
+        [TestCase(true, false)]  // O-search, N-glycan as fixed mod
+        [TestCase(false, false)] // O-search, N-glycan as variable mod
+        [TestCase(true, true)]   // N_O-search, N-glycan as fixed mod
+        [TestCase(false, true)]  // N_O-search, N-glycan as variable mod
+        public static void GlycoSearch_WithNGlycanAsFixedOrVariableMod_DoesNotCrash(bool asFixedMod, bool isNOSearch)
+        {
+            // Integration smoke test: the search pipeline must complete WITHOUT CRASHING when an
+            // N-glycan is used as a fixed or variable modification and reaches GetGlycanYIons.
+            // This is the crash (NullReferenceException) this PR fixes.
+            //
+            // N-glycan-as-a-mod is not hydrated in this mode: if the glycan has no Y ions, the
+            // consumption site skips them (dummy score) rather than generating them. Users should
+            // use NO-search for correct N-glycan identification. So the only assertion that matters
+            // here is a crash-free run; there is nothing to check on the results (the matched N/O
+            // co-glycopeptides are FDR-filtered out anyway).
+            //
+            // The pre-search assertion below confirms the "N1" mods start with null Ions — i.e. the
+            // exact state that used to trigger the crash — so DoesNotThrow is meaningfully exercising
+            // the fixed path, not a trivially-safe one.
+            string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory,
+                $@"TESTGlycoData_{(isNOSearch ? "NO" : "O")}With{(asFixedMod ? "Fixed" : "Var")}NMod");
+            Directory.CreateDirectory(outputFolder);
+
+            string fakeNGlycanDbPath = null;
+            var nGlycanModsFromNGlycan_ForNoSearch = new List<(string, string)>
+        {
+            ("N-linked glycosylation", "N1 on Nxs"),
+            ("N-linked glycosylation", "N1 on Nxt"),
+    };
+
+            try
+            {
+                if (isNOSearch)
+                {
+                    // For the NO-search case, point the N-glycan database at a "fake" file with a single
+                    // unrealistic composition (HexNAc(9)Hex(9)) that the data won't match. This forces
+                    // any N-glycan to come from the "N1" mod, so candidates route through FindOGlycan ->
+                    // CreateGsm (the GetGlycanYIons path this test guards) instead of being explained by
+                    // the N-glycan search.
+                    fakeNGlycanDbPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "GlycoTestData", "NGlycan_fakeN-glycan.gdb");
+                    if (!GlobalVariables.NGlycanDatabasePaths.Contains(fakeNGlycanDbPath))
+                    {
+                        GlobalVariables.NGlycanDatabasePaths.Add(fakeNGlycanDbPath);
+                    }
+                }
+                Assert.That(nGlycanModsFromNGlycan_ForNoSearch.All(mod => GlobalVariables.AllModsKnown.Any(m => m.IdWithMotif == mod.Item2)), Is.True,
+                    "Test setup assumption failed: expected N-glycans mod not found in AllModsKnown.");
+
+                // Confirm the "N1" mods start with null Ions — the exact state that used to NRE in
+                // GetGlycanYIons. This makes the DoesNotThrow below a real regression check.
+                foreach (var (_, nGlycanIdWithMotif) in nGlycanModsFromNGlycan_ForNoSearch)
+                {
+                    if (GlobalVariables.AllModsKnown.First(mod => mod.IdWithMotif == nGlycanIdWithMotif) is Glycan g)
+                    {
+                        Assert.That(g.Ions, Is.Null, $"Test setup assumption failed: expected Glycan {nGlycanIdWithMotif} to have null Ions before the search.");
+                    }
+                }
+
+                var commonParameters = new CommonParameters(
+                    dissociationType: DissociationType.HCD,
+                    ms2childScanDissociationType: DissociationType.EThcD,
+                    listOfModsFixed: asFixedMod ? nGlycanModsFromNGlycan_ForNoSearch : null,
+                    listOfModsVariable: asFixedMod ? null : nGlycanModsFromNGlycan_ForNoSearch);
+
+                var glycoSearchTask = new GlycoSearchTask
+                {
+                    CommonParameters = commonParameters,
+                    _glycoSearchParameters = new GlycoSearchParameters
+                    {
+                        GlycoSearchType = isNOSearch ? GlycoSearchType.N_O_GlycanSearch : GlycoSearchType.OGlycanSearch,
+                        OGlycanDatabasefile = "OGlycan.gdb",
+                        NGlycanDatabasefile = isNOSearch ? "NGlycan_fakeN-glycan.gdb" : null,
+                        MaximumOGlycanAllowed = 1,
+                    }
+                };
+
+                DbForTask db = new(Path.Combine(TestContext.CurrentContext.TestDirectory, @"GlycoTestData/FiveMucinFasta.fasta"), false);
+                string raw = Path.Combine(TestContext.CurrentContext.TestDirectory, @"GlycoTestData/N_O_glycoWithFileSpecific/2019_09_16_StcEmix_35trig_EThcD25_rep1_4999_5500.mzML");
+
+                // Before the fix, this call would throw a NullReferenceException from GetGlycanYIons
+                // once a peptide candidate carrying the N-glycan fixed/variable mod reached CreateGsm.
+                //Assert.DoesNotThrow(() =>
+                //{
+                //    new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("Task", glycoSearchTask) },
+                //        new List<string> { raw }, new List<DbForTask> { db }, outputFolder).Run();
+                //});
+                new EverythingRunnerEngine(new List<(string, MetaMorpheusTask)> { ("Task", glycoSearchTask) },
+                        new List<string> { raw }, new List<DbForTask> { db }, outputFolder).Run();
+
+            }
+            finally
+            {
+                if (Directory.Exists(outputFolder)) // clean up the output folder after the test
+                {
+                    Directory.Delete(outputFolder, true);
+                }
+
+                if (fakeNGlycanDbPath != null) // only remove if it was added
+                    GlobalVariables.NGlycanDatabasePaths.Remove(fakeNGlycanDbPath);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Problem

Setting an N-glycan as a **fixed** or **variable** modification while running an O-glycan or N/O-glycan search caused a `NullReferenceException` in `GlycoPeptides.GetGlycanYIons`, called from `GlycoSearchEngine.CreateGsm`.

## Root Cause

N-glycans loaded into `GlobalVariables.AllModsKnown` (the known-modification list that populates fixed/variable mod selections) are loaded without their Y-ion fragments generated (`ToGenerateIons: false`). Ion generation was only performed on the dedicated N-glycan search path.

When an N-glycan is instead selected as a fixed or variable mod, it is attached to peptides during digestion and reaches `CreateGsm`, which then tried to build Y ions from a `null` ion list — throwing the exception. The old consumption-site code also cast with `as Glycan` after selecting by `ModificationType` string, so a non-`Glycan` modification carrying that type string (e.g. a database/GPTMD annotation) would cast to `null` and hit the same crash.

## Fix

At the consumption site in `CreateGsm`, N-linked glycan mods are now selected with `OfType<Glycan>()` and only contribute Y ions when they actually have them:

- `OfType<Glycan>()` filters out any non-`Glycan` modification carrying the `"N-linked glycosylation"` type string, so it can no longer cast to `null` and crash.
- If the glycan has no Y ions (an N-glycan used as a plain fixed/variable mod), its Y ions are simply skipped rather than generated on the fly.

This is a deliberate, minimal fix: N-glycan-as-a-mod is **not** scored on its Y ions in this mode. Correct N-glycan identification is the job of the dedicated **NO-search**, which is where users should go for that.

## Testing

- `GlycoSearch_WithNGlycanAsFixedOrVariableMod_DoesNotCrash` — parameterized integration smoke test over {fixed, variable} × {O-search, NO-search}. A pre-search assertion confirms the N-glycan mods start with `null` Ions (the state that used to crash), so the crash-free run is a meaningful regression check. Results-level assertions aren't made because the matched N/O co-glycopeptides are FDR-filtered out.

## Impact

Prevents the crash when an N-glycan is used as a fixed or variable modification, including from database/GPTMD annotations. N-glycan Y ions are not scored in this mode by design — dedicated N-glycan / NO-search behavior is unchanged.