### PR TITLE
Split the Windows test job across two runners (21m -> ~13m)

### DIFF
--- a/.github/no-empty-test-run.runsettings
+++ b/.github/no-empty-test-run.runsettings
@@ -4,10 +4,13 @@
 
   Test.yml splits the Windows suite by a FullyQualifiedName filter. If a fixture is renamed or a
   filter string is mistyped, one half matches zero tests, and by default VSTest reports that as a
-  warning and exits 0 -- so the job stays green while the tests silently stop running.
+  warning and exits 0, so the job stays green while those tests silently stop running.
 
-  Only this runsettings form works. Plain `dotnet test --filter` and `-p:TreatNoTestsAsError=true`
-  both still exit 0 on a zero-match filter.
+  This runsettings form is the only one that works. Passing the filter alone, or setting
+  TreatNoTestsAsError as an MSBuild property, both still exit 0 on a zero match.
+
+  Note for editors: XML comments cannot contain a double hyphen, so command line flags are
+  spelled out in words above rather than quoted literally.
 -->
 <RunSettings>
   <RunConfiguration>

--- a/.github/no-empty-test-run.runsettings
+++ b/.github/no-empty-test-run.runsettings
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Makes a filter that matches nothing a build failure instead of a warning.
+
+  Test.yml splits the Windows suite by a FullyQualifiedName filter. If a fixture is renamed or a
+  filter string is mistyped, one half matches zero tests, and by default VSTest reports that as a
+  warning and exits 0 -- so the job stays green while the tests silently stop running.
+
+  Only this runsettings form works. Plain `dotnet test --filter` and `-p:TreatNoTestsAsError=true`
+  both still exit 0 on a zero-match filter.
+-->
+<RunSettings>
+  <RunConfiguration>
+    <TreatNoTestsAsError>true</TreatNoTestsAsError>
+  </RunConfiguration>
+</RunSettings>

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -35,11 +35,8 @@ jobs:
       - name: Build
         run: dotnet build --no-restore ./MetaMorpheus/MetaMorpheus.sln --configuration Release
 
-      - name: Install Coverlet for code coverage
-        run: dotnet add ./MetaMorpheus/Test/Test.csproj package coverlet.collector -v 6.0.2
-
       - name: Run unit tests with coverage
-        run: dotnet test .\MetaMorpheus\Test\Test.csproj --configuration Release --verbosity normal --filter "Category!=ExternalService&FullyQualifiedName~Test.TestOGlyco" --collect:"XPlat Code Coverage"
+        run: dotnet test .\MetaMorpheus\Test\Test.csproj --configuration Release --no-build --verbosity normal --filter "Category!=ExternalService&FullyQualifiedName~Test.TestOGlyco" --collect:"XPlat Code Coverage"
 
       # Both halves upload. Codecov merges uploads for the same commit, so a single upload would
       # report the suite as covering only its own half and sink the project/patch percentages.
@@ -65,11 +62,8 @@ jobs:
       - name: Build
         run: dotnet build --no-restore ./MetaMorpheus/MetaMorpheus.sln --configuration Release
 
-      - name: Install Coverlet for code coverage
-        run: dotnet add ./MetaMorpheus/Test/Test.csproj package coverlet.collector -v 6.0.2
-
       - name: Run unit tests with coverage
-        run: dotnet test .\MetaMorpheus\Test\Test.csproj --configuration Release --verbosity normal --filter "Category!=ExternalService&FullyQualifiedName!~Test.TestOGlyco" --collect:"XPlat Code Coverage"
+        run: dotnet test .\MetaMorpheus\Test\Test.csproj --configuration Release --no-build --verbosity normal --filter "Category!=ExternalService&FullyQualifiedName!~Test.TestOGlyco" --collect:"XPlat Code Coverage"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -11,10 +11,18 @@ env:
   DOTNET_FRAMEWORK: net10.0
 
 jobs:
-  test:
-    name: Test on Windows
+  # The suite is split across two runners purely for wall clock. The partition is on fixture name and
+  # is exhaustive by construction: a test either matches ~Test.TestOGlyco or matches !~Test.TestOGlyco.
+  # TestOGlyco is the half chosen because it holds OGlycoTest_Run5_WriteDecoys, which alone is ~32% of
+  # the suite's runtime, and because it is NOT one of the fixtures sharing EverythingRunnerEngineTestCase
+  # -- so neither runner rebuilds a cached search the other already built.
+  #
+  # These are separate jobs, not NUnit parallelism. Each runner still executes its own tests
+  # sequentially in one process, so tests that share an output folder (TESTGlycoData is used by five
+  # test files) never run concurrently. In-process parallelism is not safe in this suite.
+  test-glyco:
+    name: Test on Windows (glyco)
     runs-on: windows-latest
-
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET
@@ -23,17 +31,45 @@ jobs:
           dotnet-version: ${{ env.DOTNET_VERSION }}
       - name: Restore dependencies
         run: dotnet restore ./MetaMorpheus/MetaMorpheus.sln
-        
+
       - name: Build
         run: dotnet build --no-restore ./MetaMorpheus/MetaMorpheus.sln --configuration Release
-        
+
       - name: Install Coverlet for code coverage
         run: dotnet add ./MetaMorpheus/Test/Test.csproj package coverlet.collector -v 6.0.2
-        
+
       - name: Run unit tests with coverage
-        # Exclude live external-service tests (UniProt, etc.) from the required run; they run in the
-        # separate, non-blocking external-service-tests job below.
-        run: dotnet test .\MetaMorpheus\Test\Test.csproj --configuration Release --verbosity normal --filter "Category!=ExternalService" --collect:"XPlat Code Coverage"
+        run: dotnet test .\MetaMorpheus\Test\Test.csproj --configuration Release --verbosity normal --filter "Category!=ExternalService&FullyQualifiedName~Test.TestOGlyco" --collect:"XPlat Code Coverage"
+
+      # Both halves upload. Codecov merges uploads for the same commit, so a single upload would
+      # report the suite as covering only its own half and sink the project/patch percentages.
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+          flags: unittests
+
+  test-core:
+    name: Test on Windows (core)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+      - name: Restore dependencies
+        run: dotnet restore ./MetaMorpheus/MetaMorpheus.sln
+
+      - name: Build
+        run: dotnet build --no-restore ./MetaMorpheus/MetaMorpheus.sln --configuration Release
+
+      - name: Install Coverlet for code coverage
+        run: dotnet add ./MetaMorpheus/Test/Test.csproj package coverlet.collector -v 6.0.2
+
+      - name: Run unit tests with coverage
+        run: dotnet test .\MetaMorpheus\Test\Test.csproj --configuration Release --verbosity normal --filter "Category!=ExternalService&FullyQualifiedName!~Test.TestOGlyco" --collect:"XPlat Code Coverage"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
@@ -41,6 +77,23 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
           flags: unittests
+
+  # Aggregator so the required status check keeps its existing name. Branch protection can go on
+  # keeping "Test on Windows" required without a settings change; this fails if either half failed
+  # or was skipped.
+  test:
+    name: Test on Windows
+    runs-on: ubuntu-latest
+    needs: [ test-glyco, test-core ]
+    if: always()
+    steps:
+      - name: Check both halves passed
+        run: |
+          echo "glyco=${{ needs.test-glyco.result }} core=${{ needs.test-core.result }}"
+          if [ "${{ needs.test-glyco.result }}" != "success" ] || [ "${{ needs.test-core.result }}" != "success" ]; then
+            echo "::error::One or both halves of the Windows test suite did not pass."
+            exit 1
+          fi
 
   # Runs tests that depend on live external web services (UniProt, ...). Kept separate and
   # intentionally NOT a required status check, so a third-party outage never blocks a PR. The tests

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -36,7 +36,10 @@ jobs:
         run: dotnet build --no-restore ./MetaMorpheus/MetaMorpheus.sln --configuration Release
 
       - name: Run unit tests with coverage
-        run: dotnet test .\MetaMorpheus\Test\Test.csproj --configuration Release --no-build --verbosity normal --filter "Category!=ExternalService&FullyQualifiedName~Test.TestOGlyco" --collect:"XPlat Code Coverage"
+        # Exclude live external-service tests (UniProt, etc.) from the required run; they run in the
+        # separate, non-blocking external-service-tests job below. --settings makes a filter that
+        # matches nothing fail rather than silently pass; see the runsettings file for why.
+        run: dotnet test .\MetaMorpheus\Test\Test.csproj --configuration Release --no-build --verbosity normal --filter "Category!=ExternalService&FullyQualifiedName~Test.TestOGlyco" --settings .github\no-empty-test-run.runsettings --collect:"XPlat Code Coverage"
 
       # Both halves upload. Codecov merges uploads for the same commit, so a single upload would
       # report the suite as covering only its own half and sink the project/patch percentages.
@@ -46,6 +49,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
           flags: unittests
+          fail_ci_if_error: true
 
   test-core:
     name: Test on Windows (core)
@@ -63,7 +67,10 @@ jobs:
         run: dotnet build --no-restore ./MetaMorpheus/MetaMorpheus.sln --configuration Release
 
       - name: Run unit tests with coverage
-        run: dotnet test .\MetaMorpheus\Test\Test.csproj --configuration Release --no-build --verbosity normal --filter "Category!=ExternalService&FullyQualifiedName!~Test.TestOGlyco" --collect:"XPlat Code Coverage"
+        # Exclude live external-service tests (UniProt, etc.) from the required run; they run in the
+        # separate, non-blocking external-service-tests job below. --settings makes a filter that
+        # matches nothing fail rather than silently pass; see the runsettings file for why.
+        run: dotnet test .\MetaMorpheus\Test\Test.csproj --configuration Release --no-build --verbosity normal --filter "Category!=ExternalService&FullyQualifiedName!~Test.TestOGlyco" --settings .github\no-empty-test-run.runsettings --collect:"XPlat Code Coverage"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
@@ -71,6 +78,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
           flags: unittests
+          fail_ci_if_error: true
 
   # Aggregator so the required status check keeps its existing name. Branch protection can go on
   # keeping "Test on Windows" required without a settings change; this fails if either half failed
@@ -79,7 +87,7 @@ jobs:
     name: Test on Windows
     runs-on: ubuntu-latest
     needs: [ test-glyco, test-core ]
-    if: always()
+    if: ${{ !cancelled() }}
     steps:
       - name: Check both halves passed
         run: |

--- a/MetaMorpheus/CMD/CMD.csproj
+++ b/MetaMorpheus/CMD/CMD.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/MetaMorpheus/CMD/CMD.csproj
+++ b/MetaMorpheus/CMD/CMD.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ApplicationManifest>app1.manifest</ApplicationManifest>
     <Configurations>Debug;Release</Configurations>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <ApplicationIcon></ApplicationIcon>
   </PropertyGroup>

--- a/MetaMorpheus/EngineLayer/EngineLayer.csproj
+++ b/MetaMorpheus/EngineLayer/EngineLayer.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>

--- a/MetaMorpheus/EngineLayer/EngineLayer.csproj
+++ b/MetaMorpheus/EngineLayer/EngineLayer.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Version>1.0.0.0</Version>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 

--- a/MetaMorpheus/GUI/GUI.csproj
+++ b/MetaMorpheus/GUI/GUI.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>

--- a/MetaMorpheus/GUI/GUI.csproj
+++ b/MetaMorpheus/GUI/GUI.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -13,7 +13,7 @@
     <RootNamespace>MetaMorpheusGUI</RootNamespace>
     <AssemblyName>MetaMorpheusGUI</AssemblyName>
     <Configurations>Debug;Release</Configurations>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <ApplicationIcon>Icons\MMnice.ico</ApplicationIcon>
 	<EnableWindowsTargeting>true</EnableWindowsTargeting>

--- a/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
+++ b/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>

--- a/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
+++ b/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
     <Configurations>Debug;Release</Configurations>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <UseWPF>true</UseWPF>
 	<EnableWindowsTargeting>true</EnableWindowsTargeting>

--- a/MetaMorpheus/TaskLayer/TaskLayer.csproj
+++ b/MetaMorpheus/TaskLayer/TaskLayer.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>

--- a/MetaMorpheus/TaskLayer/TaskLayer.csproj
+++ b/MetaMorpheus/TaskLayer/TaskLayer.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Configurations>Debug;Release</Configurations>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 

--- a/MetaMorpheus/Test/Test.csproj
+++ b/MetaMorpheus/Test/Test.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>

--- a/MetaMorpheus/Test/Test.csproj
+++ b/MetaMorpheus/Test/Test.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
     <Configurations>Debug;Release</Configurations>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
 	<EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
@@ -18,6 +18,10 @@
   
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+# Test.yml runs the Windows suite as two jobs, so every commit produces two coverage uploads.
+# Without this, Codecov posts a status as soon as the first one lands, reporting one half of the
+# suite as the whole thing.
+codecov:
+  notify:
+    after_n_builds: 2
+
+comment:
+  after_n_builds: 2


### PR DESCRIPTION
🤖 `Test on Windows` takes 21 minutes. This splits it across two runners and takes the wall clock to ~13.

## Measured, not estimated

Three jobs on one commit on a throwaway branch — the current single job as a control, plus the two halves:

| Job | Tests | Test step | Job total |
|---|---|---|---|
| Current single job | 1762 | 1062s | **21m01s** |
| `Test on Windows (glyco)` | 50 | 503s | **11m37s** |
| `Test on Windows (core)` | 1712 | 536s | **12m13s** |

503s + 536s = 1039s against the single job's 1062s, so test time is conserved rather than duplicated.

Where the 21 minutes went: the test step is 1062s of it, and one test is 324s of that — `OGlycoTest_Run5_WriteDecoys` copies a 1.8 MB mzML 19 times and searches all 20 to manufacture enough PSMs for one decoy to survive q≤0.01. That single test is 32% of the suite. Fixed per-job overhead is ~188s (checkout 15s, setup-dotnet 35s, restore 31s, build 101s).

## Why this partition

`--filter` on `FullyQualifiedName~Test.TestOGlyco` and its complement. Exhaustive by construction — a test either contains that substring or it doesn't, so nothing can fall between the halves. The counts in the table above corroborate that on the commit they were measured on: 50 + 1712 = 1762, matching the single job.

Those counts drift as tests are added upstream, and have: the run on this PR reports 50 + 1717, the extra five coming from `MzIdentMlSchemaTest.cs`, `TestCmd.cs` and `MassDiffAcceptorTypeTests.cs` landing on master since the experiment. So the count is corroboration at a point in time, not a standing check — which is the weakness, because a partition that silently drops tests is invisible in a green run.

That is what the runsettings guard is for; see below. It turns the drop scenario into a red build on every run, rather than relying on someone re-deriving two numbers from two job logs.

`TestOGlyco` is the half pulled out for two reasons. It holds the 324s test. And it is **not** one of the fixtures using `EverythingRunnerEngineTestCase`, so neither runner rebuilds a cached search the other already built — splitting `PostSearchAnalysisTaskTests` or the MetaDraw fixtures instead would have paid for `BottomUpQValue` twice, since four files share it.

## This is not NUnit parallelism

Separate jobs, separate VMs, separate filesystems. Each runner still executes its own tests **sequentially in one process**, so tests that share an output folder never run concurrently — `TESTGlycoData` is used by five test files, 24 times in `TestOGlyco.cs` alone, each ending in `Directory.Delete(outputFolder, true)`. In-process parallelism is not safe in this suite and this does not introduce any; there are already four `[NonParallelizable]` attributes from previous encounters with it.

Across both experiment runs, **no test failed in either half**, so no cross-fixture state dependency surfaced.

## Two details that would otherwise break

- **Both halves upload to Codecov.** It merges uploads for the same commit. If only one uploaded, that half would be reported as the whole suite and the project/patch percentages would collapse.
- **A `Test on Windows` aggregator job** depends on both halves and fails if either did. It uses `!cancelled()` rather than `always()`, so a cancelled run reports as cancelled instead of claiming a half failed. An existing required status check of that name keeps working with no branch-protection change. If you would rather require the two halves directly, delete that job and update the settings instead.

## Guarding the partition

A `--filter` that matches nothing exits 0. Renaming `TestOGlyco` or mistyping either filter string would silently stop running that half with every job still green, which is exactly the failure mode the partition section calls out. Of the three candidate mechanisms, only a runsettings file works — measured on the .NET 10 SDK:

| mechanism | zero-match filter | matching filter |
|---|---|---|
| plain `dotnet test --filter` | exit 0 | exit 0 |
| `-p:TreatNoTestsAsError=true` | exit 0 (no effect) | exit 0 |
| `--settings` with `TreatNoTestsAsError` | **exit 1** | exit 0 |

`.github/no-empty-test-run.runsettings` is passed to both halves. Confirmed against the production compound filters rather than simplified ones: the glyco half with its fixture renamed exits 1, both real halves still pass.

`codecov.yml` sets `after_n_builds: 2` so no status is computed off whichever upload lands first — `Test.yml` is the only workflow that uploads, and it has exactly two upload steps — and both uploads set `fail_ci_if_error: true` so a lost upload reddens its own half instead of silently halving reported coverage.

## Known interaction, worth stating plainly

There is a pre-existing intermittent failure where coverlet's instrumentation access-violates before any test runs:

```
Fatal error.  0xC0000005
   at Mono.Cecil.Pdb.ISymUnmanagedWriter2.Close()
   at Coverlet.Core.Instrumentation.Instrumenter.InstrumentModule()
   at Coverlet.Collector.DataCollection.CoverletCoverageCollector.OnSessionStart(...)
```

It hit 1 of the last 40 `Test.yml` runs on master (`truncation-search-mm`, 1824 passed / 1825 total, zero test failures, job red), and it hit one of the two experiment runs. **Two jobs means two chances per run to hit it, so this change roughly doubles exposure to it** — ~2.5% to ~5% at the observed rate.

That is an argument for fixing the flake, not for keeping one job, and the attempted fix is **included here**: every csproj set `<DebugType>full</DebugType>`, which emits native Windows PDBs, and Mono.Cecil routes those through the `ISymUnmanagedWriter2` path that crashes. All six now set `portable`, which avoids that path. This was #2746, folded in and closed.

**It is not proven to fix the crash.** The failure is intermittent — roughly 1 run in 40 — so a green run demonstrates nothing, and I have not run it enough times to claim otherwise. It is here rather than separate because splitting into two jobs doubles the exposure per run, so shipping the split without it makes the flake worse. Weigh it on that basis rather than on the wall-clock measurements, which say nothing about it.

`coverlet.collector` also moves into `Test.csproj`, replacing the `dotnet add package` step that mutated the project mid-workflow and forced the test step to re-compile (~15s per job).

Not addressed here: the 19-copy glyco test, which is the floor on any further split — ~8m30s however many ways the suite is divided.


