### PR TITLE
Drop the System.Data.SQLite metapackage (preparatory - no-op until mzLib ships the same change)

### DIFF
--- a/MetaMorpheus/CMD/CMD.csproj
+++ b/MetaMorpheus/CMD/CMD.csproj
@@ -28,7 +28,6 @@
     <PackageReference Include="mzLib" Version="1.0.584" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />
-    <PackageReference Include="System.Data.SQLite" Version="1.0.118" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.118" />
   </ItemGroup>
 

--- a/MetaMorpheus/EngineLayer/EngineLayer.csproj
+++ b/MetaMorpheus/EngineLayer/EngineLayer.csproj
@@ -28,7 +28,6 @@
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />
-    <PackageReference Include="System.Data.SQLite" Version="1.0.118" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.118" />
     <PackageReference Include="TopDownProteomics" Version="0.0.297" />
   </ItemGroup>

--- a/MetaMorpheus/GUI/GUI.csproj
+++ b/MetaMorpheus/GUI/GUI.csproj
@@ -75,7 +75,6 @@
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.CodeDom" Version="8.0.0" />
     <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
-    <PackageReference Include="System.Data.SQLite" Version="1.0.118" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.118" />
     <PackageReference Include="System.Drawing.Common" Version="8.0.7" />
     <PackageReference Include="System.Memory" Version="4.5.5" />

--- a/MetaMorpheus/MetaMorpheusSetup/MetaMorpheusSetup.wixproj
+++ b/MetaMorpheus/MetaMorpheusSetup/MetaMorpheusSetup.wixproj
@@ -54,7 +54,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />
-    <PackageReference Include="System.Data.SQLite" Version="1.0.118" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.118" />
     <PackageReference Include="WixToolset.Util.wixext" Version="5.0.1" />
     <PackageReference Include="WixToolset.UI.wixext" Version="5.0.1" />

--- a/MetaMorpheus/TaskLayer/TaskLayer.csproj
+++ b/MetaMorpheus/TaskLayer/TaskLayer.csproj
@@ -19,7 +19,6 @@
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />
-    <PackageReference Include="System.Data.SQLite" Version="1.0.118" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.118" />
   </ItemGroup>
 

--- a/MetaMorpheus/Test/DIATests/TestPfPairAndPfGroup.cs
+++ b/MetaMorpheus/Test/DIATests/TestPfPairAndPfGroup.cs
@@ -7,7 +7,6 @@ using NUnit.Framework;
 using NUnit.Framework.Interfaces;
 using System;
 using System.Collections.Generic;
-using System.Data.Entity.Core;
 using System.Linq;
 using TaskLayer;
 namespace Test.DIATests


### PR DESCRIPTION
**Draft — this is a no-op today and must not be merged until the mzLib side lands. See "Why this is a draft" below.**

Removes the `System.Data.SQLite` **metapackage** from the five projects that declare it — `CMD`, `EngineLayer`, `GUI`, `TaskLayer` and `MetaMorpheusSetup` — plus one stray `using`. The MetaMorpheus counterpart of smith-chem-wisc/mzLib#1142.

This is a pure deletion, not a swap: `System.Data.SQLite.Core 1.0.118` is already declared alongside the metapackage in every one of those projects.

## Why the metapackage is worth removing

It is `.Core` plus the EF6 and LINQ-to-Entities providers. Nothing in MetaMorpheus uses either — in fact **no `.cs` file in this repository contains the string "SQLite" at all**; the dependency exists only so mzLib's Bruker/timsTOF native interop lands in the output folder. But the metapackage drags in:

```
System.Data.SQLite → .EF6 → EntityFramework → System.Data.SqlClient 4.8.1        HIGH
                                            → …ConfigurationManager
                                               → …Permissions
                                                  → System.Windows.Extensions
                                                     → System.Drawing.Common 4.7.0   CRITICAL
```

Measured on master with `-p:NuGetAuditMode=all`:

| Advisory | Severity | Projects |
|---|---|---|
| `System.Drawing.Common 4.7.0` | **critical** | CMD, EngineLayer, TaskLayer |
| `System.Data.SqlClient 4.8.1` | **high** | CMD, EngineLayer, GUI, GuiFunctions, TaskLayer, Test |

## Why this is a draft: on its own it clears nothing

**`mzLib 1.0.584` — the version all these projects pin — declares `System.Data.SQLite` in its own nuspec**, in both the `net8.0` and `net8.0-windows7.0` dependency groups. So the metapackage returns transitively the moment the direct references go.

Verified with `dotnet list package --vulnerable --include-transitive` **after** this change:

- `System.Data.SqlClient 4.8.1` — moderate + **HIGH** — still present in CMD, GUI, Test
- `System.Drawing.Common 4.7.0` — **CRITICAL** — still present in CMD
- `EntityFramework.dll` (4.98 MB), `EntityFramework.SqlServer.dll`, `System.Data.SqlClient.dll` and `System.Data.SQLite.EF6.dll` all still land in the build output

Zero advisories are cleared. Merging this today would buy nothing but a tidier direct-dependency list, while *looking* like a security fix — which is worse than leaving it alone.

**The sequence that actually works:**

1. mzLib#1142 merges *(approved)*
2. A new mzLib is released to nuget.org **without** the `System.Data.SQLite` nuspec dependency
3. MetaMorpheus bumps its mzLib pin to that version
4. **Then** this PR, plus the `Product.wxs` change below, genuinely cleans the graph

## What still needs doing before this can merge

`MetaMorpheusSetup/Product.wxs` hard-codes installer entries for DLLs that only exist because of this dependency chain:

- `EntityFramework.dll` (`:339-340`)
- `EntityFramework.SqlServer.dll` (`:342-343`)
- `System.Data.SqlClient.dll` (`:351-352`)
- `System.Data.SQLite.dll` (`:354-355`)
- `System.Data.SQLite.EF6.dll` (`:357-358`)

Once those stop landing in `GUI`'s bin, **the WiX build fails outright** ("cannot open file") and `InstallRunAndArtifact.yml`'s `validate_installer_contents` job fails with it. Those five `<Component>`/`<File>` blocks have to come out in the same commit that makes the removal effective.

(`Product.wxs:506-507` harvests `runtimes\win-x64\native\SQLite.Interop.dll`, which is fine — that comes from `Stub.System.Data.SQLite.Core.NetStandard` and survives.)

## Verification of what *is* here

Clean `rm -rf bin obj` + restore + build on both sides, Debug:

- **CMD** 171 files before / 171 after · **GUI** 193 / 193 · **Test** 513 / 513
- 0 errors both sides; identical warning counts
- Every DLL byte-for-byte identical, **including all four `runtimes/*/native/SQLite.Interop.dll`**
- Only delta: `.deps.json` shrinks by exactly 132 bytes per project, as `"System.Data.SQLite": "1.0.118"` drops out of the direct-dependency map

I also checked the MSBuild-targets question, since `GUI.csproj:22-27` sets `ContentSQLiteInteropFiles`, `CopySQLiteInteropFiles`, `CleanSQLiteInteropFiles` and `CollectSQLiteInteropFiles` — properties read by targets, not by the compiler. **No SQLite package in this graph ships any build assets**: the `System.Data.SQLite` and `.Core` nupkgs contain only a nuspec and metadata (no `lib/`, no `build/`), no SQLite entry in `project.assets.json` carries a `build` key, and nothing in the NuGet cache contains the string `SQLiteInteropFiles`. Those four properties are already dead on master. Native handling is pure RID resolution via `runtimeTargets` and is untouched.

The removed `using System.Data.Entity.Core;` in `Test/DIATests/TestPfPairAndPfGroup.cs` was the only EF surface in the repository, and it was unused — no `ObjectContext`, `EntityKey` or any other type from that namespace appears in the file. Both `App.config` files were checked independently: binding redirects only, no `<entityFramework>` and no `<DbProviderFactories>`.

## Noticed while here, deliberately not in this PR

- **`SQLite.Interop.dll 1.0.103`** (declared in all five projects) is completely inert — its nupkg has a bare DLL at the package root rather than in `lib/`, `content/` or `runtimes/`, so NuGet places nothing. Its assets entry is `{ "type": "package" }` and its deps.json entry is `{}`. It is an unsigned third-party package (author "jinming", description "X64"), not from the SQLite team. The native genuinely comes from `Stub.System.Data.SQLite.Core.NetStandard`. Worth removing separately.
- **`GUI/GUI_h05aw1sq_wpftmp.csproj`** is a tracked WPF build-temp artifact committed by accident in 10b60613a, absent from the solution, referencing another developer's NuGet cache by absolute path. Worth `git rm` plus a `*_wpftmp.csproj` .gitignore rule.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SzUYj5BNsww1wd9cYTpyA
