### PR TITLE
Pin patched BouncyCastle instead of upgrading iText

### DIFF
--- a/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
+++ b/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
@@ -16,6 +16,8 @@
   <ItemGroup>
     <PackageReference Include="itext7" Version="8.0.5" />
     <PackageReference Include="itext7.bouncy-castle-adapter" Version="8.0.5" />
+    <!-- Patched BouncyCastle; iText 8.0.5 pulls 2.2.1, which is flagged. -->
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
     <PackageReference Include="mzLib" Version="1.0.584" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.0.0" />
     <PackageReference Include="Svg" Version="3.4.7" />


### PR DESCRIPTION
🤖

iText 8.0.5 pulls `BouncyCastle.Cryptography` **2.2.1**, which is flagged moderate. **8.0.5 is the
last 8.x release**, so taking iText's own fix means going to **9.7.0** — a major version, with
MetaDraw's PDF export on the hook for any API change.

Referencing the patched BouncyCastle directly gets the same result without that risk. **2.6.2 is
exactly what iText 9.7.0 itself depends on**, so it is the combination they ship and test against,
just reached from 8.0.5.

### Verification

With `NuGetAuditMode=all`, before and after:

| Package | Severity | Before | After |
|---|---|---|---|
| `BouncyCastle.Cryptography` 2.2.1 | moderate | flagged | **gone** |
| `System.Drawing.Common` 4.7.0 | critical | flagged | flagged — from mzLib |
| `System.Data.SqlClient` 4.8.1 | high | flagged | flagged — from mzLib |
| `OpenMcdf` 2.3.1 | moderate | flagged | flagged — from mzLib |

GuiFunctions builds with 0 errors. The remaining three all come from mzLib and are handled in
smith-chem-wisc/mzLib#1142, which clears the critical and the high and documents the OpenMcdf one
as unfixable while Thermo links OpenMcdf 2.x.

### Why these appeared now

Nothing changed in the dependency tree. .NET 9+ audits transitive packages by default when
targeting net9.0+, so the .NET 10 work (#2710) surfaced them. They are visible on master today with
`-p:NuGetAuditMode=all`.

**Not verified here:** PDF export at runtime — it is a Windows path, and CI covers it.