### PR TITLE
Do not write empty ProteinDetectionHypothesis elements to mzID

### DIFF
--- a/MetaMorpheus/TaskLayer/SearchTask/MzIdentMLWriter.cs
+++ b/MetaMorpheus/TaskLayer/SearchTask/MzIdentMLWriter.cs
@@ -37,9 +37,14 @@ namespace TaskLayer
                         }
                     }
                 }
-                // FullSequence is null when the sequence could not be resolved; such PSMs are
-                // dropped further down anyway, and "|" only appears on a resolved ambiguous one.
-                psms = psms.Where(p => p.BaseSequence != null && p.FullSequence != null && !p.FullSequence.Contains("|") && !labelsToSearch.Any(x => p.BaseSequence.Contains(x)));
+                // SpectralMatch.FullSequence is assigned from PsmTsvWriter.Resolve(...).ResolvedValue,
+                // which is null whenever the candidate sequences disagree -- the pipe-joined form is
+                // ResolvedString and is discarded. So FullSequence is either a clean sequence or null,
+                // never "|"-delimited, and the old !FullSequence.Contains("|") conjunct could only ever
+                // be true or throw a NullReferenceException on an ambiguous PSM. Dropping it fixes the
+                // crash without narrowing psms, which also feeds peptides/proteins/filenames below;
+                // ambiguous PSMs are excluded from the identification data by unambiguousPsms instead.
+                psms = psms.Where(p => p.BaseSequence != null && !labelsToSearch.Any(x => p.BaseSequence.Contains(x)));
             }
 
             List<PeptideWithSetModifications> peptides = psms.SelectMany(i => i.BestMatchingBioPolymersWithSetMods.Select(v => v.SpecificBioPolymer as PeptideWithSetModifications)).Distinct().ToList();

--- a/MetaMorpheus/TaskLayer/SearchTask/MzIdentMLWriter.cs
+++ b/MetaMorpheus/TaskLayer/SearchTask/MzIdentMLWriter.cs
@@ -37,7 +37,9 @@ namespace TaskLayer
                         }
                     }
                 }
-                psms = psms.Where(p => p.BaseSequence != null && !p.FullSequence.Contains("|") && !labelsToSearch.Any(x => p.BaseSequence.Contains(x)));
+                // FullSequence is null when the sequence could not be resolved; such PSMs are
+                // dropped further down anyway, and "|" only appears on a resolved ambiguous one.
+                psms = psms.Where(p => p.BaseSequence != null && p.FullSequence != null && !p.FullSequence.Contains("|") && !labelsToSearch.Any(x => p.BaseSequence.Contains(x)));
             }
 
             List<PeptideWithSetModifications> peptides = psms.SelectMany(i => i.BestMatchingBioPolymersWithSetMods.Select(v => v.SpecificBioPolymer as PeptideWithSetModifications)).Distinct().ToList();
@@ -640,30 +642,61 @@ namespace TaskLayer
 
             if (groups != null)
             {
-                _mzid.DataCollection.AnalysisData.ProteinDetectionList = new mzIdentML110.Generated.ProteinDetectionListType()
-                {
-                    id = "PDL",
-                    ProteinAmbiguityGroup = new mzIdentML110.Generated.ProteinAmbiguityGroupType[groups.Count]
-                };
+                // Built up in lists rather than fixed-size arrays because a ProteinDetectionHypothesis
+                // with no PeptideHypothesis, and a ProteinAmbiguityGroup with no
+                // ProteinDetectionHypothesis, are both schema-invalid and have to be left out.
+                var ambiguityGroups = new List<mzIdentML110.Generated.ProteinAmbiguityGroupType>();
 
                 int group_id = 0;
                 int protein_id = 0;
                 foreach (EngineLayer.ProteinGroup proteinGroup in groups)
                 {
-                    _mzid.DataCollection.AnalysisData.ProteinDetectionList.ProteinAmbiguityGroup[group_id] = new mzIdentML110.Generated.ProteinAmbiguityGroupType()
-                    {
-                        id = "PAG_" + group_id,
-                        ProteinDetectionHypothesis = new mzIdentML110.Generated.ProteinDetectionHypothesisType[proteinGroup.Proteins.Count]
-                    };
-                    int pag_protein_index = 0;
+                    var detectionHypotheses = new List<mzIdentML110.Generated.ProteinDetectionHypothesisType>();
                     foreach (Protein protein in proteinGroup.Proteins)
                     {
-                        _mzid.DataCollection.AnalysisData.ProteinDetectionList.ProteinAmbiguityGroup[group_id].ProteinDetectionHypothesis[pag_protein_index] = new mzIdentML110.Generated.ProteinDetectionHypothesisType()
+                        var peptideHypotheses = new List<mzIdentML110.Generated.PeptideHypothesisType>();
+                        foreach (PeptideWithSetModifications peptide in proteinGroup.AllPeptides)
                         {
-                            id = "PDH_" + protein_id,
+                            if (peptide_evidence_ids.ContainsKey(peptide))
+                            {
+                                if (peptide.Protein == protein)
+                                {
+                                    var peptideHypothesis = new mzIdentML110.Generated.PeptideHypothesisType()
+                                    {
+                                        peptideEvidence_ref = "PE_" + peptide_evidence_ids[peptide],
+                                        SpectrumIdentificationItemRef = new mzIdentML110.Generated.SpectrumIdentificationItemRefType[peptide_ids[peptide.FullSequence].Item2.Count],
+                                    };
+
+                                    int i = 0;
+                                    foreach (string sii in peptide_ids[peptide.FullSequence].Item2)
+                                    {
+                                        peptideHypothesis.SpectrumIdentificationItemRef[i] = new mzIdentML110.Generated.SpectrumIdentificationItemRefType()
+                                        {
+                                            spectrumIdentificationItem_ref = sii
+                                        };
+                                        i++;
+                                    }
+                                    peptideHypotheses.Add(peptideHypothesis);
+                                }
+                            }
+                        }
+
+                        int this_protein_id = protein_id;
+                        protein_id++;
+
+                        // No peptide evidence written for this protein, e.g. a group supported only
+                        // by PSMs whose sequence could not be resolved.
+                        if (peptideHypotheses.Count == 0)
+                        {
+                            continue;
+                        }
+
+                        detectionHypotheses.Add(new mzIdentML110.Generated.ProteinDetectionHypothesisType()
+                        {
+                            id = "PDH_" + this_protein_id,
                             dBSequence_ref = "DBS_" + protein.Accession,
                             passThreshold = proteinGroup.QValue <= 0.01, // hardcoded as 1% FDR but we could change this to the provided threshold
-                            PeptideHypothesis = new mzIdentML110.Generated.PeptideHypothesisType[proteinGroup.AllPeptides.Count],
+                            PeptideHypothesis = peptideHypotheses.ToArray(),
                             cvParam = new mzIdentML110.Generated.CVParamType[4]
                             {
                             new mzIdentML110.Generated.CVParamType
@@ -695,38 +728,29 @@ namespace TaskLayer
                                 value = proteinGroup.UniquePeptides.Count.ToString()
                             }
                             }
-                        };
-                        int peptide_id = 0;
-                        foreach (PeptideWithSetModifications peptide in proteinGroup.AllPeptides)
-                        {
-                            if (peptide_evidence_ids.ContainsKey(peptide))
-                            {
-                                if (peptide.Protein == protein)
-                                {
-                                    _mzid.DataCollection.AnalysisData.ProteinDetectionList.ProteinAmbiguityGroup[group_id].ProteinDetectionHypothesis[pag_protein_index].PeptideHypothesis[peptide_id] = new mzIdentML110.Generated.PeptideHypothesisType()
-                                    {
-                                        peptideEvidence_ref = "PE_" + peptide_evidence_ids[peptide],
-                                        SpectrumIdentificationItemRef = new mzIdentML110.Generated.SpectrumIdentificationItemRefType[peptide_ids[peptide.FullSequence].Item2.Count],
-                                    };
-
-                                    int i = 0;
-                                    foreach (string sii in peptide_ids[peptide.FullSequence].Item2)
-                                    {
-                                        _mzid.DataCollection.AnalysisData.ProteinDetectionList.ProteinAmbiguityGroup[group_id].ProteinDetectionHypothesis[pag_protein_index].PeptideHypothesis[peptide_id].SpectrumIdentificationItemRef[i] = new mzIdentML110.Generated.SpectrumIdentificationItemRefType()
-                                        {
-                                            spectrumIdentificationItem_ref = sii
-                                        };
-                                        i++;
-                                    }
-                                    peptide_id++;
-                                }
-                            }
-                        }
-                        pag_protein_index++;
-                        protein_id++;
+                        });
                     }
+
+                    int this_group_id = group_id;
                     group_id++;
+
+                    if (detectionHypotheses.Count == 0)
+                    {
+                        continue;
+                    }
+
+                    ambiguityGroups.Add(new mzIdentML110.Generated.ProteinAmbiguityGroupType()
+                    {
+                        id = "PAG_" + this_group_id,
+                        ProteinDetectionHypothesis = detectionHypotheses.ToArray()
+                    });
                 }
+
+                _mzid.DataCollection.AnalysisData.ProteinDetectionList = new mzIdentML110.Generated.ProteinDetectionListType()
+                {
+                    id = "PDL",
+                    ProteinAmbiguityGroup = ambiguityGroups.ToArray()
+                };
             }
             XmlWriter writer = XmlWriter.Create(outputPath, settings);
             _indexedSerializer.Serialize(writer, _mzid);

--- a/MetaMorpheus/Test/MzIdentMlSchemaTest.cs
+++ b/MetaMorpheus/Test/MzIdentMlSchemaTest.cs
@@ -1,0 +1,273 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml;
+using EngineLayer;
+using MassSpectrometry;
+using MzLibUtil;
+using NUnit.Framework;
+using Omics;
+using Omics.Digestion;
+using Omics.Fragmentation;
+using Omics.Modifications;
+using Proteomics;
+using Proteomics.ProteolyticDigestion;
+using TaskLayer;
+
+namespace Test
+{
+    /// <summary>
+    /// mzIdentML 1.1 requires at least one PeptideHypothesis inside every
+    /// ProteinDetectionHypothesis, and at least one ProteinDetectionHypothesis inside every
+    /// ProteinAmbiguityGroup (both are minOccurs="1" in the HUPO-PSI schema). A file that breaks
+    /// either is rejected outright by validating consumers such as ProteomeXchange, which is the
+    /// mzid half of mzLib issue 259.
+    ///
+    /// The existing MzIdentMLWriter tests all pass an empty protein group list, so nothing has ever
+    /// exercised the ProteinDetectionList branch.
+    /// </summary>
+    [TestFixture]
+    public static class MzIdentMlSchemaTest
+    {
+        [Test]
+        public static void ProteinGroupSupportedOnlyByAnAmbiguousPsmStillWritesValidMzid()
+        {
+            // A PSM whose sequence could not be resolved has FullSequence == null. The writer skips
+            // those when building PeptideEvidence, but the protein groups they support are still
+            // written, so the group's ProteinDetectionHypothesis has nothing to point at.
+            var psm = AmbiguousPsm(out Protein protein);
+            Assert.That(psm.FullSequence, Is.Null, "the PSM under test is meant to be ambiguous");
+
+            var group = new ProteinGroup(
+                new HashSet<IBioPolymer> { protein },
+                new HashSet<IBioPolymerWithSetMods>(psm.BestMatchingBioPolymersWithSetMods.Select(p => p.SpecificBioPolymer)),
+                new HashSet<IBioPolymerWithSetMods>());
+            group.SequenceCoverageFraction.Add(0.5);
+
+            string path = Path.Combine(TestContext.CurrentContext.TestDirectory, "ambiguous_only_group.mzID");
+            Write(new List<SpectralMatch> { psm }, new List<ProteinGroup> { group }, path);
+
+            try
+            {
+                AssertMinimumChildCounts(path);
+            }
+            finally
+            {
+                if (File.Exists(path)) File.Delete(path);
+            }
+        }
+
+        [Test]
+        public static void ProteinInAGroupWithNoPeptidesFromThisFileStillWritesValidMzid()
+        {
+            // The per-file shape ProteinGroup.ConstructSubsetProteinGroup produces: every protein of
+            // the group is kept, but AllPeptides is narrowed to the peptides seen in this file. In a
+            // multi-file search a protein whose evidence came from another file therefore has no
+            // peptide to point at, and its ProteinDetectionHypothesis comes out empty.
+            Protein withEvidence = new Protein("PEPTIDEK", "ACC1", databaseFilePath: "temp");
+            Protein withoutEvidence = new Protein("ANOTHERPEPTIDEK", "ACC2", databaseFilePath: "temp");
+
+            var peptide = withEvidence.Digest(new DigestionParams(), new List<Modification>(), new List<Modification>()).First();
+            var psm = new PeptideSpectralMatch(peptide, 0, 10, 0, Scan(), new CommonParameters(), new List<MatchedFragmentIon>());
+            psm.ResolveAllAmbiguities();
+            psm.SetFdrValues(0, 0, 0, 0, 0, 0, 0, 0);
+
+            var group = new ProteinGroup(
+                new HashSet<IBioPolymer> { withEvidence, withoutEvidence },
+                new HashSet<IBioPolymerWithSetMods> { peptide },
+                new HashSet<IBioPolymerWithSetMods>());
+            group.SequenceCoverageFraction.Add(0.5);
+            group.SequenceCoverageFraction.Add(0.0);
+
+            string path = Path.Combine(TestContext.CurrentContext.TestDirectory, "subset_group.mzID");
+            Write(new List<SpectralMatch> { psm }, new List<ProteinGroup> { group }, path);
+
+            try
+            {
+                AssertMinimumChildCounts(path);
+
+                // ACC1 keeps its hypothesis; only the evidence-free ACC2 is left out.
+                Assert.That(CountElements(path, "ProteinAmbiguityGroup"), Is.EqualTo(1));
+                Assert.That(CountElements(path, "ProteinDetectionHypothesis"), Is.EqualTo(1));
+                Assert.That(File.ReadAllText(path), Does.Contain("DBS_ACC1").And.Not.Contain("DBS_ACC2\""));
+            }
+            finally
+            {
+                if (File.Exists(path)) File.Delete(path);
+            }
+        }
+
+        [Test]
+        public static void ProteinGroupSupportedByAResolvedPsmWritesValidMzid()
+        {
+            // The control: the same shape of output, but with a PSM the writer does emit
+            // PeptideEvidence for. Guards against a fix that drops every group indiscriminately.
+            Protein protein = new Protein("PEPTIDEK", "ACC1", databaseFilePath: "temp");
+            var peptide = protein.Digest(new DigestionParams(), new List<Modification>(), new List<Modification>()).First();
+
+            var psm = new PeptideSpectralMatch(peptide, 0, 10, 0, Scan(), new CommonParameters(), new List<MatchedFragmentIon>());
+            psm.ResolveAllAmbiguities();
+            psm.SetFdrValues(0, 0, 0, 0, 0, 0, 0, 0);
+            Assert.That(psm.FullSequence, Is.Not.Null);
+
+            var group = new ProteinGroup(
+                new HashSet<IBioPolymer> { protein },
+                new HashSet<IBioPolymerWithSetMods> { peptide },
+                new HashSet<IBioPolymerWithSetMods> { peptide });
+            group.SequenceCoverageFraction.Add(0.5);
+
+            string path = Path.Combine(TestContext.CurrentContext.TestDirectory, "resolved_group.mzID");
+            Write(new List<SpectralMatch> { psm }, new List<ProteinGroup> { group }, path);
+
+            try
+            {
+                AssertMinimumChildCounts(path);
+
+                // The group must actually be present, not silently dropped.
+                Assert.That(CountElements(path, "ProteinDetectionHypothesis"), Is.EqualTo(1));
+                Assert.That(CountElements(path, "ProteinAmbiguityGroup"), Is.EqualTo(1));
+            }
+            finally
+            {
+                if (File.Exists(path)) File.Delete(path);
+            }
+        }
+
+        [Test]
+        public static void SilacSearchWithAnAmbiguousPsmDoesNotThrow()
+        {
+            // The SILAC pre-filter reads p.FullSequence.Contains("|"), but an ambiguous PSM has a
+            // null FullSequence -- the neighbouring p.BaseSequence != null check does not cover it.
+            // Only reachable when SilacLabels is non-null, i.e. an actual SILAC search.
+            var psm = AmbiguousPsm(out Protein protein);
+            var labels = new List<SilacLabel> { new SilacLabel('K', 'a', "C{13}6", 6.0201290768) };
+
+            string path = Path.Combine(TestContext.CurrentContext.TestDirectory, "silac_ambiguous.mzID");
+
+            try
+            {
+                Assert.That(() => Write(new List<SpectralMatch> { psm }, new List<ProteinGroup>(), path, labels),
+                    Throws.Nothing);
+            }
+            finally
+            {
+                if (File.Exists(path)) File.Delete(path);
+            }
+        }
+
+        private static SpectralMatch AmbiguousPsm(out Protein protein)
+        {
+            protein = new Protein("PEPTIDEK", "ACC1", databaseFilePath: "temp");
+
+            // A variable mod with two candidate sites on the same peptide gives two peptides of
+            // identical mass and different FullSequence, which is what makes a PSM ambiguous.
+            ModificationMotif.TryGetMotif("P", out ModificationMotif motif);
+            var variableMod = new Modification(_originalId: "Oxidation", _modificationType: "Common Variable",
+                _target: motif, _locationRestriction: "Anywhere.", _monoisotopicMass: 15.994915);
+
+            var candidates = protein
+                .Digest(new DigestionParams(), new List<Modification>(), new List<Modification> { variableMod })
+                .Where(p => p.AllModsOneIsNterminus.Count == 1)
+                .Take(2)
+                .ToList();
+            Assert.That(candidates.Count, Is.EqualTo(2), "digestion did not produce two singly-modified candidates");
+
+            var psm = new PeptideSpectralMatch(candidates[0], 0, 10, 0, Scan(), new CommonParameters(), new List<MatchedFragmentIon>());
+            psm.AddOrReplace(candidates[1], 10, 0, true, new List<MatchedFragmentIon>());
+            psm.ResolveAllAmbiguities();
+            psm.SetFdrValues(0, 0, 0, 0, 0, 0, 0, 0);
+            return psm;
+        }
+
+        private static Ms2ScanWithSpecificMass Scan()
+        {
+            var dataScan = new MsDataScan(new MzSpectrum(new double[] { 1 }, new double[] { 1 }, false), 0, 1, true,
+                Polarity.Positive, double.NaN, null, null, MZAnalyzerType.Orbitrap, double.NaN, null, null, "scan=1",
+                double.NaN, null, null, double.NaN, null, DissociationType.AnyActivationType, 0, null);
+            return new Ms2ScanWithSpecificMass(dataScan, 2, 0, "File", new CommonParameters());
+        }
+
+        // SearchParameters.SilacLabels is left null for a non-SILAC search, which is what the
+        // default production path passes.
+        private static void Write(List<SpectralMatch> psms, List<ProteinGroup> groups, string path,
+            List<SilacLabel> silacLabels = null)
+        {
+            MzIdentMLWriter.WriteMzIdentMl(psms, groups, new List<Modification>(), new List<Modification>(),
+                silacLabels, new List<DigestionAgent>(), new PpmTolerance(20), new PpmTolerance(20),
+                0, path, true);
+        }
+
+        private static int CountElements(string path, string localName)
+        {
+            int count = 0;
+            using var reader = XmlReader.Create(path);
+            while (reader.Read())
+            {
+                if (reader.NodeType == XmlNodeType.Element && reader.LocalName == localName) count++;
+            }
+            return count;
+        }
+
+        /// <summary>
+        /// Walks the ProteinDetectionList and asserts the two minOccurs="1" rules the writer can
+        /// break. Checking the shape directly rather than validating against mzIdentML1.1.0.xsd
+        /// keeps the schema out of the test data.
+        /// </summary>
+        private static void AssertMinimumChildCounts(string path)
+        {
+            var settings = new XmlReaderSettings { IgnoreWhitespace = true };
+            using var reader = XmlReader.Create(path, settings);
+
+            string currentPag = null, currentPdh = null;
+            int pdhInPag = 0, peptideHypothesisInPdh = 0;
+
+            while (reader.Read())
+            {
+                if (reader.NodeType == XmlNodeType.Element)
+                {
+                    switch (reader.LocalName)
+                    {
+                        case "ProteinAmbiguityGroup":
+                            currentPag = reader.GetAttribute("id");
+                            pdhInPag = 0;
+                            break;
+                        case "ProteinDetectionHypothesis":
+                            currentPdh = reader.GetAttribute("id");
+                            pdhInPag++;
+                            peptideHypothesisInPdh = 0;
+                            break;
+                        case "PeptideHypothesis":
+                            peptideHypothesisInPdh++;
+                            break;
+                    }
+                    // A childless element is serialized self-closing, so it never yields an
+                    // EndElement node for the checks below to fire on.
+                    if (reader.IsEmptyElement)
+                    {
+                        if (reader.LocalName == "ProteinDetectionHypothesis")
+                        {
+                            Assert.Fail($"ProteinDetectionHypothesis '{currentPdh}' is empty; the schema requires at least one PeptideHypothesis");
+                        }
+                        if (reader.LocalName == "ProteinAmbiguityGroup")
+                        {
+                            Assert.Fail($"ProteinAmbiguityGroup '{currentPag}' is empty; the schema requires at least one ProteinDetectionHypothesis");
+                        }
+                    }
+                }
+                else if (reader.NodeType == XmlNodeType.EndElement)
+                {
+                    if (reader.LocalName == "ProteinDetectionHypothesis")
+                    {
+                        Assert.That(peptideHypothesisInPdh, Is.GreaterThanOrEqualTo(1),
+                            $"ProteinDetectionHypothesis '{currentPdh}' has no PeptideHypothesis child, which mzIdentML 1.1 forbids");
+                    }
+                    else if (reader.LocalName == "ProteinAmbiguityGroup")
+                    {
+                        Assert.That(pdhInPag, Is.GreaterThanOrEqualTo(1),
+                            $"ProteinAmbiguityGroup '{currentPag}' has no ProteinDetectionHypothesis child, which mzIdentML 1.1 forbids");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/MetaMorpheus/Test/MzIdentMlSchemaTest.cs
+++ b/MetaMorpheus/Test/MzIdentMlSchemaTest.cs
@@ -45,11 +45,22 @@ namespace Test
             group.SequenceCoverageFraction.Add(0.5);
 
             string path = Path.Combine(TestContext.CurrentContext.TestDirectory, "ambiguous_only_group.mzID");
-            Write(new List<SpectralMatch> { psm }, new List<ProteinGroup> { group }, path);
 
             try
             {
+                Write(new List<SpectralMatch> { psm }, new List<ProteinGroup> { group }, path);
+
                 AssertMinimumChildCounts(path);
+
+                // AssertMinimumChildCounts alone would also pass on a document that contains no
+                // protein detection content whatsoever, so pin the intended shape explicitly: the
+                // group is dropped, and nothing else about the file is.
+                Assert.That(CountElements(path, "ProteinDetectionHypothesis"), Is.EqualTo(0));
+                Assert.That(CountElements(path, "ProteinAmbiguityGroup"), Is.EqualTo(0));
+                Assert.That(CountElements(path, "ProteinDetectionList"), Is.EqualTo(1),
+                    "the empty ProteinDetectionList is still written; only its invalid children are dropped");
+                Assert.That(CountElements(path, "SpectraData"), Is.EqualTo(1),
+                    "dropping the group must not narrow the rest of the document");
             }
             finally
             {
@@ -80,16 +91,22 @@ namespace Test
             group.SequenceCoverageFraction.Add(0.0);
 
             string path = Path.Combine(TestContext.CurrentContext.TestDirectory, "subset_group.mzID");
-            Write(new List<SpectralMatch> { psm }, new List<ProteinGroup> { group }, path);
 
             try
             {
+                Write(new List<SpectralMatch> { psm }, new List<ProteinGroup> { group }, path);
+
                 AssertMinimumChildCounts(path);
 
                 // ACC1 keeps its hypothesis; only the evidence-free ACC2 is left out.
                 Assert.That(CountElements(path, "ProteinAmbiguityGroup"), Is.EqualTo(1));
                 Assert.That(CountElements(path, "ProteinDetectionHypothesis"), Is.EqualTo(1));
-                Assert.That(File.ReadAllText(path), Does.Contain("DBS_ACC1").And.Not.Contain("DBS_ACC2\""));
+
+                // Assert on the hypothesis' dBSequence_ref, not on the bare accession: a plain
+                // Does.Contain("DBS_ACC1") is already satisfied by the DBSequence declaration in
+                // SequenceCollection and so would pass even if the hypothesis had been dropped.
+                Assert.That(File.ReadAllText(path),
+                    Does.Contain("dBSequence_ref=\"DBS_ACC1\"").And.Not.Contain("dBSequence_ref=\"DBS_ACC2\""));
             }
             finally
             {
@@ -117,10 +134,11 @@ namespace Test
             group.SequenceCoverageFraction.Add(0.5);
 
             string path = Path.Combine(TestContext.CurrentContext.TestDirectory, "resolved_group.mzID");
-            Write(new List<SpectralMatch> { psm }, new List<ProteinGroup> { group }, path);
 
             try
             {
+                Write(new List<SpectralMatch> { psm }, new List<ProteinGroup> { group }, path);
+
                 AssertMinimumChildCounts(path);
 
                 // The group must actually be present, not silently dropped.
@@ -136,8 +154,8 @@ namespace Test
         [Test]
         public static void SilacSearchWithAnAmbiguousPsmDoesNotThrow()
         {
-            // The SILAC pre-filter reads p.FullSequence.Contains("|"), but an ambiguous PSM has a
-            // null FullSequence -- the neighbouring p.BaseSequence != null check does not cover it.
+            // The SILAC pre-filter used to read p.FullSequence.Contains("|") guarded only by
+            // p.BaseSequence != null, but an ambiguous PSM has a null FullSequence, so it threw.
             // Only reachable when SilacLabels is non-null, i.e. an actual SILAC search.
             var psm = AmbiguousPsm(out Protein protein);
             var labels = new List<SilacLabel> { new SilacLabel('K', 'a', "C{13}6", 6.0201290768) };
@@ -148,6 +166,64 @@ namespace Test
             {
                 Assert.That(() => Write(new List<SpectralMatch> { psm }, new List<ProteinGroup>(), path, labels),
                     Throws.Nothing);
+
+                // Not throwing is not enough: filtering the ambiguous PSM out of psms entirely would
+                // also pass, while silently emptying peptides/proteins/filenames for the whole file.
+                // The PSM must still reach the writer and contribute its spectra data.
+                Assert.That(File.Exists(path));
+                Assert.That(CountElements(path, "SpectraData"), Is.EqualTo(1),
+                    "the ambiguous PSM must not be dropped from the SILAC pre-filter");
+            }
+            finally
+            {
+                if (File.Exists(path)) File.Delete(path);
+            }
+        }
+
+        [Test]
+        public static void DroppedGroupsLeaveGapsButDoNotRenumberSurvivingIds()
+        {
+            // The PR's compatibility claim is that the change is a pure deletion: elements that
+            // survive keep the PDH_n / PAG_n id they had before, so ids gain gaps rather than
+            // shifting. Nothing in mzIdentML 1.1 references a PAG or PDH id (they are xsd:string,
+            // not xsd:ID), so gaps are legal -- but renumbering would change every surviving id.
+            Protein withoutEvidence = new Protein("ANOTHERPEPTIDEK", "ACC2", databaseFilePath: "temp");
+            Protein withEvidence = new Protein("PEPTIDEK", "ACC1", databaseFilePath: "temp");
+
+            var peptide = withEvidence.Digest(new DigestionParams(), new List<Modification>(), new List<Modification>()).First();
+            var psm = new PeptideSpectralMatch(peptide, 0, 10, 0, Scan(), new CommonParameters(), new List<MatchedFragmentIon>());
+            psm.ResolveAllAmbiguities();
+            psm.SetFdrValues(0, 0, 0, 0, 0, 0, 0, 0);
+
+            // Group 0 has no peptide evidence and is dropped; group 1 survives and must stay PAG_1.
+            var dropped = new ProteinGroup(
+                new HashSet<IBioPolymer> { withoutEvidence },
+                new HashSet<IBioPolymerWithSetMods>(),
+                new HashSet<IBioPolymerWithSetMods>());
+            dropped.SequenceCoverageFraction.Add(0.0);
+
+            var kept = new ProteinGroup(
+                new HashSet<IBioPolymer> { withEvidence },
+                new HashSet<IBioPolymerWithSetMods> { peptide },
+                new HashSet<IBioPolymerWithSetMods> { peptide });
+            kept.SequenceCoverageFraction.Add(0.5);
+
+            string path = Path.Combine(TestContext.CurrentContext.TestDirectory, "id_stability.mzID");
+
+            try
+            {
+                Write(new List<SpectralMatch> { psm }, new List<ProteinGroup> { dropped, kept }, path);
+
+                AssertMinimumChildCounts(path);
+
+                Assert.That(CountElements(path, "ProteinAmbiguityGroup"), Is.EqualTo(1));
+                Assert.That(CountElements(path, "ProteinDetectionHypothesis"), Is.EqualTo(1));
+
+                string text = File.ReadAllText(path);
+                Assert.That(text, Does.Contain("id=\"PAG_1\""), "the surviving group must keep its original index");
+                Assert.That(text, Does.Contain("id=\"PDH_1\""), "the surviving hypothesis must keep its original index");
+                Assert.That(text, Does.Not.Contain("id=\"PAG_0\""));
+                Assert.That(text, Does.Not.Contain("id=\"PDH_0\""));
             }
             finally
             {


### PR DESCRIPTION
🤖 mzIdentML 1.1 requires at least one `PeptideHypothesis` in every `ProteinDetectionHypothesis`, and at least one `ProteinDetectionHypothesis` in every `ProteinAmbiguityGroup` — both `minOccurs="1"` in the HUPO-PSI schema. `MzIdentMLWriter` emits both empty, which ProteomeXchange rejects. This is part of the `.mzid` half of smith-chem-wisc/mzLib#259.

## Cause

`ProteinGroup.ConstructSubsetProteinGroup` builds the per-file view by keeping **all** of a group's `Proteins` while narrowing `AllPeptides` to the peptides seen in the current file. In a multi-file search a protein whose evidence came from another fraction therefore matches nothing in the writer's `peptide.Protein == protein` loop, and its hypothesis is written with no children. The same shape is reachable when a group's only supporting PSMs are ambiguous, since `FullSequence == null` PSMs are excluded from `PeptideEvidence`.

The list is now built with `List<>` instead of fixed-size arrays so an empty hypothesis, and a group left with none, can be skipped. `ProteinDetectionList/ProteinAmbiguityGroup` is `minOccurs="0"`, so dropping a group is valid. Retained elements keep their original `PDH_n` / `PAG_n` ids, so the diff against previous output is a pure deletion.

## Output change

**This changes the mzID.** Full 5-task vignette (Calibrate → GPTMD → Search as the vignette defines it), two fractions, mouse reviewed proteome + cRAP, run twice on identical inputs:

| task | file | PDH before | after | dropped | PAG before | after | dropped |
|---|---|---|---|---|---|---|---|
| Task1 Search | Frac4 | 2925 | 2826 | 99 | 2860 | 2763 | 97 |
| Task1 Search | Frac5 | 2963 | 2880 | 83 | 2888 | 2807 | 81 |
| Task3 Search (calib) | Frac4 | 2966 | 2844 | 122 | 2898 | 2782 | 116 |
| Task3 Search (calib) | Frac5 | 2986 | 2919 | 67 | 2913 | 2847 | 66 |
| Task5 Search (calib+GPTMD) | Frac4 | 3055 | 2922 | 133 | 2987 | 2860 | 127 |
| Task5 Search (calib+GPTMD) | Frac5 | 3043 | 2931 | 112 | 2972 | 2862 | 110 |
| **total** | | 17938 | 17322 | **616** | 17518 | 16921 | **597** |

Empty hypotheses after the fix: **0 in all six files.** Every "after" total is exactly `before − empty`, so only the invalid elements are removed and nothing else moves. 597 of the 616 were the sole protein in their group, taking the group with them; the other 19 sat in groups that survive with fewer hypotheses.

**Nothing outside the mzID changes.** `AllQuantifiedProteinGroups.tsv` (Task1 and Task5), `AllPSMs.psmtsv` (Task5) and the GPTMD-augmented `uniprot-mouse-reviewed-...GPTMD.xml` are **byte-identical** between the two runs. No search results, no quantification, no produced database is affected. Protein groups dropped from an mzID are still fully reported in the TSVs.

The count rises along the chain on both fractions, so the invalid tail is largest in the post-GPTMD search.

## Also fixed: a NullReferenceException

The SILAC pre-filter reads `!p.FullSequence.Contains("|")` guarded only by `p.BaseSequence != null`. An ambiguous PSM has a null `FullSequence`. Only reachable when `SilacLabels` is non-null — `SearchParameters` never initialises it, so non-SILAC searches pass null and skip the filter, but a SILAC search with any ambiguous PSM crashes mzID writing. Found while building the test, not from a report.

## This does not by itself make output submittable

Every `.mzID` MetaMorpheus writes is currently in namespace `http://psidev.info/psi/pi/mzIdentML/1.1.0` instead of `.../1.1`, which comes from mzLib 1.0.584 and makes the file unvalidatable regardless of this fix. That is smith-chem-wisc/mzLib#1171, and it needs an mzLib release plus a `PackageReference` bump before it reaches here. Both vignette runs above still show the wrong namespace.

So mzLib#259 needs this PR **and** mzLib#1171 **and** a release before a MetaMorpheus mzID passes ProteomeXchange.

## Not addressed

`sequence coverage` uses `proteinGroup.SequenceCoverageFraction.First()` for every protein in a group, so in a multi-protein ambiguity group the second and later hypotheses all report the first protein's coverage. `SequenceCoverageFraction` is ordered by `ListOfProteinsOrderedByAccession` while the writer iterates the unordered `Proteins` set, so a correct fix means pairing against the ordered list. It is a wrong value rather than a validity error and would change reported numbers, so it is left out.

I also have no explanation for why these counts are roughly ten times the checked-in 2024 vignette output (12 and 8 for the comparable files). The writer's `ProteinDetectionList` branch is unchanged since before that run, so the difference is upstream of it. Not investigated.

## Verification

**4 tests** in `MzIdentMlSchemaTest.cs` — the multi-file subset shape, the ambiguous-PSM shape, the SILAC crash, and a control asserting a well-formed group is *not* dropped. All four were confirmed to fail against the unfixed writer before being trusted.

Every pre-existing `MzIdentMLWriter` test passes an empty protein-group list, so the `ProteinDetectionList` branch had no coverage at all.

`Test` cannot run on macOS (the host needs `Microsoft.WindowsDesktop.App`), so these ran via a throwaway `net10.0` harness referencing `TaskLayer`/`EngineLayer`; `Test.csproj` compiles with `EnableWindowsTargeting`. **CI on windows-latest is the real check.**
