### PR TITLE
Portable PDBs so coverlet stops crashing the test job

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -27,13 +27,10 @@ jobs:
       - name: Build
         run: dotnet build --no-restore ./MetaMorpheus/MetaMorpheus.sln --configuration Release
         
-      - name: Install Coverlet for code coverage
-        run: dotnet add ./MetaMorpheus/Test/Test.csproj package coverlet.collector -v 6.0.2
-        
       - name: Run unit tests with coverage
         # Exclude live external-service tests (UniProt, etc.) from the required run; they run in the
         # separate, non-blocking external-service-tests job below.
-        run: dotnet test .\MetaMorpheus\Test\Test.csproj --configuration Release --verbosity normal --filter "Category!=ExternalService" --collect:"XPlat Code Coverage"
+        run: dotnet test .\MetaMorpheus\Test\Test.csproj --configuration Release --no-build --verbosity normal --filter "Category!=ExternalService" --collect:"XPlat Code Coverage"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/MetaMorpheus/CMD/CMD.csproj
+++ b/MetaMorpheus/CMD/CMD.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ApplicationManifest>app1.manifest</ApplicationManifest>
     <Configurations>Debug;Release</Configurations>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <ApplicationIcon></ApplicationIcon>
   </PropertyGroup>

--- a/MetaMorpheus/EngineLayer/EngineLayer.csproj
+++ b/MetaMorpheus/EngineLayer/EngineLayer.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Version>1.0.0.0</Version>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 

--- a/MetaMorpheus/GUI/GUI.csproj
+++ b/MetaMorpheus/GUI/GUI.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -13,7 +13,7 @@
     <RootNamespace>MetaMorpheusGUI</RootNamespace>
     <AssemblyName>MetaMorpheusGUI</AssemblyName>
     <Configurations>Debug;Release</Configurations>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <ApplicationIcon>Icons\MMnice.ico</ApplicationIcon>
 	<EnableWindowsTargeting>true</EnableWindowsTargeting>

--- a/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
+++ b/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
     <Configurations>Debug;Release</Configurations>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <UseWPF>true</UseWPF>
 	<EnableWindowsTargeting>true</EnableWindowsTargeting>

--- a/MetaMorpheus/TaskLayer/TaskLayer.csproj
+++ b/MetaMorpheus/TaskLayer/TaskLayer.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <Configurations>Debug;Release</Configurations>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 

--- a/MetaMorpheus/Test/Test.csproj
+++ b/MetaMorpheus/Test/Test.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
     <IsPackable>false</IsPackable>
     <Configurations>Debug;Release</Configurations>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
 	<EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
@@ -18,6 +18,10 @@
   
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
🤖 `Test on Windows` intermittently goes red with every test passing. This is the likely cause, plus two cleanups to the same job.

## The crash

```
Fatal error.  0xC0000005
   at Mono.Cecil.Pdb.ISymUnmanagedWriter2.Close()
   at Mono.Cecil.Pdb.NativePdbWriter.Write()
   at Coverlet.Core.Instrumentation.Instrumenter.InstrumentModule()
   at Coverlet.Collector.DataCollection.CoverletCoverageCollector.OnSessionStart(...)
```

`DebugType=full` emits legacy **native Windows PDBs**. Coverlet instruments each assembly by rewriting it with Mono.Cecil, and rewriting a module means rewriting its symbols — for a native PDB that hands off to the COM interface `ISymUnmanagedWriter2`, which is native code. `0xC0000005` is an access violation *inside* it, so nothing managed can catch it and the data collector dies outright. That is why the failure looks like "Fatal error" with no exception and no failing test.

It fired on **1 of the last 40 `Test.yml` runs on master** (`truncation-search-mm`: 1824 of 1825 passed, job red), and twice more while measuring an unrelated change. Coverlet's own [KnownIssues](https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/KnownIssues.md) prescribes this exact remedy: "Change DebugType from `full` to `portable`."

Verified on `windows-latest` that the setting does what it claims — the first four bytes of `EngineLayer.pdb` go from `Micr` (native) to `BSJB` (portable).

**Not proven to fix it.** The crash did not reproduce in 10 trials of `full`, which at a ~1-in-40 rate is unsurprising and demonstrates nothing either way. Showing the flake gone would take a hundred-plus runs, which is not a good use of CI. The mechanism is implicated by the stack trace and by coverlet's documentation; it is not established by experiment. Worth knowing before merging on the strength of it.

## This moves the coverage numbers

Measured over a fixed test subset, reproducible across 10 `full` trials and 3 `portable` trials with the same 32 tests passing:

| Metric | `full` | `portable` | Δ |
|---|---|---|---|
| lines_valid | 21877 | 21927 | **+50** |
| lines_covered | 4469 | 4516 | **+47** |
| branches_valid | 10553 | 10565 | +12 |
| branches_covered | 1755 | 1764 | +9 |
| line rate | 20.427% | 20.596% | **+0.17pp** |

Portable exposes more instrumentable lines, so coverlet sees slightly more of the code. **Both numerator and denominator move**, so expect this PR's own Codecov delta to be nonzero and unrelated to any test change. The direction is favourable — more of the codebase is visible to coverage — but it is a real change and shouldn't be read as tests improving. The percentages above are for the subset, so I am not extrapolating an exact figure for the full suite; the +50 denominator carries over, the covered delta depends partly on which tests run.

## Why per-csproj and not Directory.Build.props

A props file also applies to `MetaMorpheusSetup.wixproj`, and WiX maps `DebugType` onto its own `-pdbType`, which accepts only `full` or `none`:

```
wix.exe : error WIX0268: The argument -pdbType value 'portable' is invalid.
```

Found by breaking the installer build exactly that way. Hence six explicit csproj edits. Note all six need it, not just `Test.csproj` — coverlet instruments the *product* assemblies, so `EngineLayer`, `TaskLayer`, `CMD`, `GuiFunctions` and `GUI` are the ones being rewritten.

## Two cleanups to the same job

`coverlet.collector` becomes a normal `PackageReference` in `Test.csproj` instead of being bolted on with `dotnet add` after the build. That mutation was the only reason the test step recompiled everything it had just built, so `--no-build` is now safe and the step stops rebuilding — about 15s.

`coverlet.msbuild` is left alone. It is inert on the collector path but removing it is unrelated scope.
