### PR TITLE
fix(deps): align TopDownProteomics and Newtonsoft.Json with mzLib

### DIFF
--- a/MetaMorpheus/EngineLayer/EngineLayer.csproj
+++ b/MetaMorpheus/EngineLayer/EngineLayer.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.118" />
-    <PackageReference Include="TopDownProteomics" Version="0.0.297" />
+    <PackageReference Include="TopDownProteomics" Version="0.0.299" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes the top-down Jenkins crash.

## Symptom

Top-down searches crash while writing results:

```
System.IO.FileNotFoundException: Could not load file or assembly
'TopDownProteomics, Version=0.0.299.0, Culture=neutral, PublicKeyToken=null'
   at Readers.ProForma.ProFormaExtensions.ToProFormaString(IBioPolymerWithSetMods)
   at EngineLayer.PsmTsvWriter.AddPeptideSequenceData(...) PsmTsvWriter.cs:line 207
   at TaskLayer.PostSearchAnalysisTask.WritePsmResults()
```

## Cause

Not a missing file — a **version mismatch**. `TopDownProteomics.dll` is in the output folder the whole time; it is just the wrong version.

| | version |
|---|---|
| mzLib `Readers` is compiled against | **0.0.299** |
| What actually lands in the output folder | **0.0.297** |

`EngineLayer.csproj` carried a direct `PackageReference` to 0.0.297. NuGet's nearest-wins rule lets a direct reference beat mzLib's transitive one, so 0.0.297 wins. .NET rolls assembly versions *forward* but never *backward*, so the request for `0.0.299.0` cannot bind to `0.0.297.0` and `ToProFormaString` throws.

This surfaced now because #2675 (ProForma column) added the first call into `Readers.ProForma`, and #2728 bumped mzLib to 1.0.585.

## Fix

One line. `EngineLayer` uses TopDownProteomics directly (`GlobalVariables.cs`), so the reference stays — it just tracks the version mzLib builds against.

## Verification

- Re-ran a top-down search that previously threw: completes, writes `AllPSMs.psmtsv` / `AllProteoforms.psmtsv` / `AllProteinGroups.tsv` / mzID, and populates the ProForma column.
- Confirmed the output folder now carries `TopDownProteomics, Version=0.0.299.0`.
- ProForma + top-down tests: 22 passed, 0 failed.

## Follow-ups (not in this PR)

1. **`mzLib.nuspec` is hand-authored** and its `<dependencies>` list has drifted from the csprojs. `TopDownProteomics` is not declared there at all, which is why MetaMorpheus's stale pin was free to win. Needs an mzLib-side fix in both target-framework groups, ideally generated from the csprojs.
2. **`ZstdSharp.Port` is the next one.** `Readers` references it, the nuspec omits it, and nothing supplies it to MetaMorpheus — `ZstdSharp.dll` is absent from the output folder entirely. Any zstd-compressed read will throw the identical error.
3. **Test-data gap.** The existing top-down fixtures (`TDGPTMDSearchSingleSpectra.mzML` + `ThreeHumanHistone.fasta`) yield zero PSMs, so the ProForma writer is never invoked and the run passes green. A top-down fixture that actually produces PSMs would have caught this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)