### PR TITLE
Read both spellings of the Cleavable column in a crosslinker tsv

### DIFF
--- a/MetaMorpheus/EngineLayer/CrosslinkSearch/Crosslinker.cs
+++ b/MetaMorpheus/EngineLayer/CrosslinkSearch/Crosslinker.cs
@@ -98,11 +98,10 @@ namespace EngineLayer
         public static Crosslinker ParseCrosslinkerFromString(string line)
         {
             var split = line.Split('\t');
-            bool cleavable = true;
-            if (split[3] == "F")
-            {
-                cleavable = false;
-            }
+            // Crosslinkers.tsv writes T/F but ToString(true) writes the bool's own True/False, so a
+            // custom crosslinker saved as uncleavable reloaded as cleavable
+            string cleavableField = split[3].Trim().ToUpperInvariant();
+            bool cleavable = cleavableField != "F" && cleavableField != "FALSE";
 
             Crosslinker crosslinker = new Crosslinker(
                 crosslinkerName: split[0],

--- a/MetaMorpheus/Test/XLTest.cs
+++ b/MetaMorpheus/Test/XLTest.cs
@@ -53,6 +53,48 @@ namespace Test
             Assert.That(crosslinkerString == "testCrosslinker\tK\tK\tTrue\tCID|HCD|\t100\t25\t60\t0\t0\t50");
         }
 
+        /// <summary>
+        /// A custom crosslinker has to survive the save-and-reload the GUI puts it through:
+        /// CustomCrosslinkerWindow writes ToString(true), which spells the bool "True"/"False", while the
+        /// shipped Crosslinkers.tsv spells it "T"/"F". The reader has to read both, or an uncleavable
+        /// custom crosslinker comes back cleavable on the next launch.
+        /// </summary>
+        [Test]
+        public static void UncleavableCrosslinkerStaysUncleavableThroughAFileRoundTrip()
+        {
+            var asEntered = new Crosslinker("K", "K", "MyNonCleavable", false, "", 138.06808, 0, 0,
+                138.06808, 156.0786, 155.0946, 259.142);
+
+            string customCrosslinkerFile = Path.Combine(TestContext.CurrentContext.TestDirectory,
+                "XlTestData", "RoundTripCustomCrosslinkers.tsv");
+            Directory.CreateDirectory(Path.GetDirectoryName(customCrosslinkerFile));
+            File.WriteAllLines(customCrosslinkerFile, new[]
+            {
+                "Name\tCrosslinkAminoAcid\tCrosslinkerAminoAcid2\tCleavable\tDissociationType\tCrosslinkerTotalMass\tCrosslinkerShortMass\tCrosslinkerLongMass\tQuenchMassH2O\tQuenchMassNH2\tQuenchMassTris",
+                asEntered.ToString(true)
+            });
+
+            var reloaded = Crosslinker.LoadCrosslinkers(customCrosslinkerFile).Single();
+            Assert.That(reloaded.Cleavable, Is.False);
+            Assert.That(reloaded.CleaveDissociationTypes, Is.Empty);
+
+            // the bool alone gates signature-ion generation, so getting it wrong adds a theoretical M ion
+            // at the intact crosslinked precursor mass
+            var alphaPeptide = new Protein("PEPTIDEK", "").Digest(new DigestionParams(),
+                new List<Modification>(), new List<Modification>()).First();
+            var fragments = CrosslinkedPeptide.XlGetTheoreticalFragments(DissociationType.HCD, reloaded,
+                new List<int> { 7 }, 1000, alphaPeptide).Single().Item2;
+            Assert.That(fragments.Where(v => v.ProductType == ProductType.M), Is.Empty);
+
+            // the shipped T/F spelling still reads, in both directions
+            Assert.That(Crosslinker.ParseCrosslinkerFromString(
+                "shipped\tK\tK\tF\t\t138.06808\t0\t0\t156.0786\t155.0946\t259.142").Cleavable, Is.False);
+            Assert.That(Crosslinker.ParseCrosslinkerFromString(
+                "shipped\tK\tK\tT\tCID|HCD\t158.0038\t54.01056\t85.982635\t176.0143\t175.0303\t279.0777").Cleavable, Is.True);
+
+            File.Delete(customCrosslinkerFile);
+        }
+
         [Test]
         public static void XlTestXlPosCal()
         {


### PR DESCRIPTION
🤖 A custom crosslinker saved with the Cleavable box unticked came back **cleavable** on the next launch.

`Data/Crosslinkers.tsv` spells that column `T`/`F`. The custom-crosslinker GUI saves through `Crosslinker.ToString(true)` (`CustomCrosslinkerWindow.xaml.cs:66`), which interpolates the bool and so spells it `True`/`False`. `ParseCrosslinkerFromString` only recognised `"F"`, so `"False"` fell through to the `cleavable = true` default.

## Output change

Measured on the exact line the GUI writes for an uncleavable DSS-like entry:

```
file line    : MyNonCleavable<TAB>K<TAB>K<TAB>False<TAB><TAB>138.06808<TAB>0<TAB>0<TAB>156.0786<TAB>155.0946<TAB>259.142
as entered   : Cleavable=False  CleaveDissociationTypes=[]
after reload : Cleavable=True   CleaveDissociationTypes=[]
```

The type list stays empty, so `IsCleavedBy` stays false and the localized masses do not move. But `Cleavable` gates signature-ion generation on its own at `CrosslinkedPeptides.cs:61`, so the reloaded crosslinker generated **one extra theoretical M ion per candidate**, at the intact crosslinked precursor mass — for `PEPTIDEK` crosslinked to a 1000 Da partner, 15 theoretical fragments instead of 14, the extra one at 2065.523 = 927.455 + 138.068 + 1000.

Inferred, not measured: that mass is the precursor, which is often present unfragmented in an MS2 scan, so it can match and add to a score; `Cleavable` also gates `CrosslinkSearchEngine.cs:315` and `:657`, which then populate `ParentIonMaxIntensityRanks` from those matched ions. **I have not run a search on real data, so I cannot say whether any PSM or FDR value moves.** Only searches using a *custom* uncleavable crosslinker are affected at all — the shipped file's `T`/`F` always parsed correctly.

Two output fields also reported the wrong value and are fixed by the same change: the pepXML `Cross-linker cleavable` parameter (`WriteXlFile.cs:123`) and the prose line at `XLSearchTask.cs:70`.

The session in which the crosslinker is created was always fine — `AddCrosslinkers` keeps the in-memory object. The bug only appeared after a restart.

## Fix

Reader-side, so existing `Data/CustomCrosslinkers.tsv` files are repaired rather than just newly-written ones. Making `ToString(true)` emit `T`/`F` instead would align the writer with the shipped format but would leave files already on disk misparsing; it is also the only production caller of that overload, so it can be changed later without touching anything else.

## Test

`UncleavableCrosslinkerStaysUncleavableThroughAFileRoundTrip` builds the file the GUI writes, reads it back through `LoadCrosslinkers`, and asserts the bool survives, that no signature ion is generated, and that the shipped `T`/`F` spelling still reads in both directions. It fails against the unfixed reader (`Expected: False / But was: True`).

Verified: `Test.csproj` compiles with `EnableWindowsTargeting`, and the test was run through a net10.0 harness against `EngineLayer`, both against the fix and against the unfixed reader. The full `XLTest` fixture cannot run on macOS.

Found while working on #2717 — same save-and-reload path, where the dissociation-type column had a matching case-sensitivity bug (#2716).
