### PR TITLE
Place non-specific terminal modifications by peptide-relative key

### DIFF
--- a/MetaMorpheus/EngineLayer/NonSpecificEnzymeSearch/NonSpecificEnzymeSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/NonSpecificEnzymeSearch/NonSpecificEnzymeSearchEngine.cs
@@ -350,17 +350,20 @@ namespace EngineLayer.NonSpecificEnzymeSearch
                     if (fragmentationTerminus == FragmentationTerminus.N)
                     {
                         int endResidue = peptide.OneBasedStartResidue + fragment.FragmentNumber - 1; //-1 for one based index
+                        // Mod keys are peptide-relative: 1 is the N-terminus, 2 the first residue, length+2 the C-terminus.
+                        int cTerminusModKey = fragment.FragmentNumber + 2;
                         Dictionary<int, Modification> updatedMods = new Dictionary<int, Modification>();
                         foreach (KeyValuePair<int, Modification> mod in peptide.AllModsOneIsNterminus)
                         {
-                            if (mod.Key < endResidue - peptide.OneBasedStartResidue + 3) //check if we cleaved it off, +1 for N-terminus being mod 1 and first residue being mod 2, +1 again for the -1 on end residue for one based index, +1 (again) for the one-based start residue
+                            if (mod.Key < cTerminusModKey) //check if we cleaved it off
                             {
                                 updatedMods.Add(mod.Key, mod.Value);
                             }
                         }
                         if (terminalMod != null)
                         {
-                            updatedMods.Add(endResidue, terminalMod);
+                            // The filter above admits only keys below this one, so it is always free.
+                            updatedMods.Add(cTerminusModKey, terminalMod);
                         }
                         updatedPwsm = new PeptideWithSetModifications(peptide.Protein, peptide.DigestionParams, peptide.OneBasedStartResidue, endResidue, CleavageSpecificity.Unknown, "", 0, updatedMods, 0);
                     }
@@ -377,9 +380,10 @@ namespace EngineLayer.NonSpecificEnzymeSearch
                                 updatedMods.Add(key, mod.Value);
                             }
                         }
-                        if (terminalMod != null && !updatedMods.Keys.Contains(startResidue - 1))
+                        if (terminalMod != null)
                         {
-                            updatedMods.Add(startResidue - 1, terminalMod);
+                            // Key 1 is the peptide N-terminus; the shift above only produces keys of 2 or more.
+                            updatedMods.Add(1, terminalMod);
                         }
                         updatedPwsm = new PeptideWithSetModifications(peptide.Protein, peptide.DigestionParams, startResidue, peptide.OneBasedEndResidue, CleavageSpecificity.Unknown, "", 0, updatedMods, 0);
                     }
@@ -421,11 +425,11 @@ namespace EngineLayer.NonSpecificEnzymeSearch
                                 //add the terminal mod
                                 if (fragmentationTerminus == FragmentationTerminus.N)
                                 {
-                                    updatedMods[peptide.OneBasedEndResidue + 1] = terminalMod;
+                                    updatedMods[peptide.Length + 2] = terminalMod;
                                 }
                                 else
                                 {
-                                    updatedMods[peptide.OneBasedStartResidue - 1] = terminalMod;
+                                    updatedMods[1] = terminalMod;
                                 }
 
                                 PeptideWithSetModifications updatedPwsm = new PeptideWithSetModifications(peptide.Protein, peptide.DigestionParams, peptide.OneBasedStartResidue, peptide.OneBasedEndResidue, CleavageSpecificity.Unknown, "", 0, updatedMods, peptide.NumFixedMods);

--- a/MetaMorpheus/Test/SearchEngineTests.cs
+++ b/MetaMorpheus/Test/SearchEngineTests.cs
@@ -2034,5 +2034,191 @@ namespace Test
             File.Delete(xmlName);
             File.Delete(mzmlName);
         }
+
+        /// <summary>
+        /// A C-terminal variable modification found by Accepts must land on the truncated peptide's
+        /// C-terminus regardless of where in the protein that peptide starts. The key used to be an
+        /// absolute protein coordinate, so it was only correct for peptides starting at residue 3.
+        /// The parameter is where the matched peptide begins in the protein.
+        /// </summary>
+        [Test]
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(3)]
+        [TestCase(5)]
+        public static void TestNonSpecificEnzymeSearchTerminalModPlacementSingleN(int startResidue)
+        {
+            SearchParameters SearchParameters = new SearchParameters
+            {
+                SearchTarget = true,
+                MassDiffAcceptorType = MassDiffAcceptorType.Exact,
+                LocalFdrCategories = new List<FdrCategory> { FdrCategory.NonSpecific }
+            };
+            DigestionParams dp = new DigestionParams("singleN", minPeptideLength: 5,
+                fragmentationTerminus: FragmentationTerminus.N, searchModeType: CleavageSpecificity.None);
+            CommonParameters CommonParameters = new CommonParameters(
+                dissociationType: DissociationType.HCD, digestionParams: dp, scoreCutoff: 5,
+                precursorMassTolerance: new PpmTolerance(5), addCompIons: true);
+
+            ModificationMotif.TryGetMotif("K", out ModificationMotif kMotif);
+            Modification cTerminalMod = new Modification(_originalId: "TerminalProbe", _modificationType: "TestTerminal",
+                _target: kMotif, _locationRestriction: "C-terminal.", _monoisotopicMass: 42.010565);
+            var variableModifications = new List<Modification> { cTerminalMod };
+            var fixedModifications = new List<Modification>();
+
+            // The searched peptide is always AAAAAK; a glycine prefix moves where it starts in the
+            // protein, which is the coordinate the old key depended on. Glycine differs in mass from
+            // alanine, so a window starting at residue 1 cannot match the same precursor.
+            PeptideWithSetModifications guiltyPwsm = new PeptideWithSetModifications(
+                "AAAAAK-[TestTerminal:TerminalProbe on K]",
+                new Dictionary<string, Modification> { { "TerminalProbe on K", cTerminalMod } });
+            var fragments = new List<Product>();
+            guiltyPwsm.Fragment(CommonParameters.DissociationType, FragmentationTerminus.Both, fragments);
+
+            var myMsDataFile = new TestDataFile(guiltyPwsm.MonoisotopicMass, fragments.Select(x => x.NeutralMass.ToMz(1)).ToArray());
+            string prefix = new string('G', startResidue - 1);
+            var proteinList = new List<Protein> { new Protein(prefix + "AAAAAK" + new string('G', 10), null) };
+
+            SpectralMatch bestPsm = RunNonSpecificEngine(proteinList, variableModifications, fixedModifications,
+                CommonParameters, SearchParameters, myMsDataFile);
+
+            Assert.That(bestPsm, Is.Not.Null);
+            bestPsm.ResolveAllAmbiguities();
+            // The mod must render at the C-terminus ("-[...]"), not on an interior residue, and must
+            // still be present at all -- an out-of-range key silently drops it from the sequence.
+            Assert.That(bestPsm.FullSequence, Is.EqualTo(guiltyPwsm.FullSequence));
+        }
+
+        /// <summary>
+        /// The mirror case: an N-terminal variable modification on a singleC search must land on the
+        /// truncated peptide's N-terminus (key 1), not on its first residue.
+        /// </summary>
+        [Test]
+        public static void TestNonSpecificEnzymeSearchTerminalModPlacementSingleC()
+        {
+            SearchParameters SearchParameters = new SearchParameters
+            {
+                SearchTarget = true,
+                MassDiffAcceptorType = MassDiffAcceptorType.Exact,
+                LocalFdrCategories = new List<FdrCategory> { FdrCategory.NonSpecific }
+            };
+            DigestionParams dp = new DigestionParams("singleC", minPeptideLength: 5,
+                fragmentationTerminus: FragmentationTerminus.C, searchModeType: CleavageSpecificity.None);
+            CommonParameters CommonParameters = new CommonParameters(
+                dissociationType: DissociationType.HCD, digestionParams: dp, scoreCutoff: 5,
+                precursorMassTolerance: new PpmTolerance(5), addCompIons: true);
+
+            ModificationMotif.TryGetMotif("K", out ModificationMotif kMotif);
+            Modification nTerminalMod = new Modification(_originalId: "TerminalProbe", _modificationType: "TestTerminal",
+                _target: kMotif, _locationRestriction: "N-terminal.", _monoisotopicMass: 42.010565);
+            var variableModifications = new List<Modification> { nTerminalMod };
+            var fixedModifications = new List<Modification>();
+
+            PeptideWithSetModifications guiltyPwsm = new PeptideWithSetModifications(
+                "[TestTerminal:TerminalProbe on K]KAAAAAAA",
+                new Dictionary<string, Modification> { { "TerminalProbe on K", nTerminalMod } });
+            var fragments = new List<Product>();
+            guiltyPwsm.Fragment(CommonParameters.DissociationType, FragmentationTerminus.Both, fragments);
+
+            var myMsDataFile = new TestDataFile(guiltyPwsm.MonoisotopicMass, fragments.Select(x => x.NeutralMass.ToMz(1)).ToArray());
+            var proteinList = new List<Protein> { new Protein("GGK" + new string('A', 7), null) };
+
+            SpectralMatch bestPsm = RunNonSpecificEngine(proteinList, variableModifications, fixedModifications,
+                CommonParameters, SearchParameters, myMsDataFile);
+
+            Assert.That(bestPsm, Is.Not.Null);
+            bestPsm.ResolveAllAmbiguities();
+            Assert.That(bestPsm.FullSequence, Is.EqualTo(guiltyPwsm.FullSequence));
+        }
+
+        /// <summary>
+        /// Issue #2400: a modification already occupying the key Accepts wanted for the terminal mod
+        /// threw "An item with the same key has already been added". Both modifications must survive.
+        /// </summary>
+        [Test]
+        public static void TestNonSpecificEnzymeSearchTerminalModDoesNotCollide()
+        {
+            SearchParameters SearchParameters = new SearchParameters
+            {
+                SearchTarget = true,
+                MassDiffAcceptorType = MassDiffAcceptorType.Exact,
+                LocalFdrCategories = new List<FdrCategory> { FdrCategory.NonSpecific }
+            };
+            DigestionParams dp = new DigestionParams("singleN", minPeptideLength: 5,
+                fragmentationTerminus: FragmentationTerminus.N, searchModeType: CleavageSpecificity.None);
+            CommonParameters CommonParameters = new CommonParameters(
+                dissociationType: DissociationType.HCD, digestionParams: dp, scoreCutoff: 5,
+                precursorMassTolerance: new PpmTolerance(5), addCompIons: true);
+
+            ModificationMotif.TryGetMotif("M", out ModificationMotif mMotif);
+            ModificationMotif.TryGetMotif("K", out ModificationMotif kMotif);
+            Modification oxidation = new Modification(_originalId: "Oxidation", _modificationType: "TestVariable",
+                _target: mMotif, _locationRestriction: "Anywhere.", _monoisotopicMass: 15.994915);
+            Modification cTerminalMod = new Modification(_originalId: "TerminalProbe", _modificationType: "TestTerminal",
+                _target: kMotif, _locationRestriction: "C-terminal.", _monoisotopicMass: 42.010565);
+            var variableModifications = new List<Modification> { oxidation, cTerminalMod };
+            var fixedModifications = new List<Modification>();
+
+            // Oxidation on the M occupies the mod key the old code reused for the terminal mod.
+            PeptideWithSetModifications guiltyPwsm = new PeptideWithSetModifications(
+                "AAAAAAAAM[TestVariable:Oxidation on M]K-[TestTerminal:TerminalProbe on K]",
+                new Dictionary<string, Modification>
+                {
+                    { "Oxidation on M", oxidation },
+                    { "TerminalProbe on K", cTerminalMod }
+                });
+            var fragments = new List<Product>();
+            guiltyPwsm.Fragment(CommonParameters.DissociationType, FragmentationTerminus.Both, fragments);
+
+            var myMsDataFile = new TestDataFile(guiltyPwsm.MonoisotopicMass, fragments.Select(x => x.NeutralMass.ToMz(1)).ToArray());
+            var proteinList = new List<Protein> { new Protein("AAAAAAAAMK" + new string('G', 10), null) };
+
+            SpectralMatch bestPsm = null;
+            Assert.DoesNotThrow(() => bestPsm = RunNonSpecificEngine(proteinList, variableModifications,
+                fixedModifications, CommonParameters, SearchParameters, myMsDataFile));
+
+            Assert.That(bestPsm, Is.Not.Null);
+            bestPsm.ResolveAllAmbiguities();
+            Assert.That(bestPsm.FullSequence, Is.EqualTo(guiltyPwsm.FullSequence));
+        }
+
+        /// <summary>
+        /// Shared setup for the non-specific terminal-modification tests: index the proteins, run the
+        /// engine over a single scan, and hand back the best match for the NonSpecific FDR category.
+        /// </summary>
+        private static SpectralMatch RunNonSpecificEngine(List<Protein> proteinList,
+            List<Modification> variableModifications, List<Modification> fixedModifications,
+            CommonParameters commonParameters, SearchParameters searchParameters, MsDataFile myMsDataFile)
+        {
+            var indexEngine = new IndexingEngine(proteinList, variableModifications, fixedModifications, null, null, null,
+                1, DecoyType.None, commonParameters, null, searchParameters.MaxFragmentSize, true,
+                new List<FileInfo>(), TargetContaminantAmbiguity.RemoveContaminant, new List<string>());
+            var indexResults = (IndexingResults)indexEngine.Run();
+
+            var listOfSortedms2Scans = MetaMorpheusTask.GetMs2Scans(myMsDataFile, null, new CommonParameters())
+                .OrderBy(b => b.PrecursorMass).ToArray();
+            MassDiffAcceptor massDiffAcceptor = SearchTask.GetMassDiffAcceptor(commonParameters.PrecursorMassTolerance,
+                searchParameters.MassDiffAcceptorType, searchParameters.CustomMdac);
+
+            SpectralMatch[][] allPsmsArrays = new PeptideSpectralMatch[3][];
+            for (int i = 0; i < allPsmsArrays.Length; i++)
+            {
+                allPsmsArrays[i] = new PeptideSpectralMatch[listOfSortedms2Scans.Length];
+            }
+
+            List<int>[] coisolationIndex = new List<int>[listOfSortedms2Scans.Length];
+            for (int i = 0; i < listOfSortedms2Scans.Length; i++)
+            {
+                coisolationIndex[i] = new List<int> { i };
+            }
+
+            new NonSpecificEnzymeSearchEngine(allPsmsArrays, listOfSortedms2Scans, coisolationIndex,
+                indexResults.PeptideIndex, indexResults.FragmentIndex, indexResults.PrecursorIndex, 0,
+                commonParameters, null, variableModifications, massDiffAcceptor,
+                searchParameters.MaximumMassThatFragmentIonScoreIsDoubled, new List<string>()).Run();
+
+            return allPsmsArrays[(int)FdrCategory.NonSpecific].FirstOrDefault(p => p != null);
+        }
+
     }
 }


### PR DESCRIPTION
## Problem

🤖 `NonSpecificEnzymeSearchEngine.Accepts` used **absolute protein coordinates** as keys into `AllModsOneIsNterminus`, which is **peptide-relative** (`1` = N-terminus, `2` = first residue, `length + 2` = C-terminus). Four sites were affected, each correct at exactly one start position:

| Site | Was | Should be | Correct only when |
|---|---|---|---|
| N-truncation, C-terminal mod | `endResidue` | `FragmentNumber + 2` | `OneBasedStartResidue == 3` |
| C-truncation, N-terminal mod | `startResidue - 1` | `1` | `OneBasedEndResidue == F + 1` |
| full-length fallback (N) | `OneBasedEndResidue + 1` | `Length + 2` | `OneBasedStartResidue == 2` |
| full-length fallback (C) | `OneBasedStartResidue - 1` | `1` | `OneBasedStartResidue == 2` |

Measured on a `singleN` search with a C-terminal variable modification, sweeping where the matched peptide starts in the protein:

| peptide starts at | before | after |
|---|---|---|
| residue 1 | `AAAAA[mod]K` — on residue 5 | `AAAAAK-[mod]` |
| residue 2 | `AAAAAK[mod]` — on the K as a *residue* mod | `AAAAAK-[mod]` |
| residue 3 | `AAAAAK-[mod]` (already correct) | unchanged |
| residue 5 | `AAAAAK` — **mod silently dropped**, though the mass still includes it | `AAAAAK-[mod]` |
| `singleC` | `K[mod]AAAAAAA` — residue 1, not the N-terminus | `[mod]KAAAAAAA` |

The out-of-range case is the worst: `MonoisotopicMass` includes a modification that `FullSequence` does not show.

When another modification already occupied the wanted key, `Dictionary.Add` threw `An item with the same key has already been added`.

## Why the #2453 guard is removed rather than mirrored

#2453 fixed the C-terminal twin by guarding with `!updatedMods.Keys.Contains(startResidue - 1)`. That guard **skips adding the terminal modification**, but the notch that admitted the match was computed *including* that modification's mass. So affected non-specific searches have been reporting peptides whose sequence omits a modification their precursor match depended on — a crash traded for silent data loss.

With the corrected keys the guard is unnecessary and actively harmful: the N-side copy filter admits only keys **below** `FragmentNumber + 2`, and the C-side shift produces only keys **≥ 2**, so the target slot is provably free. A guard on a correct key would drop the modification instead of placing it.

## Scope

The copy-filter bound is algebraically unchanged — `endResidue - OneBasedStartResidue + 3` is identically `FragmentNumber + 2` — so **matches without a terminal-restricted modification are unaffected**. Confirmed empirically: `TestNonSpecificEnzymeSearchEngineSingleNModifications` and `...SingleCModifications` both still pass (they use only `Anywhere.` mods).

`IndexingEngine.AddInteriorTerminalModsToPrecursorIndex` is the only other terminal-modification code path; it computes masses and bins and never builds a modification dictionary, so it needs no change.

## ⚠️ This changes output

For non-specific searches that use terminal-restricted modifications, reported sequences **and scores** change: `Accepts` re-fragments and re-scores the peptide it returns, so relocating a terminal modification changes the theoretical ion series, the score, FDR ranking, and which FDR category wins a scan. Runs without terminal-restricted modifications are unaffected.

## Tests

This branch of `Accepts` had **no placement coverage** before this PR — no existing test used a `C-terminal.`/`N-terminal.` `LocationRestriction`.

Worth knowing: the existing #2453 regression test cannot detect this class of bug. `TestNonSpecificEnzymeSearchEngine` yields **39 PSMs and 0 with a terminal-placed modification, both before and after this change** — it guards the exception, not the placement. It does still pass, which is the safety check that matters for the code being touched.

Added to `SearchEngineTests.cs`: a 4-case start-position sweep (`singleN`), the `singleC` mirror, and the collision case where a competing `Anywhere` modification occupies the wanted key. All run the real engine through `IndexingEngine` + `NonSpecificEnzymeSearchEngine`, in the style of the existing non-specific tests. **5 of the 6 fail against unfixed code; all 6 pass with the fix** — and the one that passes unfixed is `start=3`, exactly the single position the old arithmetic was right for.

Verified on macOS via a throwaway `net10.0` harness compiling the committed test methods verbatim, since `Test.csproj` targets `net10.0-windows`; `Test.csproj` and `CMD.csproj` build clean with `EnableWindowsTargeting`. **The full Windows suite has not been run locally — CI is the real gate.**

Closes #2400 — the reported crash was in the C-terminal branch and was fixed by #2453; this closes the remaining N-terminal path flagged on that issue, so the exception is no longer reachable from `Accepts`.
