### PR TITLE
fix(deps): bump Newtonsoft.Json to 13.0.4 to match mzLib

### DIFF
--- a/MetaMorpheus/EngineLayer/EngineLayer.csproj
+++ b/MetaMorpheus/EngineLayer/EngineLayer.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="mzLib" Version="1.0.585" />
     <PackageReference Include="Nett" Version="0.15.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.118" />
     <PackageReference Include="TopDownProteomics" Version="0.0.299" />

--- a/MetaMorpheus/GUI/GUI.csproj
+++ b/MetaMorpheus/GUI/GUI.csproj
@@ -64,7 +64,7 @@
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
     <PackageReference Include="mzLib" Version="1.0.585" />
     <PackageReference Include="Nett" Version="0.15.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.0.0" />
     <PackageReference Include="SharpLearning.CrossValidation" Version="0.31.8" />


### PR DESCRIPTION
Follow-up to #2740. That PR aligned `TopDownProteomics`, but was merged from the branch state just before the second commit landed, so this pin is still on master at 13.0.3.

## Why

mzLib's `PredictionClients` and `UsefulProteomicsDatabases` build against **Newtonsoft.Json 13.0.4**; `EngineLayer` and `GUI` pin **13.0.3**.

It resolves silently today only because `mzLib.nuspec` does not declare Newtonsoft.Json at all — NuGet has nothing to unify against, so the older direct reference wins by nearest-wins. That is the identical mechanism behind the top-down `FileNotFoundException`: an undeclared dependency lets a stale consumer pin quietly beat the version the library was actually compiled against.

Once mzLib declares its real dependencies (smith-chem-wisc/mzLib#1179), the pin stops being silent and becomes a hard restore failure:

```
error NU1605: Detected package downgrade: Newtonsoft.Json from 13.0.4 to 13.0.3.
  EngineLayer -> mzLib -> Newtonsoft.Json (>= 13.0.4)
```

## Scope

Two lines — `EngineLayer.csproj` and `GUI.csproj`. Both 13.0.x share assembly version `13.0.0.0`, so this is a package-resolution alignment, not a binding change.

This is the **last remaining downgrade** blocking mzLib#1179's integration job. With #2740 merged and this in, both `NU1605` errors clear and that PR can go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)