### PR TITLE
Drop the Thermo MassPrecisionEstimator component ahead of mzLib#1156

### DIFF
--- a/.github/workflows/InstallRunAndArtifact.yml
+++ b/.github/workflows/InstallRunAndArtifact.yml
@@ -218,6 +218,13 @@ jobs:
             "EntityFramework.SqlServer.dll",
             "System.Data.SqlClient.dll",
             "System.Data.SQLite.EF6.dll",
+            # Thermo's MassPrecisionEstimator is stamped AMD64 in its PE header, so an arm64
+            # runtime refuses to load it; nothing in MetaMorpheus or mzLib uses it, and
+            # smith-chem-wisc/mzLib#1156 stops referencing and shipping it. It still reaches the
+            # build through mzLib 1.0.584, whose published nuspec predates that PR, so it is in
+            # the build output while no longer being installed. This entry becomes dead and
+            # should be swept when MetaMorpheus moves to a post-#1156 mzLib.
+            "ThermoFisher.CommonCore.MassPrecisionEstimator.dll",
             "Microsoft.Win32.SystemEvents.dll",
             "Microsoft.Extensions.DependencyInjection.Abstractions.dll",
             "Microsoft.Extensions.DependencyInjection.dll",

--- a/MetaMorpheus/MetaMorpheusSetup/Product.wxs
+++ b/MetaMorpheus/MetaMorpheusSetup/Product.wxs
@@ -358,9 +358,6 @@
       <Component Id="src_ThermoFisher.CommonCore.Data.dll" Guid="E711A739-AE5D-4DB9-9B14-0E4A8281CD20">
         <File Id="src_ThermoFisher.CommonCore.Data.dll" Name="ThermoFisher.CommonCore.Data.dll" Source="$(var.GUI_TargetDir)ThermoFisher.CommonCore.Data.dll" />
       </Component>
-      <Component Id="src_ThermoFisher.CommonCore.MassPrecisionEstimator.dll" Guid="03803256-C0A9-4DE8-9923-574E4BA2DEBA">
-        <File Id="src_ThermoFisher.CommonCore.MassPrecisionEstimator.dll" Name="ThermoFisher.CommonCore.MassPrecisionEstimator.dll" Source="$(var.GUI_TargetDir)ThermoFisher.CommonCore.MassPrecisionEstimator.dll" />
-      </Component>
       <Component Id="src_ThermoFisher.CommonCore.RawFileReader.dll" Guid="F5EDAA70-06CD-49E7-932F-016C679B07C7">
         <File Id="src_ThermoFisher.CommonCore.RawFileReader.dll" Name="ThermoFisher.CommonCore.RawFileReader.dll" Source="$(var.GUI_TargetDir)ThermoFisher.CommonCore.RawFileReader.dll" />
       </Component>


### PR DESCRIPTION
🤖 Companion to **smith-chem-wisc/mzLib#1156**, which stops referencing and shipping `ThermoFisher.CommonCore.MassPrecisionEstimator.dll`. **This one has to merge first.**

## Why the file is going away

It is stamped `AMD64` in its PE header, so CoreCLR on an arm64 runtime refuses to load it. I verified the four vendored Thermo assemblies by parsing their PE headers and AssemblyRef tables directly rather than taking it on description:

| vendored DLL | machine | ilOnly | Thermo assemblies it references |
|---|---|---|---|
| `ThermoFisher.CommonCore.Data.dll` | I386 | true | — |
| `ThermoFisher.CommonCore.BackgroundSubtraction.dll` | I386 | true | `...Data` |
| `ThermoFisher.CommonCore.RawFileReader.dll` | I386 | true | `...Data` |
| **`ThermoFisher.CommonCore.MassPrecisionEstimator.dll`** | **Amd64** | true | `...Data` |

It is a **leaf**: it depends on `CommonCore.Data`, and nothing depends on it. No `.cs` file in mzLib, MetaMorpheus or ProteaseGuru references it, and no sibling Thermo assembly names it in its AssemblyRef table, so it cannot be pulled in transitively or reflectively either. Today it never loads, which is the only reason `.raw` reading works on Apple Silicon at all (see smith-chem-wisc/mzLib#1156 and #2723 for that story).

## What breaks if this doesn't land first

`Product.wxs` uses `DoNotHarvest`, so every shipped file is listed by hand and nothing reconciles that list against the build output. The component sourced the file straight out of the GUI output directory:

```xml
<Component Id="src_ThermoFisher.CommonCore.MassPrecisionEstimator.dll" Guid="03803256-...">
  <File ... Source="$(var.GUI_TargetDir)ThermoFisher.CommonCore.MassPrecisionEstimator.dll" />
</Component>
```

The first MetaMorpheus build against a post-#1156 mzLib would get a `WIX0103` for a file that is no longer there — the same failure mode as the EF6 chain in #2713 / #2720.

## Why the whitelist entry ships with it

Removing the component on its own would redden CI **immediately**, before any mzLib bump. `validate_installer_contents` fails on any DLL that is in the build output but not installed and not whitelisted:

```powershell
$missingDlls = $buildDlls | Where-Object { $_ -notin $installedDlls -and $_ -notin $whitelistedMissingDlls }
```
(`InstallRunAndArtifact.yml:275`)

mzLib 1.0.584 — what master pins today — still delivers the DLL to the bin root. I confirmed it is there in a real Release build, in one of the five folders that job actually scans:

```
MetaMorpheus\CMD\bin\Release\net10.0\ThermoFisher.CommonCore.MassPrecisionEstimator.dll
```

So the whitelist entry is what makes this PR correct on **today's** mzLib and still correct after the bump. It follows the convention already set by the EF6 entries directly above it, including the note that it becomes dead once MetaMorpheus moves to a post-#1156 mzLib and should be swept then.

## Scope

Two changes, both small:

- `Product.wxs` — the three-line `<Component>` removed. It is only a member of `ExecutablesAndLibrariesComponentGroup`; there is no `<ComponentRef>` to it anywhere, so the removal is self-contained. XML well-formedness re-checked after the edit.
- `InstallRunAndArtifact.yml` — one whitelist entry plus the comment explaining when to delete it.

Nothing else in MetaMorpheus mentions the assembly — no `.cs`, no other packaging manifest, no `bootstrapper.wxs` / `Maintenance.wxs` / `MetaSCDlg.wxs`.

## Merge order

1. **this PR**
2. mzLib#1156
3. mzLib release
4. MetaMorpheus mzLib version bump — at which point the whitelist entry added here becomes dead and can be swept

## Not verified here

I did not build the MSI locally; WiX is not in this environment. The change is a deletion of a self-contained component plus a CI whitelist string, and `Validate Installer Contents` exercises exactly the path in question, so CI on this PR is the real check.

Also worth a reviewer's eye rather than my assertion: removing a component `Guid` has MSI component-rules implications on major upgrade for machines that already have the file installed. The intended outcome — the old file is removed on upgrade — is what a component removal normally produces, but I did not test an upgrade from an installed older version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
