### PR TITLE
fix(installer): drop EF6 components no longer in the build output

### DIFF
--- a/.github/workflows/InstallRunAndArtifact.yml
+++ b/.github/workflows/InstallRunAndArtifact.yml
@@ -207,6 +207,17 @@ jobs:
             "System.Drawing.Common.dll",
             "System.Security.Permissions.dll",
             "System.Windows.Extensions.dll",
+            # The EF6 chain itself, no longer shipped in the MSI. Nothing in MetaMorpheus uses
+            # EntityFramework, and #2710 dropped the System.Data.SQLite metapackage that was its
+            # only direct source; it now reaches the build only transitively, through mzLib
+            # 1.0.584, whose published nuspec predates smith-chem-wisc/mzLib#1142. These four
+            # entries become dead and should be swept when MetaMorpheus moves to a post-#1142
+            # mzLib. sni.dll rides the same chain but lives in runtimes\win-x64\native\, which
+            # the non-recursive scan below never sees -- it needs an entry only if #2690 lands.
+            "EntityFramework.dll",
+            "EntityFramework.SqlServer.dll",
+            "System.Data.SqlClient.dll",
+            "System.Data.SQLite.EF6.dll",
             "Microsoft.Win32.SystemEvents.dll",
             "Microsoft.Extensions.DependencyInjection.Abstractions.dll",
             "Microsoft.Extensions.DependencyInjection.dll",

--- a/MetaMorpheus/MetaMorpheusSetup/Product.wxs
+++ b/MetaMorpheus/MetaMorpheusSetup/Product.wxs
@@ -336,26 +336,14 @@
 	  <Component Id="src_CsvHelper.dll" Guid="79F28320-5AF2-4825-9B9B-AC0776E753C1">
 	  	<File Id="src_CsvHelper.dll" Name="CsvHelper.dll" Source="$(var.GUI_TargetDir)CsvHelper.dll" />
 	  </Component>
-	  <Component Id="src_EntityFramework.dll" Guid="AAB0BE24-C695-42CE-9495-B804B0929589">
-	  	<File Id="src_EntityFramework.dll" Name="EntityFramework.dll" Source="$(var.GUI_TargetDir)EntityFramework.dll" />
-	  </Component>
-	  <Component Id="src_EntityFramework.SqlServer.dll" Guid="C8207F75-5358-4EEB-9E86-D648FAFDD735">
-	  	<File Id="src_EntityFramework.SqlServer.dll" Name="EntityFramework.SqlServer.dll" Source="$(var.GUI_TargetDir)EntityFramework.SqlServer.dll" />
-	  </Component>
 	  <Component Id="src_msvcp110.dll" Guid="36947FB1-E7F0-4580-A15C-66CB25D566C4">
 	  	<File Id="src_msvcp110.dll" Name="msvcp110.dll" Source="$(var.GUI_TargetDir)msvcp110.dll" />
 	  </Component>
 	  <Component Id="src_msvcr110.dll" Guid="4C52ED24-C962-42B7-AE53-0FF423D25E64">
 	  	<File Id="src_msvcr110.dll" Name="msvcr110.dll" Source="$(var.GUI_TargetDir)msvcr110.dll" />
 	  </Component>
-	  <Component Id="src_System.Data.SqlClient.dll" Guid="46279896-7740-429F-A4B4-F4453F577F67">
-	  	<File Id="src_System.Data.SqlClient.dll" Name="System.Data.SqlClient.dll" Source="$(var.GUI_TargetDir)System.Data.SqlClient.dll" />
-	  </Component>
 	  <Component Id="src_System.Data.SQLite.dll" Guid="5CB69DD0-680A-4E49-9A93-74D0F4A10661">
 		<File Id="src_System.Data.SQLite.dll" Name="System.Data.SQLite.dll" Source="$(var.GUI_TargetDir)System.Data.SQLite.dll" />
-	  </Component>
-	  <Component Id="src_System.Data.SQLite.EF6.dll" Guid="F9804BA5-D660-4079-8BB4-738DF62EAF7E">
-	  	<File Id="src_System.Data.SQLite.EF6.dll" Name="System.Data.SQLite.EF6.dll" Source="$(var.GUI_TargetDir)System.Data.SQLite.EF6.dll" />
 	  </Component>
 
 	  <Component Id="src_System.Numerics.Tensors.dll" Guid="E82682ED-383F-4592-8B64-A0314FFB5481">
@@ -539,9 +527,6 @@
       <!--Native backing library for the managed SkiaSharp.dll, which ships but has no native pair.-->
       <Component Id="src_libSkiaSharp.dll" Guid="08B9E210-A08C-457F-9618-7D7DBEFE233A">
         <File Id="src_libSkiaSharp.dll" Name="libSkiaSharp.dll" Source="$(var.GUI_TargetDir)runtimes\win-x64\native\libSkiaSharp.dll" />
-      </Component>
-      <Component Id="src_sni.dll" Guid="67D93F86-AC5E-4D0C-9900-FDCEEE35881C">
-        <File Id="src_sni.dll" Name="sni.dll" Source="$(var.GUI_TargetDir)runtimes\win-x64\native\sni.dll" />
       </Component>
     </ComponentGroup>
   </Fragment>


### PR DESCRIPTION
Prunes five `Product.wxs` components whose source files no longer exist, and keeps `validate_installer_contents` honest across the transition.

Partially addresses #2713 (its step 5), but does **not** close it — the mzLib release and the version bump (steps 2–3) are still outstanding. Doing the manifest half now, ahead of the bump, is what unblocks CI; see below.

## What is broken

#2710 removed the last `PackageReference` to the `System.Data.SQLite` metapackage but pruned only `System.Drawing.Common` from `Product.wxs`. Five files that reached the build **only** through that metapackage are still listed:

| `Product.wxs` | file |
|---|---|
| `:339–341` | `EntityFramework.dll` |
| `:342–344` | `EntityFramework.SqlServer.dll` |
| `:351–353` | `System.Data.SqlClient.dll` |
| `:357–359` | `System.Data.SQLite.EF6.dll` |
| `:543–545` | `runtimes\win-x64\native\sni.dll` |

`Product.wxs` uses `DoNotHarvest`, so every shipped file is listed by hand and nothing reconciles that list against the build output. Any solution build where the chain is absent gets five `WIX0103`s.

**This is live right now.** mzLib's `integration` job clones MetaMorpheus master, swaps in a locally-packed mzLib, and runs a bare `dotnet build` — which is **Debug**, and the solution has a live `Debug|Any CPU.Build.0` row for the wixproj. Since #2710 merged, that job fails on every open mzLib PR, including ones that touch nothing but a YAML timeout (smith-chem-wisc/mzLib#1153, smith-chem-wisc/mzLib#1141).

**MetaMorpheus's own CI is green only by accident.** We pin `mzLib 1.0.584`, and that *published* nuspec still declares the `System.Data.SQLite` metapackage in both dependency groups, so the EF6 chain still reaches our output transitively and every `Source=` resolves. mzLib master already cut it (smith-chem-wisc/mzLib#1142). The moment anyone bumps the pin, `install` fails in Release and takes `test_installer` and `validate_installer_contents` down with it (both `needs: install`). No workflow here builds in Debug, so nothing local would have caught it first.

## Prune, not restore

Nothing in MetaMorpheus uses Entity Framework. Repo-wide there are zero C# hits for `EntityFramework`, `SqlClient`, `DbContext` or `SQLiteConnection`; the only `Entity` matches are `assemblyIdentity` elements in binding-redirect blocks. #2710 said the same: *"nothing uses EF6, so the metapackage goes."* These five ship binaries nothing loads.

**Kept:** `src_System.Data.SQLite.dll` and `src_SQLite.Interop.dll` — both still come from `System.Data.SQLite.Core` / `Stub.System.Data.SQLite.Core.NetStandard`.

> One correction to #2713's checklist: it lists `System.Data.SQLite.dll (:354-355)` for deletion. That one **survives** the swap and must stay. It also does not list `sni.dll`, which does not survive. This PR follows the build output, not that list.

## The workflow change is required, not incidental

While we still pin mzLib 1.0.584 those four top-level DLLs remain in the build output. Removing them from the MSI without whitelisting flips them into `$missingDlls` and turns `validate_installer_contents` red. They are added under the existing comment block that already describes this chain, with the sunset condition noted — they go dead on the next mzLib bump and should be swept then.

`sni.dll` needs no entry today: the scan at `:251` is `Get-ChildItem -Filter *.dll` with no `-Recurse`, so it never sees `runtimes\win-x64\native\`. It **will** need one if #2690 lands — worth sequencing.

## Verification

A full Debug solution build succeeds (`0 Error(s)`, MSI produced). That alone does not prove much here, since 1.0.584 still supplies the DLLs locally, so the real check expands every `Source=`/`SourceFile=` in `Product.wxs` and asserts existence against a build output with the EF6 chain deleted:

| | Source paths checked | missing |
|---|---|---|
| master `Product.wxs` | 155 | **5** — exactly the five CI errors |
| this branch | 150 | **0** |

Two local approaches that look like verification but are not, recorded so nobody repeats them: building the wixproj standalone with `-p:Platform=x64` repoints `GUI_TargetDir` at a nonexistent `GUI\bin\x64\Debug\...` and throws unrelated `WIX0103`s; and building through the solution **re-copies the deleted DLLs before candle/light runs**, so the deletion test passes for the wrong reason.

## Notes for review

- **No `ComponentRef` pruning needed.** The first four live in `ExecutablesAndLibrariesComponentGroup` and `sni.dll` in `WinNativeMathComponents`; both groups are referenced once each as `ComponentGroupRef` at `:23` and `:26`. There are no per-component refs in `Product.wxs`, `Maintenance.wxs` or `MetaSCDlg.wxs`, and `Bootstrapper/` has no hits.
- **Retired GUIDs must not be reused:** `AAB0BE24-…`, `C8207F75-…`, `46279896-…`, `F9804BA5-…`, `67D93F86-…`. (cf. #2527, "Eliminated duplicate GUIDs".)
- **Upgrade-safe.** Removing components from a shipped product would normally risk orphaned files, but `Product.wxs:13` schedules `RemoveExistingProducts` at `afterInstallValidate`, so the prior product is fully uninstalled before the new one installs. If that schedule ever moves, this reasoning stops holding.
- **Safe in both directions**, which is why it should land now rather than wait for the bump: before the bump the DLLs are in the output and whitelisted; after, they are gone and there is nothing to whitelist.

## Follow-up worth filing separately

`validate_installer_contents` structurally cannot catch this class of bug: it `needs: install`, so a `WIX0103` means it never runs; it compares build output against the *installed MSI*, never against the manifest; and it is Release-only. A step that parses every `Source=` in `Product.wxs` and asserts the file exists — the check #2710 ran by hand — would have caught it in seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
