### PR TITLE
Bump mzLib to 1.0.585, clearing the critical and high advisories

### DIFF
--- a/MetaMorpheus/CMD/CMD.csproj
+++ b/MetaMorpheus/CMD/CMD.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.584" />
+    <PackageReference Include="mzLib" Version="1.0.585" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.118" />

--- a/MetaMorpheus/EngineLayer/EngineLayer.csproj
+++ b/MetaMorpheus/EngineLayer/EngineLayer.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.584" />
+    <PackageReference Include="mzLib" Version="1.0.585" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />

--- a/MetaMorpheus/GUI/GUI.csproj
+++ b/MetaMorpheus/GUI/GUI.csproj
@@ -62,7 +62,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.584" />
+    <PackageReference Include="mzLib" Version="1.0.585" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0" />

--- a/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
+++ b/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="itext7" Version="9.7.0" />
     <PackageReference Include="itext7.bouncy-castle-adapter" Version="9.7.0" />
-    <PackageReference Include="mzLib" Version="1.0.584" />
+    <PackageReference Include="mzLib" Version="1.0.585" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.0.0" />
     <PackageReference Include="Svg" Version="3.4.7" />
   </ItemGroup>

--- a/MetaMorpheus/TaskLayer/TaskLayer.csproj
+++ b/MetaMorpheus/TaskLayer/TaskLayer.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.584" />
+    <PackageReference Include="mzLib" Version="1.0.585" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />

--- a/MetaMorpheus/Test/Test.csproj
+++ b/MetaMorpheus/Test/Test.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.584" />
+    <PackageReference Include="mzLib" Version="1.0.585" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />


### PR DESCRIPTION
Closes the two-repository chain recorded in #2713.

## What this clears

MetaMorpheus resolves these transitively on `master` today:

| Advisory | Severity |
|---|---|
| [`System.Drawing.Common 4.7.0`](https://github.com/advisories/GHSA-rxg9-xrhp-64gj) | **critical** |
| [`System.Data.SqlClient 4.8.1`](https://github.com/advisories/GHSA-98g6-xh36-x2p7) | **high** |

Both arrive through the `System.Data.SQLite` **metapackage** — `System.Data.SQLite.Core` plus the EF6 and LINQ-to-Entities providers — via `→ .EF6 → EntityFramework → System.Data.SqlClient → … → System.Drawing.Common`.

## Why the bump is the fix, and not something we could do here

Removing the direct references from this repository was **not** sufficient: `mzLib 1.0.584` declares the metapackage in its own nuspec, in both dependency groups, so it returned transitively. #2712 verified exactly that and was closed as a no-op — zero advisories cleared, `EntityFramework.dll` still landing in `bin`.

smith-chem-wisc/mzLib#1142 referenced `System.Data.SQLite.Core` directly instead, and **1.0.585 is the first release carrying that nuspec**. This bump is therefore the step that actually clears them — step 3 of the ordering in #2713.

Six sites: `CMD`, `EngineLayer`, `GuiFunctions`, `GUI`, `TaskLayer`, `Test`.

## Nothing about what gets read changes

The provider assembly and the native SQLite engine both come from `.Core`, still at the same `1.0.118` that already resolved. Only the unused ORM adapters go away — no `.cs` file in this repository contains the string "SQLite" at all; the dependency existed only so mzLib's Bruker/timsTOF native interop reached the output folder, which `.Core` supplies on its own.

## No installer change is needed

Worth stating explicitly, because #2713 lists it as a mandatory paired step and the usual failure mode here is `WIX0103` on a file that stopped being produced.

`Product.wxs` on current `master` no longer lists the `EntityFramework`, `EntityFramework.SqlServer`, `System.Data.SqlClient` or `System.Data.SQLite.EF6` components — those were already removed. Its two surviving SQLite entries both come from packages that remain:

- `System.Data.SQLite.dll` (`:345-346`) — ships in `.Core`
- `runtimes\win-x64\native\SQLite.Interop.dll` (`:491-492`) — from `Stub.System.Data.SQLite.Core.NetStandard`

So the installer harvest is unaffected. `InstallRunAndArtifact.yml` is the check that proves it.

## Follow-up, deliberately not in this PR

`SQLite.Interop.dll 1.0.103` is still declared in five projects and is completely inert — the nupkg has a bare DLL at the package root rather than under `lib/`, `content/` or `runtimes/`, so NuGet places nothing, and its deps.json entry is `{}`. It is also an unsigned third-party package. #2713 flags it as an adjacent cleanup; removing it is a separate change with its own verification, and keeping this PR to the bump makes the advisory delta unambiguous.

Refs #2713
