### PR TITLE
feat(gui): drag and drop to reorder tasks

### DIFF
--- a/MetaMorpheus/GUI/MainWindow.xaml
+++ b/MetaMorpheus/GUI/MainWindow.xaml
@@ -699,8 +699,11 @@
                     </Grid>
 
                     <!--List of tasks-->
-                    <TreeView x:Name="tasksTreeView" Grid.Row="3" ItemsSource="{Binding}" MouseDoubleClick="TasksTreeView_MouseDoubleClick" 
-                              Margin="10,0,10,10" BorderBrush="{StaticResource BorderColor}" PreviewKeyDown="BoxWithList_PreviewKeyDown">
+                    <TreeView x:Name="tasksTreeView" Grid.Row="3" ItemsSource="{Binding}" MouseDoubleClick="TasksTreeView_MouseDoubleClick"
+                              Margin="10,0,10,10" BorderBrush="{StaticResource BorderColor}" PreviewKeyDown="BoxWithList_PreviewKeyDown"
+                              AllowDrop="True" PreviewMouseLeftButtonDown="TaskTreeView_PreviewMouseLeftButtonDown"
+                              PreviewMouseMove="TaskTreeView_PreviewMouseMove" DragOver="TaskTreeView_DragOver"
+                              DragLeave="TaskTreeView_DragLeave" Drop="TaskTreeView_Drop">
                     </TreeView>
                 </Grid>
             </TabItem>
@@ -791,7 +794,10 @@
 
                         <!--Task Summary-->
                         <TreeView Name="taskSummary" ItemsSource="{Binding}" Grid.Column="2" Margin="0,10,20,10" MouseDoubleClick="TasksTreeView_MouseDoubleClick"
-                                  PreviewKeyDown="BoxWithList_PreviewKeyDown">
+                                  PreviewKeyDown="BoxWithList_PreviewKeyDown"
+                                  AllowDrop="True" PreviewMouseLeftButtonDown="TaskTreeView_PreviewMouseLeftButtonDown"
+                                  PreviewMouseMove="TaskTreeView_PreviewMouseMove" DragOver="TaskTreeView_DragOver"
+                                  DragLeave="TaskTreeView_DragLeave" Drop="TaskTreeView_Drop">
                             <TreeView.ItemContainerStyle>
                                 <Style TargetType="{x:Type TreeViewItem}">
                                     <Setter Property="FontSize" Value="13" />

--- a/MetaMorpheus/GUI/MainWindow.xaml.cs
+++ b/MetaMorpheus/GUI/MainWindow.xaml.cs
@@ -16,6 +16,7 @@ using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Documents;
 using System.Windows.Input;
+using System.Windows.Media;
 using System.Windows.Navigation;
 using Omics.Modifications;
 using TaskLayer;
@@ -37,6 +38,9 @@ namespace MetaMorpheusGUI
         private readonly ObservableCollection<RawDataForDataGrid> SelectedSpectraFiles = new ObservableCollection<RawDataForDataGrid>();
         private readonly ObservableCollection<ProteinDbForDataGrid> SelectedProteinDatabaseFiles = new ObservableCollection<ProteinDbForDataGrid>();
         private ObservableCollection<InRunTask> InProgressTasks;
+        private Point DragStartPoint;
+        private PreRunTask TaskToDrag;
+        private TreeViewItem DropIndicatorItem;
         public static string NewestKnownMetaMorpheusVersion { get; private set; }
 
         public MainWindow()
@@ -874,18 +878,202 @@ namespace MetaMorpheusGUI
                 // renames the tasks in the new correct order (Task1, Task2, etc.)
                 UpdateGuiOnPreRunChange();
 
-                var item = tasksTreeView.ItemContainerGenerator.ContainerFromItem(taskToMove);
-                if (item != null)
-                {
-                    ((TreeViewItem)item).IsSelected = true;
-                }
+                SelectTaskInTreeViews(taskToMove);
+            }
+        }
 
-                item = taskSummary.ItemContainerGenerator.ContainerFromItem(taskToMove);
-                if (item != null)
+        /// <summary>
+        /// Re-selects a task in both task tree views after it has been moved.
+        /// </summary>
+        private void SelectTaskInTreeViews(PreRunTask task)
+        {
+            foreach (var treeView in new[] { tasksTreeView, taskSummary })
+            {
+                if (treeView.ItemContainerGenerator.ContainerFromItem(task) is TreeViewItem item)
                 {
-                    ((TreeViewItem)item).IsSelected = true;
+                    item.IsSelected = true;
                 }
             }
+        }
+
+        /// <summary>
+        /// Records which task the left button went down on, and where, so that a drag can be told apart from a click.
+        /// </summary>
+        private void TaskTreeView_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            DragStartPoint = e.GetPosition(null);
+            TaskToDrag = GetTreeViewItemContaining(e.OriginalSource)?.DataContext as PreRunTask;
+        }
+
+        /// <summary>
+        /// Begins a drag once the mouse has moved far enough from where the left button went down.
+        /// </summary>
+        private void TaskTreeView_PreviewMouseMove(object sender, MouseEventArgs e)
+        {
+            if (e.LeftButton != MouseButtonState.Pressed)
+            {
+                // the press a drag could have started from is over, so it is no longer a candidate
+                TaskToDrag = null;
+                return;
+            }
+
+            if (TaskToDrag == null || !TasksCanBeReordered(sender as TreeView))
+            {
+                return;
+            }
+
+            Vector dragDistance = e.GetPosition(null) - DragStartPoint;
+            if (Math.Abs(dragDistance.X) < SystemParameters.MinimumHorizontalDragDistance
+                && Math.Abs(dragDistance.Y) < SystemParameters.MinimumVerticalDragDistance)
+            {
+                return;
+            }
+
+            // the task is taken from the press, not from whatever is under the cursor once the threshold is passed
+            PreRunTask taskToDrag = TaskToDrag;
+            TaskToDrag = null;
+
+            DragDrop.DoDragDrop((TreeView)sender, new DataObject(typeof(PreRunTask), taskToDrag), DragDropEffects.Move);
+            ClearDropIndicator();
+        }
+
+        /// <summary>
+        /// Draws a line showing where the dragged task would land.
+        /// </summary>
+        private void TaskTreeView_DragOver(object sender, DragEventArgs e)
+        {
+            ClearDropIndicator();
+
+            var treeView = sender as TreeView;
+
+            // anything that isn't a task reorder (e.g. dropping files onto the window) is left to bubble up
+            if (GetDraggedTask(e, treeView) == null)
+            {
+                return;
+            }
+
+            e.Effects = DragDropEffects.Move;
+            e.Handled = true;
+
+            var targetItem = GetTreeViewItemContaining(e.OriginalSource);
+            bool lineAboveTarget = targetItem != null && IsInUpperHalf(targetItem, e);
+
+            // hovering past the last task draws the line below it, matching the drop-at-the-end behavior
+            targetItem ??= treeView.ItemContainerGenerator.ContainerFromIndex(PreRunTasks.Count - 1) as TreeViewItem;
+            if (targetItem == null)
+            {
+                return;
+            }
+
+            DropIndicatorItem = targetItem;
+            targetItem.BorderBrush = SystemColors.HighlightBrush;
+            targetItem.BorderThickness = lineAboveTarget ? new Thickness(0, 2, 0, 0) : new Thickness(0, 0, 0, 2);
+        }
+
+        private void TaskTreeView_DragLeave(object sender, DragEventArgs e)
+        {
+            ClearDropIndicator();
+        }
+
+        /// <summary>
+        /// Moves the dragged task to the position it was dropped on.
+        /// </summary>
+        private void TaskTreeView_Drop(object sender, DragEventArgs e)
+        {
+            ClearDropIndicator();
+
+            // anything that isn't a task reorder (e.g. dropping files onto the window) is left to bubble up
+            PreRunTask draggedTask = GetDraggedTask(e, sender as TreeView);
+            if (draggedTask == null)
+            {
+                return;
+            }
+
+            e.Handled = true;
+
+            int oldPosition = PreRunTasks.IndexOf(draggedTask);
+            var targetItem = GetTreeViewItemContaining(e.OriginalSource);
+
+            // dropping past the last task moves it to the end of the list
+            int newPosition = PreRunTasks.Count;
+            if (targetItem?.DataContext is PreRunTask targetTask)
+            {
+                newPosition = PreRunTasks.IndexOf(targetTask) + (IsInUpperHalf(targetItem, e) ? 0 : 1);
+            }
+
+            // the dragged task is removed from its old position before being re-inserted
+            if (oldPosition < newPosition)
+            {
+                newPosition--;
+            }
+
+            if (oldPosition < 0 || newPosition < 0 || oldPosition == newPosition)
+            {
+                return;
+            }
+
+            PreRunTasks.Move(oldPosition, newPosition);
+
+            // renames the tasks in the new correct order (Task1, Task2, etc.)
+            UpdateGuiOnPreRunChange();
+
+            SelectTaskInTreeViews(draggedTask);
+        }
+
+        /// <summary>
+        /// Returns the task being dragged, or null if this drag is not a task reorder that the tree view can accept.
+        /// </summary>
+        private PreRunTask GetDraggedTask(DragEventArgs e, TreeView treeView)
+        {
+            if (!TasksCanBeReordered(treeView) || e.Data == null || !e.Data.GetDataPresent(typeof(PreRunTask)))
+            {
+                return null;
+            }
+
+            var task = e.Data.GetData(typeof(PreRunTask)) as PreRunTask;
+
+            return task != null && PreRunTasks.Contains(task) ? task : null;
+        }
+
+        /// <summary>
+        /// Tasks can only be reordered before a run; during a run the tree views are bound to InProgressTasks.
+        /// </summary>
+        private bool TasksCanBeReordered(TreeView treeView)
+        {
+            return treeView != null && ReferenceEquals(treeView.DataContext, PreRunTasks) && PreRunTasks.Count > 1;
+        }
+
+        private static bool IsInUpperHalf(TreeViewItem item, DragEventArgs e)
+        {
+            return e.GetPosition(item).Y < item.ActualHeight / 2;
+        }
+
+        private void ClearDropIndicator()
+        {
+            if (DropIndicatorItem == null)
+            {
+                return;
+            }
+
+            DropIndicatorItem.ClearValue(Control.BorderBrushProperty);
+            DropIndicatorItem.ClearValue(Control.BorderThicknessProperty);
+            DropIndicatorItem = null;
+        }
+
+        /// <summary>
+        /// Walks up from a hit-tested element to the tree view item that contains it, if any.
+        /// </summary>
+        private static TreeViewItem GetTreeViewItemContaining(object source)
+        {
+            DependencyObject current = source as DependencyObject;
+
+            while (current != null && !(current is TreeViewItem))
+            {
+                // VisualTreeHelper throws on non-visuals (e.g. a Run inside a TextBlock)
+                current = current is Visual ? VisualTreeHelper.GetParent(current) : LogicalTreeHelper.GetParent(current);
+            }
+
+            return current as TreeViewItem;
         }
 
         /// <summary>


### PR DESCRIPTION
Closes #1087.

Tasks can now be reordered by dragging them, in both the Tasks tab tree and the Run tab summary.

## Why this turned out to be tractable

The concern raised on the issue in 2018 was that the TreeView data structure made this hard. That no longer applies: `PreRunTask` is rendered by a plain `DataTemplate` (`MainWindow.xaml:333`), not a `HierarchicalDataTemplate`, so the task tree is a flat list bound to `ObservableCollection<PreRunTask>`. Reordering is a single `Move()` on the same collection that the `+`/`-` keys from #1122 already mutate, followed by the existing `UpdateGuiOnPreRunChange()` to renumber Task1/Task2/…

## Behavior

- Drop position follows which half of the target row you are over — insert above or below — with a line drawn on the target to show where the task will land. Hovering past the last task draws the line beneath it and drops at the end.
- Drag starts only past `SystemParameters.Minimum{Horizontal,Vertical}DragDistance`, so clicking and double-click-to-edit are unaffected.
- Reordering is blocked during a run, when both trees rebind to `InProgressTasks`.

## Two things worth a reviewer's attention

**File drops still work.** The window already has `Drop="Window_Drop"` for `.toml`/`.mzML`/`.fasta`. Setting `AllowDrop` on the tree makes the tree the drop target for those drags too, so the handlers only set `e.Handled` once the drag is confirmed to be a task reorder; anything else bubbles up to `Window_Drop` untouched. This was a regression I introduced and then fixed, so it is the thing most worth re-checking.

**The dragged task is captured on mouse-down**, not hit-tested when the drag threshold is passed. Hit-testing at threshold time means a fast flick picks up whichever task the cursor has already moved onto, and lets a press that began outside the tree drag a task it never grabbed.

## Verification status

Compiles clean, XAML markup compile included — which is what confirms the handler signatures resolve on both trees.

**The drag interaction itself is untested.** This was written on macOS, where WPF cannot run, hence the draft. Two things specifically want a Windows pass:

1. The insertion line assumes the default `TreeViewItem` template template-binds `BorderBrush`/`BorderThickness`. If it does not, the line simply will not render — reordering still works, it is only the visual cue.
2. There is no auto-scroll when dragging near the edge of a long task list. Task lists are typically short enough that this has not seemed worth the complexity, but say the word if you would like it.

No test: `Test.csproj` references `GuiFunctions`, not `GUI`, so this code-behind is not reachable from the test project — the same reason the existing `MoveSelectedTask_Click` is untested. Making the index arithmetic testable would mean lifting it into `GuiFunctions`; happy to do that if it is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)