### PR TITLE
Store the fragment index as flat arrays and build it in parallel (index build 5.9x, 1.8x less memory)

### DIFF
--- a/MetaMorpheus/EngineLayer/CrosslinkSearch/CrosslinkSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/CrosslinkSearch/CrosslinkSearchEngine.cs
@@ -1,4 +1,5 @@
 ﻿using EngineLayer.ModernSearch;
+using EngineLayer.Indexing;
 using MassSpectrometry;
 using MzLibUtil;
 using Omics.Fragmentation;
@@ -34,12 +35,12 @@ namespace EngineLayer.CrosslinkSearch
         private Modification NH2DeadEnd;
         private Modification Loop;
         private readonly char[] AllCrosslinkerSites;
-        private readonly List<int>[] SecondFragmentIndex;
+        private readonly MassBinIndex SecondFragmentIndex;
         private readonly double[] PrecursorMassTable;
         private readonly double[] NextPrecursorMassTable;
 
         public CrosslinkSearchEngine(List<CrosslinkSpectralMatch>[] globalCsms, Ms2ScanWithSpecificMass[] listOfSortedms2Scans, List<PeptideWithSetModifications> peptideIndex,
-            List<int>[] fragmentIndex, List<int>[] secondFragmentIndex, int currentPartition, CommonParameters commonParameters, 
+            MassBinIndex fragmentIndex, MassBinIndex secondFragmentIndex, int currentPartition, CommonParameters commonParameters, 
             List<(string fileName, CommonParameters fileSpecificParameters)> fileSpecificParameters,
             Crosslinker crosslinker, int CrosslinkSearchTopNum, bool CleaveAtCrosslinkSite, bool quench_H2O, bool quench_NH2, bool quench_Tris, List<string> nestedIds, 
             List<(int, int, int)>[] candidates, int nextPartition, 

--- a/MetaMorpheus/EngineLayer/CrosslinkSearch/CrosslinkSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/CrosslinkSearch/CrosslinkSearchEngine.cs
@@ -1,5 +1,6 @@
 ﻿using EngineLayer.ModernSearch;
 using EngineLayer.Indexing;
+using EngineLayer.Util;
 using MassSpectrometry;
 using MzLibUtil;
 using Omics.Fragmentation;
@@ -116,10 +117,11 @@ namespace EngineLayer.CrosslinkSearch
             int[] threads = Enumerable.Range(0, maxThreadsPerFile).ToArray();
             Parallel.ForEach(threads, (scanIndex) =>
             {
-                byte[] scoringTable = new byte[PeptideIndex.Count];
+                var scoringTable = new ScanScoringTable(PeptideIndex.Count, UseStampedScoringTable);
                 List<int> idsOfPeptidesPossiblyObserved = new List<int>();
-                byte[] secondScoringTable = new byte[PeptideIndex.Count];
+                var secondScoringTable = new ScanScoringTable(PeptideIndex.Count, UseStampedScoringTable);
                 List<int> childIdsOfPeptidesPossiblyObserved = new List<int>();
+                var scoreSorter = new DescendingScoreSorter();
 
                 byte scoreAtTopN = 0;
                 int peptideCount = 0;
@@ -130,7 +132,7 @@ namespace EngineLayer.CrosslinkSearch
                     if (GlobalVariables.StopLoops) { return; }
 
                     // empty the scoring table to score the new scan (conserves memory compared to allocating a new array)
-                    Array.Clear(scoringTable, 0, scoringTable.Length);
+                    scoringTable.BeginScan();
                     idsOfPeptidesPossiblyObserved.Clear();      
 
                     var scan = ListOfSortedMs2Scans[scanIndex];
@@ -147,7 +149,7 @@ namespace EngineLayer.CrosslinkSearch
                     //child scan first - pass scoring
                     if (scan.ChildScans != null && CommonParameters.MS2ChildScanDissociationType != DissociationType.Unknown && CommonParameters.MS2ChildScanDissociationType != DissociationType.LowCID)
                     {
-                        Array.Clear(secondScoringTable, 0, secondScoringTable.Length);
+                        secondScoringTable.BeginScan();
                         childIdsOfPeptidesPossiblyObserved.Clear();
 
                         List<int> childBinsToSearch = new List<int>();
@@ -166,7 +168,7 @@ namespace EngineLayer.CrosslinkSearch
                             {
                                 idsOfPeptidesPossiblyObserved.Add(childId);
                             }
-                            scoringTable[childId] = (byte)(scoringTable[childId] + secondScoringTable[childId]);
+                            scoringTable.Set(childId, (byte)(scoringTable[childId] + secondScoringTable[childId]));
                         }
                     }
 
@@ -176,7 +178,7 @@ namespace EngineLayer.CrosslinkSearch
                         scoreAtTopN = 0;
                         peptideCount = 0;
 
-                        foreach (int id in idsOfPeptidesPossiblyObserved.OrderByDescending(p => scoringTable[p]))
+                        foreach (int id in scoreSorter.Sort(idsOfPeptidesPossiblyObserved, scoringTable))
                         {
                             peptideCount++;
                             // Whenever the count exceeds the TopN that we want to keep, we removed everything with a score lower than the score of the TopN-th peptide in the ids list

--- a/MetaMorpheus/EngineLayer/GlycoSearch/GlycoSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/GlycoSearchEngine.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using EngineLayer.Indexing;
+using EngineLayer.Util;
 using MassSpectrometry;
 using EngineLayer.SpectrumMatch;
 
@@ -121,11 +122,12 @@ namespace EngineLayer.GlycoSearch
             int[] threads = Enumerable.Range(0, maxThreadsPerFile).ToArray(); // We can do the parallel search on different threads
             Parallel.ForEach(threads, (scanIndex) =>
             {
-                byte[] scoringTable = new byte[PeptideIndex.Count];
+                var scoringTable = new ScanScoringTable(PeptideIndex.Count, UseStampedScoringTable);
                 List<int> idsOfPeptidesPossiblyObserved = new List<int>();
 
-                byte[] secondScoringTable = new byte[PeptideIndex.Count]; // We didn't use that right now.
+                var secondScoringTable = new ScanScoringTable(PeptideIndex.Count, UseStampedScoringTable); // We didn't use that right now.
                 List<int> childIdsOfPeptidesPossiblyObserved = new List<int>();
+                var scoreSorter = new DescendingScoreSorter();
 
                 List<int> idsOfPeptidesTopN = new List<int>();
                 byte scoreAtTopN = 0;
@@ -137,7 +139,7 @@ namespace EngineLayer.GlycoSearch
                     if (GlobalVariables.StopLoops) { return; }
 
                     // empty the scoring table to score the new scan (conserves memory compared to allocating a new array)
-                    Array.Clear(scoringTable, 0, scoringTable.Length);
+                    scoringTable.BeginScan();
                     idsOfPeptidesPossiblyObserved.Clear();
                     idsOfPeptidesTopN.Clear();
 
@@ -184,7 +186,7 @@ namespace EngineLayer.GlycoSearch
                     {
                         scoreAtTopN = 0;
                         peptideCount = 0;
-                        foreach (int id in idsOfPeptidesPossiblyObserved.OrderByDescending(p => scoringTable[p])) //from the higest score to the lowest score
+                        foreach (int id in scoreSorter.Sort(idsOfPeptidesPossiblyObserved, scoringTable)) //from the higest score to the lowest score
                         {
                             if (scoringTable[id] < (int)byteScoreCutoff) //if the score is lower than the cutoff, we can skip this peptide.
                             {

--- a/MetaMorpheus/EngineLayer/GlycoSearch/GlycoSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/GlycoSearchEngine.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using EngineLayer.Indexing;
 using MassSpectrometry;
 using EngineLayer.SpectrumMatch;
 
@@ -28,7 +29,7 @@ namespace EngineLayer.GlycoSearch
         private readonly Tolerance PrecusorSearchMode;
         private readonly MassDiffAcceptor ProductSearchMode;
 
-        private readonly List<int>[] SecondFragmentIndex;
+        private readonly MassBinIndex SecondFragmentIndex;
 
         protected string[] Motifs
         {
@@ -44,7 +45,7 @@ namespace EngineLayer.GlycoSearch
 
         // The constructor for GlycoSearchEngine, we can load the parameter for the searhcing like mode, topN, maxOGlycanNum, oxoniumIonFilter, datsbase, etc.
         public GlycoSearchEngine(List<GlycoSpectralMatch>[] globalCsms, Ms2ScanWithSpecificMass[] listOfSortedms2Scans, List<PeptideWithSetModifications> peptideIndex,
-            List<int>[] fragmentIndex, List<int>[] secondFragmentIndex, int currentPartition, CommonParameters commonParameters, List<(string fileName, CommonParameters fileSpecificParameters)> fileSpecificParameters,
+            MassBinIndex fragmentIndex, MassBinIndex secondFragmentIndex, int currentPartition, CommonParameters commonParameters, List<(string fileName, CommonParameters fileSpecificParameters)> fileSpecificParameters,
              string oglycanDatabase, string nglycanDatabase, GlycoSearchType glycoSearchType, int glycoSearchTopNum, int maxOGlycanNum, bool oxoniumIonFilter, List<string> nestedIds)
             : base(null, listOfSortedms2Scans, peptideIndex, fragmentIndex, currentPartition, commonParameters, fileSpecificParameters, new OpenSearchMode(), 0, nestedIds)
         {

--- a/MetaMorpheus/EngineLayer/Indexing/IndexingEngine.cs
+++ b/MetaMorpheus/EngineLayer/Indexing/IndexingEngine.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Omics;
 using Omics.Fragmentation.Peptide;
@@ -148,18 +149,18 @@ namespace EngineLayer.Indexing
             // have produced -- and therefore the exact per-bin ordering the old List<int>[] build gave.
             // That ordering is load-bearing: BinarySearchBinForPrecursorIndex binary-searches a bin by
             // peptide mass, which only works while peptide ids ascend within the bin.
-            progress = 0;
-            oldPercentProgress = 0;
-
+            // Blocks are independent -- each one fragments its own peptides into its own run -- so they
+            // run in parallel. Digestion above this point was already parallel; fragmenting was not.
             List<PeptideBlock> blocks = PartitionPeptidesIntoBlocks(peptides.Count);
             var fragmentEmissions = new MassBinEmissionRun[blocks.Count];
             var interiorTerminalModEmissions = addInteriorTerminalModsToPrecursorIndex ? new MassBinEmissionRun[blocks.Count] : null;
+            var fragmentationProgress = new FragmentationProgress();
 
-            for (int blockIndex = 0; blockIndex < blocks.Count; blockIndex++)
+            Parallel.For(0, blocks.Count, new ParallelOptions { MaxDegreeOfParallelism = Math.Max(1, CommonParameters.MaxThreadsToUsePerFile) }, blockIndex =>
             {
                 FragmentPeptideBlock(blocks[blockIndex], blockIndex, peptides, addInteriorTerminalModsToPrecursorIndex,
-                    terminalModifications, fragmentEmissions, interiorTerminalModEmissions, ref progress, ref oldPercentProgress);
-            }
+                    terminalModifications, fragmentEmissions, interiorTerminalModEmissions, fragmentationProgress);
+            });
 
             MassBinIndex fragmentIndex;
             MassBinIndex precursorIndex = null;
@@ -186,6 +187,25 @@ namespace EngineLayer.Indexing
             }
 
             return new IndexingResults(peptides, fragmentIndex, precursorIndex, this);
+        }
+
+        /// <summary>
+        /// Counts fragmented peptides across the parallel blocks. Each whole percent is announced by
+        /// exactly one thread -- whichever wins the compare-exchange that advances the counter.
+        /// </summary>
+        private sealed class FragmentationProgress
+        {
+            private long _peptidesFragmented;
+            private int _lastPercentReported;
+
+            internal bool AdvanceOnePeptide(int totalPeptides, out int percentProgress)
+            {
+                long done = Interlocked.Increment(ref _peptidesFragmented);
+                percentProgress = (int)(done * 100 / totalPeptides);
+
+                int last = Volatile.Read(ref _lastPercentReported);
+                return percentProgress > last && Interlocked.CompareExchange(ref _lastPercentReported, percentProgress, last) == last;
+            }
         }
 
         private readonly struct PeptideBlock
@@ -234,7 +254,7 @@ namespace EngineLayer.Indexing
         private void FragmentPeptideBlock(PeptideBlock block, int blockIndex, List<PeptideWithSetModifications> peptides,
             bool addInteriorTerminalModsToPrecursorIndex, List<Modification> terminalModifications,
             MassBinEmissionRun[] fragmentEmissions, MassBinEmissionRun[] interiorTerminalModEmissions,
-            ref double progress, ref int oldPercentProgress)
+            FragmentationProgress fragmentationProgress)
         {
             int blockLength = block.End - block.Start;
             var fragmentRun = new MassBinEmissionRun(block.Start, blockLength);
@@ -271,12 +291,8 @@ namespace EngineLayer.Indexing
                     AddInteriorTerminalModsToPrecursorIndex(interiorRun, fragments, peptides[peptideId], terminalModifications);
                 }
 
-                progress++;
-                var percentProgress = (int)((progress / peptides.Count) * 100);
-
-                if (percentProgress > oldPercentProgress)
+                if (fragmentationProgress.AdvanceOnePeptide(peptides.Count, out int percentProgress))
                 {
-                    oldPercentProgress = percentProgress;
                     ReportProgress(new ProgressEventArgs(percentProgress, "Fragmenting peptides...", NestedIds));
                 }
             }

--- a/MetaMorpheus/EngineLayer/Indexing/IndexingEngine.cs
+++ b/MetaMorpheus/EngineLayer/Indexing/IndexingEngine.cs
@@ -130,36 +130,123 @@ namespace EngineLayer.Indexing
             // sort peptides by mass
             peptides.Sort((x, y) => x.MonoisotopicMass.CompareTo(y.MonoisotopicMass));
 
+            int binCount = (int)Math.Ceiling(MaxFragmentSize) * FragmentBinsPerDalton + 1;
+
             //create precursor index (if specified)
-            List<int>[] precursorIndex = null;
+            MassBinEmissionRun precursorBaseEmissions = null;
             if (GeneratePrecursorIndex)
             {
-                precursorIndex = CreateNewPrecursorIndex(peptides);
+                precursorBaseEmissions = CreatePrecursorBaseEmissions(peptides);
             }
             bool addInteriorTerminalModsToPrecursorIndex = GeneratePrecursorIndex && CommonParameters.DigestionParams.DigestionAgent.Name.Contains("single");
             List<Modification> terminalModifications = addInteriorTerminalModsToPrecursorIndex ?
                 NonSpecificEnzymeSearchEngine.GetVariableTerminalMods(CommonParameters.DigestionParams.FragmentationTerminus, VariableModifications) :
                 null;
 
-            // create fragment index
-            List<int>[] fragmentIndex;
+            // Fragment every peptide once, emitting into per-block runs. The runs are concatenated in
+            // block order below, which reproduces the emission sequence a single sequential pass would
+            // have produced -- and therefore the exact per-bin ordering the old List<int>[] build gave.
+            // That ordering is load-bearing: BinarySearchBinForPrecursorIndex binary-searches a bin by
+            // peptide mass, which only works while peptide ids ascend within the bin.
+            progress = 0;
+            oldPercentProgress = 0;
+
+            List<PeptideBlock> blocks = PartitionPeptidesIntoBlocks(peptides.Count);
+            var fragmentEmissions = new MassBinEmissionRun[blocks.Count];
+            var interiorTerminalModEmissions = addInteriorTerminalModsToPrecursorIndex ? new MassBinEmissionRun[blocks.Count] : null;
+
+            for (int blockIndex = 0; blockIndex < blocks.Count; blockIndex++)
+            {
+                FragmentPeptideBlock(blocks[blockIndex], blockIndex, peptides, addInteriorTerminalModsToPrecursorIndex,
+                    terminalModifications, fragmentEmissions, interiorTerminalModEmissions, ref progress, ref oldPercentProgress);
+            }
+
+            MassBinIndex fragmentIndex;
+            MassBinIndex precursorIndex = null;
 
             try
             {
-                fragmentIndex = new List<int>[(int)Math.Ceiling(MaxFragmentSize) * FragmentBinsPerDalton + 1];
+                fragmentIndex = MassBinIndex.Build(binCount, fragmentEmissions);
+
+                if (GeneratePrecursorIndex)
+                {
+                    // Base precursor masses first, then the interior terminal mods, matching the order
+                    // in which the old two-pass build appended them.
+                    var precursorEmissions = new List<MassBinEmissionRun> { precursorBaseEmissions };
+                    if (addInteriorTerminalModsToPrecursorIndex)
+                    {
+                        precursorEmissions.AddRange(interiorTerminalModEmissions);
+                    }
+                    precursorIndex = MassBinIndex.Build(binCount, precursorEmissions);
+                }
             }
             catch (OutOfMemoryException)
             {
                 throw new MetaMorpheusException("Max fragment mass too large for indexing engine; try \"Classic Search\" mode, or make the maximum fragment mass smaller");
             }
 
-            // populate fragment index
-            progress = 0;
-            oldPercentProgress = 0;
+            return new IndexingResults(peptides, fragmentIndex, precursorIndex, this);
+        }
+
+        private readonly struct PeptideBlock
+        {
+            public PeptideBlock(int start, int end)
+            {
+                Start = start;
+                End = end;
+            }
+
+            /// <summary>First peptide id in the block.</summary>
+            public int Start { get; }
+
+            /// <summary>One past the last peptide id in the block.</summary>
+            public int End { get; }
+        }
+
+        /// <summary>
+        /// Splits the peptide ids into contiguous blocks. Emissions are concatenated in block order, so
+        /// the index that comes out does not depend on how many blocks there are.
+        /// </summary>
+        private List<PeptideBlock> PartitionPeptidesIntoBlocks(int peptideCount)
+        {
+            var blocks = new List<PeptideBlock>();
+            if (peptideCount == 0)
+            {
+                return blocks;
+            }
+
+            int blockCount = Math.Max(1, Math.Min(CommonParameters.MaxThreadsToUsePerFile, peptideCount));
+            int blockSize = (peptideCount + blockCount - 1) / blockCount;
+
+            for (int start = 0; start < peptideCount; start += blockSize)
+            {
+                blocks.Add(new PeptideBlock(start, Math.Min(start + blockSize, peptideCount)));
+            }
+
+            return blocks;
+        }
+
+        /// <summary>
+        /// Fragments one contiguous block of peptides, recording the fragment bins each peptide lands in
+        /// and, when the search needs them, the interior terminal mod precursor bins -- which come out of
+        /// the same fragmentation so that peptides are not fragmented twice.
+        /// </summary>
+        private void FragmentPeptideBlock(PeptideBlock block, int blockIndex, List<PeptideWithSetModifications> peptides,
+            bool addInteriorTerminalModsToPrecursorIndex, List<Modification> terminalModifications,
+            MassBinEmissionRun[] fragmentEmissions, MassBinEmissionRun[] interiorTerminalModEmissions,
+            ref double progress, ref int oldPercentProgress)
+        {
+            int blockLength = block.End - block.Start;
+            var fragmentRun = new MassBinEmissionRun(block.Start, blockLength);
+            MassBinEmissionRun interiorRun = addInteriorTerminalModsToPrecursorIndex ? new MassBinEmissionRun(block.Start, blockLength) : null;
+
             List<Product> fragments = new List<Product>();
 
-            for (int peptideId = 0; peptideId < peptides.Count; peptideId++)
+            for (int peptideId = block.Start; peptideId < block.End; peptideId++)
             {
+                fragmentRun.BeginPeptide();
+                interiorRun?.BeginPeptide();
+
                 peptides[peptideId].Fragment(CommonParameters.DissociationType, CommonParameters.DigestionParams.FragmentationTerminus, fragments, CommonParameters.FragmentationParameters);
 
                 foreach (var theoreticalFragment in fragments)
@@ -174,23 +261,14 @@ namespace EngineLayer.Indexing
 
                     if (theoreticalFragmentMass < MaxFragmentSize && theoreticalFragmentMass > 0)
                     {
-                        int fragmentBin = (int)Math.Round(theoreticalFragmentMass * FragmentBinsPerDalton);
-
-                        if (fragmentIndex[fragmentBin] == null)
-                        {
-                            fragmentIndex[fragmentBin] = new List<int> { peptideId };
-                        }
-                        else
-                        {
-                            fragmentIndex[fragmentBin].Add(peptideId);
-                        }
+                        fragmentRun.Add((int)Math.Round(theoreticalFragmentMass * FragmentBinsPerDalton));
                     }
                 }
 
                 //Add terminal mods if needed (do it here rather than earlier so that we don't have to fragment twice)
                 if (addInteriorTerminalModsToPrecursorIndex)
                 {
-                    AddInteriorTerminalModsToPrecursorIndex(precursorIndex, fragments, peptides[peptideId], peptideId, terminalModifications);
+                    AddInteriorTerminalModsToPrecursorIndex(interiorRun, fragments, peptides[peptideId], terminalModifications);
                 }
 
                 progress++;
@@ -203,21 +281,23 @@ namespace EngineLayer.Indexing
                 }
             }
 
-            return new IndexingResults(peptides, fragmentIndex, precursorIndex, this);
+            fragmentRun.Complete();
+            interiorRun?.Complete();
+
+            fragmentEmissions[blockIndex] = fragmentRun;
+            if (interiorTerminalModEmissions != null)
+            {
+                interiorTerminalModEmissions[blockIndex] = interiorRun;
+            }
         }
 
-        private List<int>[] CreateNewPrecursorIndex(List<PeptideWithSetModifications> peptidesSortedByMass)
+        /// <summary>
+        /// Emits the base precursor bin for every peptide, in peptide id order. These land in the
+        /// precursor index ahead of any interior terminal mod entries.
+        /// </summary>
+        private MassBinEmissionRun CreatePrecursorBaseEmissions(List<PeptideWithSetModifications> peptidesSortedByMass)
         {
-            // create precursor index
-            List<int>[] precursorIndex = null;
-            try
-            {
-                precursorIndex = new List<int>[(int)Math.Ceiling(MaxFragmentSize) * FragmentBinsPerDalton + 1];
-            }
-            catch (OutOfMemoryException)
-            {
-                throw new MetaMorpheusException("Max precursor mass too large for indexing engine; try \"Classic Search\" mode, or make the maximum fragment mass smaller");
-            }
+            var run = new MassBinEmissionRun(0, peptidesSortedByMass.Count);
 
             double progress = 0;
             int oldPercentProgress = 0;
@@ -226,6 +306,8 @@ namespace EngineLayer.Indexing
             //Add all the precursors
             for (int i = 0; i < peptidesSortedByMass.Count; i++)
             {
+                run.BeginPeptide();
+
                 double mass = peptidesSortedByMass[i].MonoisotopicMass;
                 if (!double.IsNaN(mass))
                 {
@@ -234,16 +316,7 @@ namespace EngineLayer.Indexing
                         break;
                     }
 
-                    int precursorBin = (int)Math.Round(mass * FragmentBinsPerDalton);
-
-                    if (precursorIndex[precursorBin] == null)
-                    {
-                        precursorIndex[precursorBin] = new List<int> { i };
-                    }
-                    else
-                    {
-                        precursorIndex[precursorBin].Add(i);
-                    }
+                    run.Add((int)Math.Round(mass * FragmentBinsPerDalton));
                 }
                 progress++;
                 var percentProgress = (int)((progress / peptidesSortedByMass.Count) * 100);
@@ -254,12 +327,14 @@ namespace EngineLayer.Indexing
                     ReportProgress(new ProgressEventArgs(percentProgress, "Creating precursor index...", NestedIds));
                 }
             }
-            return precursorIndex;
+
+            run.Complete();
+            return run;
         }
 
         //add possible protein/peptide terminal modifications that aren't on the terminal amino acids
         //The purpose is for terminal mods that are contained WITHIN the Single peptide
-        private void AddInteriorTerminalModsToPrecursorIndex(List<int>[] precursorIndex, List<Product> fragmentMasses, PeptideWithSetModifications peptide, int peptideId, List<Modification> variableModifications)
+        private void AddInteriorTerminalModsToPrecursorIndex(MassBinEmissionRun precursorRun, List<Product> fragmentMasses, PeptideWithSetModifications peptide, List<Modification> variableModifications)
         {
             //Get database annotated mods
             Dictionary<int, List<Modification>> databaseAnnotatedMods = NonSpecificEnzymeSearchEngine.GetTerminalModPositions(peptide, CommonParameters.DigestionParams, variableModifications);
@@ -285,16 +360,7 @@ namespace EngineLayer.Indexing
                     double modifiedMass = basePrecursorMass + mod.MonoisotopicMass.Value;
                     if (modifiedMass <= MaxFragmentSize) //if the precursor is larger than the index allows, then don't add it
                     {
-                        int precursorBin = (int)Math.Round(modifiedMass * FragmentBinsPerDalton);
-
-                        if (precursorIndex[precursorBin] == null)
-                        {
-                            precursorIndex[precursorBin] = new List<int> { peptideId };
-                        }
-                        else
-                        {
-                            precursorIndex[precursorBin].Add(peptideId);
-                        }
+                        precursorRun.Add((int)Math.Round(modifiedMass * FragmentBinsPerDalton));
                     }
                 }
             }

--- a/MetaMorpheus/EngineLayer/Indexing/IndexingResults.cs
+++ b/MetaMorpheus/EngineLayer/Indexing/IndexingResults.cs
@@ -7,15 +7,15 @@ namespace EngineLayer.Indexing
 {
     public class IndexingResults : MetaMorpheusEngineResults
     {
-        public IndexingResults(List<PeptideWithSetModifications> peptideIndex, List<int>[] fragmentIndex, List<int>[] precursorIndex, IndexingEngine indexParams) : base(indexParams)
+        public IndexingResults(List<PeptideWithSetModifications> peptideIndex, MassBinIndex fragmentIndex, MassBinIndex precursorIndex, IndexingEngine indexParams) : base(indexParams)
         {
             PeptideIndex = peptideIndex;
             FragmentIndex = fragmentIndex;
             PrecursorIndex = precursorIndex;
         }
 
-        public List<int>[] FragmentIndex { get; private set; }
-        public List<int>[] PrecursorIndex { get; private set; }
+        public MassBinIndex FragmentIndex { get; private set; }
+        public MassBinIndex PrecursorIndex { get; private set; }
         public List<PeptideWithSetModifications> PeptideIndex { get; private set; }
 
         public override string ToString()

--- a/MetaMorpheus/EngineLayer/Indexing/MassBinIndex.cs
+++ b/MetaMorpheus/EngineLayer/Indexing/MassBinIndex.cs
@@ -130,7 +130,34 @@ namespace EngineLayer.Indexing
             writer.Write(_binStarts.Length);
             writer.Write(_entries.Length);
 
-            WriteInts(file, _binStarts);
+            // Most bins are empty -- there are 30 million of them at the default fragment ceiling --
+            // so store only the occupied ones, as a gap from the previous occupied bin plus a count,
+            // both varint. Writing the offset table verbatim would cost 120 MB no matter how little
+            // of it was used.
+            int occupiedBins = 0;
+            for (int b = 0; b < Length; b++)
+            {
+                if (_binStarts[b + 1] > _binStarts[b])
+                {
+                    occupiedBins++;
+                }
+            }
+            writer.Write(occupiedBins);
+
+            int previousBin = 0;
+            for (int b = 0; b < Length; b++)
+            {
+                int count = _binStarts[b + 1] - _binStarts[b];
+                if (count == 0)
+                {
+                    continue;
+                }
+
+                WriteVarint(writer, (uint)(b - previousBin));
+                WriteVarint(writer, (uint)count);
+                previousBin = b;
+            }
+
             WriteInts(file, _entries);
         }
 
@@ -153,13 +180,67 @@ namespace EngineLayer.Indexing
                 throw new InvalidDataException("Index file header is corrupt.");
             }
 
-            int[] binStarts = new int[binStartsLength];
-            int[] entries = new int[entriesLength];
+            int binCount = binStartsLength - 1;
+            int occupiedBins = reader.ReadInt32();
+            if (occupiedBins < 0 || occupiedBins > binCount)
+            {
+                throw new InvalidDataException("Index file header is corrupt.");
+            }
 
-            ReadInts(file, binStarts);
+            // Rebuild the offset table by laying the counts back out and prefix-summing them.
+            int[] binStarts = new int[binStartsLength];
+            int bin = 0;
+            for (int i = 0; i < occupiedBins; i++)
+            {
+                bin += (int)ReadVarint(reader);
+                if ((uint)bin >= (uint)binCount)
+                {
+                    throw new InvalidDataException("Index file names a bin outside the index.");
+                }
+
+                binStarts[bin + 1] = (int)ReadVarint(reader);
+            }
+
+            for (int b = 0; b < binCount; b++)
+            {
+                binStarts[b + 1] += binStarts[b];
+            }
+
+            if (binStarts[binCount] != entriesLength)
+            {
+                throw new InvalidDataException("Index file bin counts do not add up to its entry count.");
+            }
+
+            int[] entries = new int[entriesLength];
             ReadInts(file, entries);
 
             return new MassBinIndex(binStarts, entries);
+        }
+
+        private static void WriteVarint(BinaryWriter writer, uint value)
+        {
+            while (value >= 0x80)
+            {
+                writer.Write((byte)(value | 0x80));
+                value >>= 7;
+            }
+            writer.Write((byte)value);
+        }
+
+        private static uint ReadVarint(BinaryReader reader)
+        {
+            uint value = 0;
+            for (int shift = 0; shift <= 28; shift += 7)
+            {
+                byte b = reader.ReadByte();
+                value |= (uint)(b & 0x7F) << shift;
+                if ((b & 0x80) == 0)
+                {
+                    return value;
+                }
+            }
+
+            throw new InvalidDataException("Index file contains a malformed varint.");
         }
 
         // Copy through a rented buffer rather than one BinaryWriter.Write(int) per element; an index

--- a/MetaMorpheus/EngineLayer/Indexing/MassBinIndex.cs
+++ b/MetaMorpheus/EngineLayer/Indexing/MassBinIndex.cs
@@ -20,6 +20,14 @@ namespace EngineLayer.Indexing
     /// Within a bin, peptide ids are ascending, exactly as appending in peptide order used to
     /// produce them. BinarySearchBinForPrecursorIndex relies on that: peptides are sorted by mass,
     /// so ascending peptide id within a bin means ascending mass within a bin.
+    ///
+    /// Holding every entry in one array caps a single index at int.MaxValue entries, which the
+    /// List&lt;int&gt;[] did not -- there, each bin carried its own list and only free memory set the
+    /// limit. The cap is reachable: the human UniProt XML with oxidation and acetylation as variable
+    /// mods needs about 3.9 billion entries in one partition, roughly 16 GB either way. Build throws
+    /// a MetaMorpheusException naming the partition count when that happens, since partitioning the
+    /// database is how MetaMorpheus already bounds index size. Lifting the cap would mean segmenting
+    /// the entry array on bin boundaries, which costs an extra indirection on every bin lookup.
     /// </summary>
     public sealed class MassBinIndex
     {
@@ -82,9 +90,15 @@ namespace EngineLayer.Indexing
 
             if (total > int.MaxValue)
             {
+                // Partitioning splits the protein list, so entries fall off roughly in proportion.
+                long partitionMultiplier = (total + int.MaxValue - 1) / int.MaxValue;
+
                 throw new MetaMorpheusException(
-                    "Fragment index is too large to address (" + total + " entries); reduce the maximum fragment mass, " +
-                    "raise the number of database partitions, or use Classic Search.");
+                    "This database needs " + total.ToString("N0") + " fragment index entries, more than the " +
+                    int.MaxValue.ToString("N0") + " a single index can hold. Multiply the number of database " +
+                    "partitions by at least " + partitionMultiplier + ", or reduce the maximum fragment mass, the " +
+                    "number of variable modifications, or the missed cleavages. Classic Search does not build a " +
+                    "fragment index at all and has no such limit.");
             }
 
             for (int b = 0; b < binCount; b++)

--- a/MetaMorpheus/EngineLayer/Indexing/MassBinIndex.cs
+++ b/MetaMorpheus/EngineLayer/Indexing/MassBinIndex.cs
@@ -1,0 +1,281 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace EngineLayer.Indexing
+{
+    /// <summary>
+    /// A fragment- or precursor-mass index, stored as one flat array of peptide ids plus a per-bin
+    /// offset table (compressed sparse row).
+    ///
+    /// This replaces the List&lt;int&gt;[] the index used to be. That layout allocated a separate List
+    /// object -- and its own backing int[], grown by doubling -- for every occupied bin, which meant
+    /// millions of small objects for the GC to trace and a pointer chase on every bin lookup in the
+    /// search inner loop. It also made the reference array alone cost 8 bytes per bin (240 MB at the
+    /// default 30000 Da / 1000-bins-per-Da), which is what the OutOfMemoryException handler in
+    /// IndexingEngine used to be apologizing for.
+    ///
+    /// Within a bin, peptide ids are ascending, exactly as appending in peptide order used to
+    /// produce them. BinarySearchBinForPrecursorIndex relies on that: peptides are sorted by mass,
+    /// so ascending peptide id within a bin means ascending mass within a bin.
+    /// </summary>
+    public sealed class MassBinIndex
+    {
+        // On-disk header. Bumping Version invalidates cached index files; the readers in
+        // MetaMorpheusTask already fall back to regenerating when a read throws.
+        private const int Magic = 0x4D4D4249; // "MMBI"
+        private const int Version = 1;
+
+        /// <summary>bin b occupies _entries[_binStarts[b].._binStarts[b + 1]). Length is BinCount + 1.</summary>
+        private readonly int[] _binStarts;
+
+        private readonly int[] _entries;
+
+        private MassBinIndex(int[] binStarts, int[] entries)
+        {
+            _binStarts = binStarts;
+            _entries = entries;
+        }
+
+        /// <summary>
+        /// Number of mass bins. Named Length rather than Count because this stands in for the
+        /// array it replaced, and callers bounds-check against it.
+        /// </summary>
+        public int Length => _binStarts.Length - 1;
+
+        /// <summary>Total number of peptide ids across all bins.</summary>
+        public int EntryCount => _entries.Length;
+
+        /// <summary>The peptide ids in a bin, ascending. Empty -- not null -- when the bin is unoccupied.</summary>
+        public ReadOnlySpan<int> this[int bin] => new ReadOnlySpan<int>(_entries, _binStarts[bin], _binStarts[bin + 1] - _binStarts[bin]);
+
+        /// <summary>
+        /// How many peptide ids are in a bin. Cheaper than materializing the span when the caller
+        /// only wants to know whether the bin is worth visiting.
+        /// </summary>
+        public int CountInBin(int bin) => _binStarts[bin + 1] - _binStarts[bin];
+
+        /// <summary>
+        /// Builds the index from emission runs. Runs are concatenated in list order, so the caller
+        /// controls the emission sequence; a stable counting sort over that sequence reproduces
+        /// exactly the per-bin ordering that appending to List&lt;int&gt;[] used to produce.
+        /// </summary>
+        public static MassBinIndex Build(int binCount, IReadOnlyList<MassBinEmissionRun> runsInEmissionOrder)
+        {
+            // binStarts doubles as the counting array, then as the scatter cursor, so a 30M-bin
+            // index needs one 120 MB array here rather than three.
+            int[] binStarts = new int[binCount + 1];
+
+            long total = 0;
+            foreach (MassBinEmissionRun run in runsInEmissionOrder)
+            {
+                int[] bins = run.Bins;
+                int n = run.EmissionCount;
+                for (int i = 0; i < n; i++)
+                {
+                    binStarts[bins[i] + 1]++;
+                }
+                total += n;
+            }
+
+            if (total > int.MaxValue)
+            {
+                throw new MetaMorpheusException(
+                    "Fragment index is too large to address (" + total + " entries); reduce the maximum fragment mass, " +
+                    "raise the number of database partitions, or use Classic Search.");
+            }
+
+            for (int b = 0; b < binCount; b++)
+            {
+                binStarts[b + 1] += binStarts[b];
+            }
+
+            int[] entries = new int[(int)total];
+
+            // Scatter using binStarts itself as the per-bin cursor. Afterwards binStarts[b] holds the
+            // end of bin b, so shifting right by one turns the cursors back into starts.
+            foreach (MassBinEmissionRun run in runsInEmissionOrder)
+            {
+                int[] bins = run.Bins;
+                int[] runLengths = run.RunLengths;
+                int peptideId = run.FirstPeptideId;
+                int emission = 0;
+
+                for (int p = 0; p < run.PeptideCount; p++)
+                {
+                    int emissionsForThisPeptide = runLengths[p];
+                    for (int k = 0; k < emissionsForThisPeptide; k++)
+                    {
+                        entries[binStarts[bins[emission++]]++] = peptideId;
+                    }
+                    peptideId++;
+                }
+            }
+
+            Array.Copy(binStarts, 0, binStarts, 1, binCount);
+            binStarts[0] = 0;
+
+            return new MassBinIndex(binStarts, entries);
+        }
+
+        public void Write(string filePath)
+        {
+            using FileStream file = File.Create(filePath);
+            using BinaryWriter writer = new BinaryWriter(file);
+
+            writer.Write(Magic);
+            writer.Write(Version);
+            writer.Write(_binStarts.Length);
+            writer.Write(_entries.Length);
+
+            WriteInts(file, _binStarts);
+            WriteInts(file, _entries);
+        }
+
+        public static MassBinIndex Read(string filePath)
+        {
+            using FileStream file = File.OpenRead(filePath);
+            using BinaryReader reader = new BinaryReader(file);
+
+            if (reader.ReadInt32() != Magic || reader.ReadInt32() != Version)
+            {
+                // An index written by a different MetaMorpheus. Callers catch this and rebuild.
+                throw new InvalidDataException("Index file is not in the format this version of MetaMorpheus writes.");
+            }
+
+            int binStartsLength = reader.ReadInt32();
+            int entriesLength = reader.ReadInt32();
+
+            if (binStartsLength < 1 || entriesLength < 0)
+            {
+                throw new InvalidDataException("Index file header is corrupt.");
+            }
+
+            int[] binStarts = new int[binStartsLength];
+            int[] entries = new int[entriesLength];
+
+            ReadInts(file, binStarts);
+            ReadInts(file, entries);
+
+            return new MassBinIndex(binStarts, entries);
+        }
+
+        // Copy through a rented buffer rather than one BinaryWriter.Write(int) per element; an index
+        // can hold hundreds of millions of ints and the per-call overhead dominates otherwise.
+        private const int CopyBufferBytes = 1 << 20;
+
+        private static void WriteInts(Stream stream, int[] values)
+        {
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(CopyBufferBytes);
+            try
+            {
+                int intsPerChunk = buffer.Length / sizeof(int);
+                for (int offset = 0; offset < values.Length; offset += intsPerChunk)
+                {
+                    int count = Math.Min(intsPerChunk, values.Length - offset);
+                    Span<byte> bytes = buffer.AsSpan(0, count * sizeof(int));
+                    MemoryMarshal.AsBytes(values.AsSpan(offset, count)).CopyTo(bytes);
+                    stream.Write(bytes);
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+        }
+
+        private static void ReadInts(Stream stream, int[] values)
+        {
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(CopyBufferBytes);
+            try
+            {
+                int intsPerChunk = buffer.Length / sizeof(int);
+                for (int offset = 0; offset < values.Length; offset += intsPerChunk)
+                {
+                    int count = Math.Min(intsPerChunk, values.Length - offset);
+                    Span<byte> bytes = buffer.AsSpan(0, count * sizeof(int));
+                    stream.ReadExactly(bytes);
+                    bytes.CopyTo(MemoryMarshal.AsBytes(values.AsSpan(offset, count)));
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+        }
+    }
+
+    /// <summary>
+    /// An ordered run of (bin, peptide id) emissions covering a contiguous block of peptide ids.
+    /// The peptide id is stored as a run length per peptide rather than once per emission, which
+    /// halves the transient memory a build needs -- the fragment index of a large search can hold
+    /// hundreds of millions of emissions.
+    /// </summary>
+    public sealed class MassBinEmissionRun
+    {
+        private int[] _bins;
+        private int[] _runLengths;
+        private int _emissionCount;
+        private int _peptideCount;
+        private int _emissionsForCurrentPeptide;
+        private bool _peptideOpen;
+
+        public MassBinEmissionRun(int firstPeptideId, int expectedPeptides = 16)
+        {
+            FirstPeptideId = firstPeptideId;
+            _bins = new int[Math.Max(16, expectedPeptides)];
+            _runLengths = new int[Math.Max(16, expectedPeptides)];
+        }
+
+        public int FirstPeptideId { get; }
+        internal int[] Bins => _bins;
+        internal int[] RunLengths => _runLengths;
+        internal int EmissionCount => _emissionCount;
+        internal int PeptideCount => _peptideCount;
+
+        /// <summary>
+        /// Starts the emissions for the next peptide id. Must be called once per peptide in the
+        /// block, in ascending id order, including for peptides that emit nothing.
+        /// </summary>
+        public void BeginPeptide()
+        {
+            if (_peptideOpen)
+            {
+                Append(ref _runLengths, _peptideCount, _emissionsForCurrentPeptide);
+                _peptideCount++;
+            }
+
+            _peptideOpen = true;
+            _emissionsForCurrentPeptide = 0;
+        }
+
+        public void Add(int bin)
+        {
+            Append(ref _bins, _emissionCount, bin);
+            _emissionCount++;
+            _emissionsForCurrentPeptide++;
+        }
+
+        /// <summary>Closes the final peptide. Call once, after the last BeginPeptide/Add.</summary>
+        public void Complete()
+        {
+            if (_peptideOpen)
+            {
+                Append(ref _runLengths, _peptideCount, _emissionsForCurrentPeptide);
+                _peptideCount++;
+                _peptideOpen = false;
+            }
+        }
+
+        private static void Append(ref int[] array, int index, int value)
+        {
+            if (index == array.Length)
+            {
+                Array.Resize(ref array, array.Length * 2);
+            }
+            array[index] = value;
+        }
+    }
+}

--- a/MetaMorpheus/EngineLayer/ModernSearch/ModernSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/ModernSearch/ModernSearchEngine.cs
@@ -1,4 +1,5 @@
 ﻿using Chemistry;
+using EngineLayer.Indexing;
 using MassSpectrometry;
 using Omics.Fragmentation;
 using Proteomics.ProteolyticDigestion;
@@ -12,7 +13,7 @@ namespace EngineLayer.ModernSearch
     public class ModernSearchEngine : MetaMorpheusEngine
     {
         protected const int FragmentBinsPerDalton = 1000;
-        protected List<int>[] FragmentIndex { get; private set; }
+        protected MassBinIndex FragmentIndex { get; private set; }
         protected readonly SpectralMatch[] PeptideSpectralMatches;
         protected readonly Ms2ScanWithSpecificMass[] ListOfSortedMs2Scans;
         protected readonly List<PeptideWithSetModifications> PeptideIndex;
@@ -22,7 +23,7 @@ namespace EngineLayer.ModernSearch
         protected readonly double MaxMassThatFragmentIonScoreIsDoubled;
 
         public ModernSearchEngine(SpectralMatch[] globalPsms, Ms2ScanWithSpecificMass[] listOfSortedms2Scans, List<PeptideWithSetModifications> peptideIndex,
-            List<int>[] fragmentIndex, int currentPartition, CommonParameters commonParameters, List<(string fileName, CommonParameters fileSpecificParameters)> fileSpecificParameters, MassDiffAcceptor massDiffAcceptor, double maximumMassThatFragmentIonScoreIsDoubled,
+            MassBinIndex fragmentIndex, int currentPartition, CommonParameters commonParameters, List<(string fileName, CommonParameters fileSpecificParameters)> fileSpecificParameters, MassDiffAcceptor massDiffAcceptor, double maximumMassThatFragmentIonScoreIsDoubled,
             List<string> nestedIds) : base(commonParameters, fileSpecificParameters, nestedIds)
         {
             PeptideSpectralMatches = globalPsms;
@@ -118,9 +119,9 @@ namespace EngineLayer.ModernSearch
                     //convert to an int since we're in discrete 1.0005...
                     int fragmentBin = (int)(Math.Round(masses[i].ToMass(1) / 1.0005079) * 1.0005079 * FragmentBinsPerDalton);
 
-                    List<int> bin = FragmentIndex[fragmentBin];
+                    ReadOnlySpan<int> bin = FragmentIndex[fragmentBin];
 
-                    if (bin != null)
+                    if (!bin.IsEmpty)
                     {
                         // filter bin by peptide mass
                         var (start, end) = GetFirstAndLastIndexesInBinToIncrement(lowestMassPeptideToLookFor, highestMassPeptideToLookFor, bin, scan.PrecursorMass);
@@ -141,7 +142,7 @@ namespace EngineLayer.ModernSearch
 
                                 bin = FragmentIndex[fragmentBin];
 
-                                if (bin != null)
+                                if (!bin.IsEmpty)
                                 {
                                     // filter bin by peptide mass
                                     var (start, end) = GetFirstAndLastIndexesInBinToIncrement(lowestMassPeptideToLookFor, highestMassPeptideToLookFor, bin, scan.PrecursorMass);
@@ -172,9 +173,9 @@ namespace EngineLayer.ModernSearch
 
                     for (int b = obsFragmentFloorMass; b <= obsFragmentCeilingMass; b++)
                     {
-                        List<int> bin = FragmentIndex[b];
+                        ReadOnlySpan<int> bin = FragmentIndex[b];
 
-                        if (bin == null)
+                        if (bin.IsEmpty)
                         {
                             continue;
                         }
@@ -201,9 +202,9 @@ namespace EngineLayer.ModernSearch
 
                                 for (int b = compFragmentFloorMass; b <= compFragmentCeilingMass; b++)
                                 {
-                                    List<int> bin = FragmentIndex[b];
+                                    ReadOnlySpan<int> bin = FragmentIndex[b];
 
-                                    if (bin == null)
+                                    if (bin.IsEmpty)
                                     {
                                         continue;
                                     }
@@ -230,10 +231,10 @@ namespace EngineLayer.ModernSearch
         /// <summary>
         /// Finds the first and last bin-indexes of the peptides to add a +1 score to, based on the precursor mass and precursor mass tolerance.
         /// </summary>
-        protected (int start, int end) GetFirstAndLastIndexesInBinToIncrement(double lowestPeptideMassToLookFor, double highestPeptideMassToLookFor, List<int> bin, double precursorMass)
+        protected (int start, int end) GetFirstAndLastIndexesInBinToIncrement(double lowestPeptideMassToLookFor, double highestPeptideMassToLookFor, ReadOnlySpan<int> bin, double precursorMass)
         {
             int start = 0;
-            int end = bin.Count - 1;
+            int end = bin.Length - 1;
 
             if (!double.IsPositiveInfinity(highestPeptideMassToLookFor))
             {
@@ -252,11 +253,11 @@ namespace EngineLayer.ModernSearch
         /// Returns the bin-index of the first peptide with a mass less than or equal to the specified mass. Returns 0 if there 
         /// are no peptides with masses smaller than the specified mass.
         /// </summary>
-        protected static int BinarySearchBinForPrecursorIndex(List<int> bin, double peptideMassToLookFor, List<PeptideWithSetModifications> peptideIndex)
+        protected static int BinarySearchBinForPrecursorIndex(ReadOnlySpan<int> bin, double peptideMassToLookFor, List<PeptideWithSetModifications> peptideIndex)
         {
             int m = 0;
             int l = 0;
-            int r = bin.Count - 1;
+            int r = bin.Length - 1;
 
             // binary search in the fragment bin for precursor mass
             while (l <= r)
@@ -291,7 +292,7 @@ namespace EngineLayer.ModernSearch
         /// <summary>
         /// Adds a +1 score to all the peptides in the fragment mass bin that meet the precursor mass tolerance.
         /// </summary>
-        protected void IncrementPeptideScoresInBin(int start, int end, List<int> bin, byte[] scoringTable, Ms2ScanWithSpecificMass scan, byte byteScoreCutoff,
+        protected void IncrementPeptideScoresInBin(int start, int end, ReadOnlySpan<int> bin, byte[] scoringTable, Ms2ScanWithSpecificMass scan, byte byteScoreCutoff,
             List<int> peptidesPossiblyObserved, DissociationType dissociationType)
         {
             if (dissociationType == DissociationType.LowCID)
@@ -398,25 +399,25 @@ namespace EngineLayer.ModernSearch
         /// <summary>
         /// Deprecated.
         /// </summary>
-        protected void IndexedScoring(List<int>[] FragmentIndex, List<int> binsToSearch, byte[] scoringTable, byte byteScoreCutoff, List<int> idsOfPeptidesPossiblyObserved, double scanPrecursorMass, double lowestMassPeptideToLookFor,
+        protected void IndexedScoring(MassBinIndex FragmentIndex, List<int> binsToSearch, byte[] scoringTable, byte byteScoreCutoff, List<int> idsOfPeptidesPossiblyObserved, double scanPrecursorMass, double lowestMassPeptideToLookFor,
             double highestMassPeptideToLookFor, List<PeptideWithSetModifications> peptideIndex, MassDiffAcceptor massDiffAcceptor, double maxMassThatFragmentIonScoreIsDoubled, DissociationType dissociationType)
         {
             // get all theoretical fragments this experimental fragment could be
             for (int i = 0; i < binsToSearch.Count; i++) //binsToSearch is the list of fragment in Spectra
             {
-                List<int> peptideIdsInThisBin = FragmentIndex[binsToSearch[i]];
+                ReadOnlySpan<int> peptideIdsInThisBin = FragmentIndex[binsToSearch[i]];
 
                 //get index for minimum monoisotopic allowed
                 int lowestPeptideMassIndex = Double.IsInfinity(lowestMassPeptideToLookFor) ? 0 : BinarySearchBinForPrecursorIndex(peptideIdsInThisBin, lowestMassPeptideToLookFor, peptideIndex);
 
                 // get index for highest mass allowed
-                int highestPeptideMassIndex = peptideIdsInThisBin.Count - 1;
+                int highestPeptideMassIndex = peptideIdsInThisBin.Length - 1;
 
                 if (!Double.IsInfinity(highestMassPeptideToLookFor)) //check if the highest mass is infinity
                 {
                     highestPeptideMassIndex = BinarySearchBinForPrecursorIndex(peptideIdsInThisBin, highestMassPeptideToLookFor, peptideIndex); //get index for maximum monoisotopic allowed
 
-                    for (int j = highestPeptideMassIndex; j < peptideIdsInThisBin.Count; j++) //find the highest peptide mass index 
+                    for (int j = highestPeptideMassIndex; j < peptideIdsInThisBin.Length; j++) //find the highest peptide mass index 
                     {
                         int nextId = peptideIdsInThisBin[j];
                         var nextPep = peptideIndex[nextId];
@@ -469,7 +470,7 @@ namespace EngineLayer.ModernSearch
         /// <summary>
         /// Deprecated.
         /// </summary>
-        protected List<int> GetBinsToSearch(Ms2ScanWithSpecificMass scan, List<int>[] FragmentIndex, DissociationType dissociationType)
+        protected List<int> GetBinsToSearch(Ms2ScanWithSpecificMass scan, MassBinIndex FragmentIndex, DissociationType dissociationType)
         {
             int obsPreviousFragmentCeilingMz = 0;
             List<int> binsToSearch = new List<int>();
@@ -484,7 +485,7 @@ namespace EngineLayer.ModernSearch
                     //convert to an int since we're in discrete 1.0005...
                     int fragmentBin = (int)(Math.Round(masses[i].ToMass(1) / 1.0005079) * 1.0005079 * FragmentBinsPerDalton);
 
-                    if (FragmentIndex[fragmentBin] != null)
+                    if (FragmentIndex.CountInBin(fragmentBin) > 0)
                     {
                         binsToSearch.Add(fragmentBin);
                     }
@@ -499,7 +500,7 @@ namespace EngineLayer.ModernSearch
                                 double protonMassShift = massshift.ToMass(1);
                                 fragmentBin = (int)Math.Round((scan.PrecursorMass + protonMassShift - masses[i]) / 1.0005079);
 
-                                if (FragmentIndex[fragmentBin] != null)
+                                if (FragmentIndex.CountInBin(fragmentBin) > 0)
                                 {
                                     binsToSearch.Add(fragmentBin);
                                 }
@@ -545,7 +546,7 @@ namespace EngineLayer.ModernSearch
                     // search mass bins within a tolerance
                     for (int fragmentBin = obsFragmentFloorMass; fragmentBin <= obsFragmentCeilingMass; fragmentBin++)
                     {
-                        if (FragmentIndex[fragmentBin] != null)
+                        if (FragmentIndex.CountInBin(fragmentBin) > 0)
                         {
                             binsToSearch.Add(fragmentBin);
                         }
@@ -581,7 +582,7 @@ namespace EngineLayer.ModernSearch
 
                                 for (int fragmentBin = compFragmentFloorMass; fragmentBin <= compFragmentCeilingMass; fragmentBin++)
                                 {
-                                    if (FragmentIndex[fragmentBin] != null)
+                                    if (FragmentIndex.CountInBin(fragmentBin) > 0)
                                     {
                                         binsToSearch.Add(fragmentBin);
                                     }

--- a/MetaMorpheus/EngineLayer/ModernSearch/ModernSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/ModernSearch/ModernSearchEngine.cs
@@ -1,5 +1,6 @@
 ﻿using Chemistry;
 using EngineLayer.Indexing;
+using EngineLayer.Util;
 using MassSpectrometry;
 using Omics.Fragmentation;
 using Proteomics.ProteolyticDigestion;
@@ -22,6 +23,13 @@ namespace EngineLayer.ModernSearch
         protected readonly DissociationType DissociationType;
         protected readonly double MaxMassThatFragmentIonScoreIsDoubled;
 
+        /// <summary>
+        /// Whether the per-scan score table stamps cells instead of clearing them. Worth it when a scan
+        /// touches a small slice of the peptide index; a losing trade for an open search, which touches
+        /// most of it. See ScanScoringTable.
+        /// </summary>
+        protected readonly bool UseStampedScoringTable;
+
         public ModernSearchEngine(SpectralMatch[] globalPsms, Ms2ScanWithSpecificMass[] listOfSortedms2Scans, List<PeptideWithSetModifications> peptideIndex,
             MassBinIndex fragmentIndex, int currentPartition, CommonParameters commonParameters, List<(string fileName, CommonParameters fileSpecificParameters)> fileSpecificParameters, MassDiffAcceptor massDiffAcceptor, double maximumMassThatFragmentIonScoreIsDoubled,
             List<string> nestedIds) : base(commonParameters, fileSpecificParameters, nestedIds)
@@ -34,6 +42,7 @@ namespace EngineLayer.ModernSearch
             MassDiffAcceptor = massDiffAcceptor;
             DissociationType = commonParameters.DissociationType;
             MaxMassThatFragmentIonScoreIsDoubled = maximumMassThatFragmentIonScoreIsDoubled;
+            UseStampedScoringTable = massDiffAcceptor is not OpenSearchMode;
         }
 
         protected override MetaMorpheusEngineResults RunSpecific()
@@ -50,9 +59,10 @@ namespace EngineLayer.ModernSearch
 
             Parallel.ForEach(threads, (scanIndex) =>
             {
-                byte[] scoringTable = new byte[PeptideIndex.Count];
+                var scoringTable = new ScanScoringTable(PeptideIndex.Count, UseStampedScoringTable);
                 List<int> idsOfPeptidesPossiblyObserved = new List<int>(PeptideIndex.Count);
                 List<Product> peptideTheorProducts = new List<Product>();
+                var scoreSorter = new DescendingScoreSorter();
 
                 for (; scanIndex < ListOfSortedMs2Scans.Length; scanIndex += maxThreadsPerFile)
                 {
@@ -68,7 +78,7 @@ namespace EngineLayer.ModernSearch
                     IndexScoreScan(scan, scoringTable, byteScoreCutoff, idsOfPeptidesPossiblyObserved, CommonParameters.DissociationType);
 
                     // take indexed-scored peptides and re-score them using the more accurate but slower scoring algorithm
-                    FineScorePeptides(idsOfPeptidesPossiblyObserved, scan, scanIndex, scoringTable, CommonParameters.DissociationType, peptideTheorProducts);
+                    FineScorePeptides(idsOfPeptidesPossiblyObserved, scan, scanIndex, scoringTable, CommonParameters.DissociationType, peptideTheorProducts, scoreSorter);
 
                     //report search progress
                     progress++;
@@ -95,7 +105,7 @@ namespace EngineLayer.ModernSearch
         /// This is a first-pass scoring method which is supposed to be *very fast* but may sometimes miscount the number of truly matched fragments. The number
         /// of matched fragments should always be overestimated, never underestimated.
         /// </summary>
-        protected void IndexScoreScan(Ms2ScanWithSpecificMass scan, byte[] scoringTable, byte byteScoreCutoff, List<int> peptidesPossiblyObserved, DissociationType dissociationType)
+        protected void IndexScoreScan(Ms2ScanWithSpecificMass scan, ScanScoringTable scoringTable, byte byteScoreCutoff, List<int> peptidesPossiblyObserved, DissociationType dissociationType)
         {
             // get allowed theoretical masses from the known experimental mass
             // note that this is the OPPOSITE of the classic search (which calculates experimental masses from theoretical values)	
@@ -105,8 +115,8 @@ namespace EngineLayer.ModernSearch
             double lowestMassPeptideToLookFor = notches.Min(p => p.Minimum);
             double highestMassPeptideToLookFor = notches.Max(p => p.Maximum);
 
-            // clear the scoring table to score the new scan (conserves memory compared to allocating a new array)
-            Array.Clear(scoringTable, 0, scoringTable.Length);
+            // retire the previous scan's scores (conserves memory compared to allocating a new array)
+            scoringTable.BeginScan();
             peptidesPossiblyObserved.Clear();
 
             if (dissociationType == DissociationType.LowCID)
@@ -292,7 +302,7 @@ namespace EngineLayer.ModernSearch
         /// <summary>
         /// Adds a +1 score to all the peptides in the fragment mass bin that meet the precursor mass tolerance.
         /// </summary>
-        protected void IncrementPeptideScoresInBin(int start, int end, ReadOnlySpan<int> bin, byte[] scoringTable, Ms2ScanWithSpecificMass scan, byte byteScoreCutoff,
+        protected void IncrementPeptideScoresInBin(int start, int end, ReadOnlySpan<int> bin, ScanScoringTable scoringTable, Ms2ScanWithSpecificMass scan, byte byteScoreCutoff,
             List<int> peptidesPossiblyObserved, DissociationType dissociationType)
         {
             if (dissociationType == DissociationType.LowCID)
@@ -312,7 +322,7 @@ namespace EngineLayer.ModernSearch
                     }
 
                     // mark the peptide as potentially observed so it doesn't get added more than once
-                    scoringTable[peptideId] = 1;
+                    scoringTable.Set(peptideId, 1);
                 }
             }
             else
@@ -321,7 +331,7 @@ namespace EngineLayer.ModernSearch
                 for (int p = start; p <= end; p++)
                 {
                     int peptideId = bin[p];
-                    byte score = ++scoringTable[peptideId];
+                    byte score = scoringTable.Increment(peptideId);
 
                     // if the peptide has met the score cutoff, add it to the list of peptides 
                     // possibly observed so it can be re-scored with the "fine scoring" algorithm
@@ -368,8 +378,8 @@ namespace EngineLayer.ModernSearch
             return PeptideSpectralMatches[scanIndex];
         }
 
-        protected void FineScorePeptides(List<int> peptideIds, Ms2ScanWithSpecificMass scan, int scanIndex, byte[] scoringTable, 
-            DissociationType dissociationType, List<Product> peptideTheorProducts)
+        protected void FineScorePeptides(List<int> peptideIds, Ms2ScanWithSpecificMass scan, int scanIndex, ScanScoringTable scoringTable, 
+            DissociationType dissociationType, List<Product> peptideTheorProducts, DescendingScoreSorter scoreSorter)
         {
             // this method re-scores the top-scoring peptides until no peptide in the rough-scored list can out-score
             // the best-scoring peptide. this guarantees that peptides will be scored accurately, according to metamorpheus score,
@@ -378,7 +388,7 @@ namespace EngineLayer.ModernSearch
             // output, though it will be very close.
             byte bestScore = 0;
 
-            foreach (int id in peptideIds.OrderByDescending(p => scoringTable[p]))
+            foreach (int id in scoreSorter.Sort(peptideIds, scoringTable))
             {
                 if (scoringTable[id] < bestScore && dissociationType != DissociationType.LowCID)
                 {
@@ -399,7 +409,7 @@ namespace EngineLayer.ModernSearch
         /// <summary>
         /// Deprecated.
         /// </summary>
-        protected void IndexedScoring(MassBinIndex FragmentIndex, List<int> binsToSearch, byte[] scoringTable, byte byteScoreCutoff, List<int> idsOfPeptidesPossiblyObserved, double scanPrecursorMass, double lowestMassPeptideToLookFor,
+        protected void IndexedScoring(MassBinIndex FragmentIndex, List<int> binsToSearch, ScanScoringTable scoringTable, byte byteScoreCutoff, List<int> idsOfPeptidesPossiblyObserved, double scanPrecursorMass, double lowestMassPeptideToLookFor,
             double highestMassPeptideToLookFor, List<PeptideWithSetModifications> peptideIndex, MassDiffAcceptor massDiffAcceptor, double maxMassThatFragmentIonScoreIsDoubled, DissociationType dissociationType)
         {
             // get all theoretical fragments this experimental fragment could be
@@ -446,7 +456,7 @@ namespace EngineLayer.ModernSearch
                         }
 
                         // mark the peptide as potentially observed so it doesn't get added more than once
-                        scoringTable[id] = 1;
+                        scoringTable.Set(id, 1);
                     }
                 }
                 else
@@ -455,10 +465,9 @@ namespace EngineLayer.ModernSearch
                     for (int j = lowestPeptideMassIndex; j <= highestPeptideMassIndex; j++) // iterate through the peptide index in the bin
                     {
                         int id = peptideIdsInThisBin[j];
-                        scoringTable[id]++;
 
                         // if the score of the peptide >3 (counts > 3 times), and the mass difference is accepted, add the peptide to the list of peptides possibly observed
-                        if (scoringTable[id] == byteScoreCutoff && massDiffAcceptor.Accepts(scanPrecursorMass, peptideIndex[id].MonoisotopicMass) >= 0)
+                        if (scoringTable.Increment(id) == byteScoreCutoff && massDiffAcceptor.Accepts(scanPrecursorMass, peptideIndex[id].MonoisotopicMass) >= 0)
                         {
                             idsOfPeptidesPossiblyObserved.Add(id);
                         }

--- a/MetaMorpheus/EngineLayer/NonSpecificEnzymeSearch/NonSpecificEnzymeSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/NonSpecificEnzymeSearch/NonSpecificEnzymeSearchEngine.cs
@@ -6,6 +6,7 @@ using Omics.Fragmentation;
 using Proteomics.ProteolyticDigestion;
 using System;
 using EngineLayer.Indexing;
+using EngineLayer.Util;
 using MassSpectrometry;
 using System.Collections.Generic;
 using System.Linq;
@@ -61,7 +62,7 @@ namespace EngineLayer.NonSpecificEnzymeSearch
             int[] threads = Enumerable.Range(0, maxThreadsPerFile).ToArray();
             Parallel.ForEach(threads, (i) =>
             {
-                byte[] scoringTable = new byte[PeptideIndex.Count];
+                var scoringTable = new ScanScoringTable(PeptideIndex.Count, UseStampedScoringTable);
 
                 List<Product> peptideTheorProducts = new List<Product>();
                 List<int> idsOfPeptidesPossiblyObserved = new List<int>();
@@ -72,7 +73,7 @@ namespace EngineLayer.NonSpecificEnzymeSearch
                     if (GlobalVariables.StopLoops) { return; }
 
                     // empty the scoring table to score the new scan (conserves memory compared to allocating a new array)
-                    Array.Clear(scoringTable, 0, scoringTable.Length);
+                    scoringTable.BeginScan();
                     idsOfPeptidesPossiblyObserved.Clear();
                     List<int> coisolatedIndexes = CoisolationIndex[i];
                     Ms2ScanWithSpecificMass scan = ListOfSortedMs2Scans[coisolatedIndexes[(coisolatedIndexes.Count - 1) / 2]]; //get first scan; all scans should be identical
@@ -173,7 +174,7 @@ namespace EngineLayer.NonSpecificEnzymeSearch
             return new MetaMorpheusEngineResults(this);
         }
 
-        private void SnesIndexedScoring(Ms2ScanWithSpecificMass scan, MassBinIndex FragmentIndex, byte[] scoringTable, List<PeptideWithSetModifications> peptideIndex, DissociationType dissociationType)
+        private void SnesIndexedScoring(Ms2ScanWithSpecificMass scan, MassBinIndex FragmentIndex, ScanScoringTable scoringTable, List<PeptideWithSetModifications> peptideIndex, DissociationType dissociationType)
         {
             int obsPreviousFragmentCeilingMz = 0;
 
@@ -193,7 +194,7 @@ namespace EngineLayer.NonSpecificEnzymeSearch
                     {
                         for (int pep = 0; pep < bin.Length; pep++)
                         {
-                            scoringTable[bin[pep]]++;
+                            scoringTable.Increment(bin[pep]);
                         }
                     }
 
@@ -217,7 +218,7 @@ namespace EngineLayer.NonSpecificEnzymeSearch
                                     {
                                         for (int pep = 0; pep < bin.Length; pep++)
                                         {
-                                            scoringTable[bin[pep]]++;
+                                            scoringTable.Increment(bin[pep]);
                                         }
                                     }
                                 }
@@ -269,7 +270,7 @@ namespace EngineLayer.NonSpecificEnzymeSearch
                             {
                                 for (int pep = 0; pep < bin.Length; pep++)
                                 {
-                                    scoringTable[bin[pep]]++;
+                                    scoringTable.Increment(bin[pep]);
                                 }
                             }
                         }
@@ -310,7 +311,7 @@ namespace EngineLayer.NonSpecificEnzymeSearch
                                         {
                                             for (int pep = 0; pep < bin.Length; pep++)
                                             {
-                                                scoringTable[bin[pep]]++;
+                                                scoringTable.Increment(bin[pep]);
                                             }
                                         }
                                     }

--- a/MetaMorpheus/EngineLayer/NonSpecificEnzymeSearch/NonSpecificEnzymeSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/NonSpecificEnzymeSearch/NonSpecificEnzymeSearchEngine.cs
@@ -5,6 +5,7 @@ using Proteomics;
 using Omics.Fragmentation;
 using Proteomics.ProteolyticDigestion;
 using System;
+using EngineLayer.Indexing;
 using MassSpectrometry;
 using System.Collections.Generic;
 using System.Linq;
@@ -20,7 +21,7 @@ namespace EngineLayer.NonSpecificEnzymeSearch
     {
         private static readonly double WaterMonoisotopicMass = PeriodicTable.GetElement("H").PrincipalIsotope.AtomicMass * 2 + PeriodicTable.GetElement("O").PrincipalIsotope.AtomicMass;
 
-        private readonly List<int>[] PrecursorIndex;
+        private readonly MassBinIndex PrecursorIndex;
         private readonly int MinimumPeptideLength;
         readonly SpectralMatch[][] GlobalCategorySpecificPsms;
         readonly CommonParameters ModifiedParametersNoComp;
@@ -29,7 +30,7 @@ namespace EngineLayer.NonSpecificEnzymeSearch
         readonly List<int>[] CoisolationIndex;
 
         public NonSpecificEnzymeSearchEngine(SpectralMatch[][] globalPsms, Ms2ScanWithSpecificMass[] listOfSortedms2Scans, List<int>[] coisolationIndex,
-            List<PeptideWithSetModifications> peptideIndex, List<int>[] fragmentIndex, List<int>[] precursorIndex, int currentPartition,
+            List<PeptideWithSetModifications> peptideIndex, MassBinIndex fragmentIndex, MassBinIndex precursorIndex, int currentPartition,
             CommonParameters commonParameters, List<(string fileName, CommonParameters fileSpecificParameters)> fileSpecificParameters, List<Modification> variableModifications, MassDiffAcceptor massDiffAcceptor, double maximumMassThatFragmentIonScoreIsDoubled, List<string> nestedIds)
             : base(null, listOfSortedms2Scans, peptideIndex, fragmentIndex, currentPartition, commonParameters, fileSpecificParameters, massDiffAcceptor, maximumMassThatFragmentIonScoreIsDoubled, nestedIds)
         {
@@ -98,18 +99,24 @@ namespace EngineLayer.NonSpecificEnzymeSearch
                                 int highestBin = obsPrecursorCeilingMz - dissociationBinShift;
                                 for (int bin = lowestBin; bin <= highestBin; bin++)
                                 {
-                                    if (bin < FragmentIndex.Length && FragmentIndex[bin] != null)
+                                    if (bin < FragmentIndex.Length)
                                     {
-                                        FragmentIndex[bin].ForEach(id => idsOfPeptidesPossiblyObserved.Add(id));
+                                        foreach (int id in FragmentIndex[bin])
+                                        {
+                                            idsOfPeptidesPossiblyObserved.Add(id);
+                                        }
                                     }
                                 }
                             }
 
                             for (int bin = obsPrecursorFloorMz; bin <= obsPrecursorCeilingMz; bin++) //no bin shift, since they're precursor masses
                             {
-                                if (bin < PrecursorIndex.Length && PrecursorIndex[bin] != null)
+                                if (bin < PrecursorIndex.Length)
                                 {
-                                    PrecursorIndex[bin].ForEach(id => idsOfPeptidesPossiblyObserved.Add(id));
+                                    foreach (int id in PrecursorIndex[bin])
+                                    {
+                                        idsOfPeptidesPossiblyObserved.Add(id);
+                                    }
                                 }
                             }
                         }
@@ -166,7 +173,7 @@ namespace EngineLayer.NonSpecificEnzymeSearch
             return new MetaMorpheusEngineResults(this);
         }
 
-        private void SnesIndexedScoring(Ms2ScanWithSpecificMass scan, List<int>[] FragmentIndex, byte[] scoringTable, List<PeptideWithSetModifications> peptideIndex, DissociationType dissociationType)
+        private void SnesIndexedScoring(Ms2ScanWithSpecificMass scan, MassBinIndex FragmentIndex, byte[] scoringTable, List<PeptideWithSetModifications> peptideIndex, DissociationType dissociationType)
         {
             int obsPreviousFragmentCeilingMz = 0;
 
@@ -179,12 +186,12 @@ namespace EngineLayer.NonSpecificEnzymeSearch
                 {
                     //convert to an int since we're in discrete 1.0005...
                     int fragmentBin = (int)(Math.Round(masses[i].ToMass(1) / 1.0005079) * 1.0005079 * FragmentBinsPerDalton);
-                    List<int> bin = FragmentIndex[fragmentBin];
+                    ReadOnlySpan<int> bin = FragmentIndex[fragmentBin];
 
                     //score
-                    if (bin != null)
+                    if (!bin.IsEmpty)
                     {
-                        for (int pep = 0; pep < bin.Count; pep++)
+                        for (int pep = 0; pep < bin.Length; pep++)
                         {
                             scoringTable[bin[pep]]++;
                         }
@@ -206,9 +213,9 @@ namespace EngineLayer.NonSpecificEnzymeSearch
                                     bin = FragmentIndex[fragmentBin];
 
                                     //score
-                                    if (bin != null)
+                                    if (!bin.IsEmpty)
                                     {
-                                        for (int pep = 0; pep < bin.Count; pep++)
+                                        for (int pep = 0; pep < bin.Length; pep++)
                                         {
                                             scoringTable[bin[pep]]++;
                                         }
@@ -255,12 +262,12 @@ namespace EngineLayer.NonSpecificEnzymeSearch
                         // search mass bins within a tolerance
                         for (int fragmentBin = obsFragmentFloorMass; fragmentBin <= obsFragmentCeilingMass; fragmentBin++)
                         {
-                            List<int> bin = FragmentIndex[fragmentBin];
+                            ReadOnlySpan<int> bin = FragmentIndex[fragmentBin];
 
                             //score
-                            if (bin != null)
+                            if (!bin.IsEmpty)
                             {
-                                for (int pep = 0; pep < bin.Count; pep++)
+                                for (int pep = 0; pep < bin.Length; pep++)
                                 {
                                     scoringTable[bin[pep]]++;
                                 }
@@ -296,12 +303,12 @@ namespace EngineLayer.NonSpecificEnzymeSearch
 
                                     for (int fragmentBin = compFragmentFloorMass; fragmentBin <= compFragmentCeilingMass; fragmentBin++)
                                     {
-                                        List<int> bin = FragmentIndex[fragmentBin];
+                                        ReadOnlySpan<int> bin = FragmentIndex[fragmentBin];
 
                                         //score
-                                        if (bin != null)
+                                        if (!bin.IsEmpty)
                                         {
-                                            for (int pep = 0; pep < bin.Count; pep++)
+                                            for (int pep = 0; pep < bin.Length; pep++)
                                             {
                                                 scoringTable[bin[pep]]++;
                                             }

--- a/MetaMorpheus/EngineLayer/Util/DescendingScoreSorter.cs
+++ b/MetaMorpheus/EngineLayer/Util/DescendingScoreSorter.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace EngineLayer.Util
+{
+    /// <summary>
+    /// Orders peptide ids by their coarse (indexed) score, highest first.
+    ///
+    /// The search used to do this with OrderByDescending, once per scan, which allocated a LINQ
+    /// ordering plus a key array every time. Coarse scores are bytes, so a counting sort over 256
+    /// buckets does the same job in two linear passes with no per-scan allocation.
+    ///
+    /// It is stable, deliberately: peptides that tie on the coarse score are handed back in the order
+    /// they were found, which is what OrderByDescending did. Ties decide which peptide ends up as the
+    /// PSM when the fine scores also tie, so an unstable sort here would quietly change results.
+    ///
+    /// One instance per thread -- it reuses its buffers and is not safe to share.
+    /// </summary>
+    public sealed class DescendingScoreSorter
+    {
+        private const int BucketCount = byte.MaxValue + 1;
+
+        private readonly int[] _bucketStarts = new int[BucketCount + 1];
+        private int[] _sorted = new int[64];
+
+        /// <summary>
+        /// Returns <paramref name="peptideIds"/> ordered by descending score in <paramref name="scores"/>,
+        /// ties in their existing order. The span is valid until the next call on this instance.
+        /// </summary>
+        public ReadOnlySpan<int> Sort(List<int> peptideIds, ScanScoringTable scores)
+        {
+            int count = peptideIds.Count;
+            if (count == 0)
+            {
+                return ReadOnlySpan<int>.Empty;
+            }
+
+            if (_sorted.Length < count)
+            {
+                _sorted = new int[Math.Max(count, _sorted.Length * 2)];
+            }
+
+            Array.Clear(_bucketStarts, 0, _bucketStarts.Length);
+
+            // Bucket by inverted score, so bucket 0 holds the highest scores.
+            for (int i = 0; i < count; i++)
+            {
+                _bucketStarts[byte.MaxValue - scores[peptideIds[i]] + 1]++;
+            }
+
+            for (int bucket = 0; bucket < BucketCount; bucket++)
+            {
+                _bucketStarts[bucket + 1] += _bucketStarts[bucket];
+            }
+
+            // Walking the ids in their original order keeps equal scores in that order.
+            for (int i = 0; i < count; i++)
+            {
+                int id = peptideIds[i];
+                _sorted[_bucketStarts[byte.MaxValue - scores[id]]++] = id;
+            }
+
+            return new ReadOnlySpan<int>(_sorted, 0, count);
+        }
+    }
+}

--- a/MetaMorpheus/EngineLayer/Util/ScanScoringTable.cs
+++ b/MetaMorpheus/EngineLayer/Util/ScanScoringTable.cs
@@ -1,0 +1,104 @@
+using System;
+
+namespace EngineLayer.Util
+{
+    /// <summary>
+    /// The coarse (indexed) score of every peptide in the index, for the scan being scored.
+    ///
+    /// The search used to keep this as a byte[] and Array.Clear the whole thing between scans, which
+    /// is O(peptides) of pure bookkeeping per scan whatever the scan actually touched. This can
+    /// instead stamp each cell with the scan it belongs to and treat a stale stamp as a score of
+    /// zero, which makes starting a scan O(1) -- the stamps only need clearing when they wrap, once
+    /// every 255 scans.
+    ///
+    /// Stamping is not always the better trade. A stamped cell is two bytes wide, so a scan that
+    /// touches most of the index pays double the memory traffic on the hot path to avoid a memset it
+    /// was already amortizing. Measured on a synthetic version of the scoring loop, stamping runs
+    /// ~8-13x faster than clearing when a scan touches ~0.1% of the index (a normal ppm-tolerance
+    /// search) and ~0.6-0.8x as fast when it touches most of it (an open search). So the caller
+    /// picks, and open searches keep clearing.
+    ///
+    /// Either way scores are bytes and increments wrap at 255, matching the byte[] this replaced.
+    ///
+    /// One instance per thread -- it is not safe to share.
+    /// </summary>
+    public sealed class ScanScoringTable
+    {
+        // Stamped layout: high byte is the scan stamp, low byte is the score.
+        private readonly ushort[] _stampedCells;
+        private readonly byte[] _scores;
+        private byte _stamp;
+
+        public ScanScoringTable(int peptideCount, bool stamped)
+        {
+            if (stamped)
+            {
+                _stampedCells = new ushort[peptideCount];
+            }
+            else
+            {
+                _scores = new byte[peptideCount];
+            }
+        }
+
+        private bool Stamped => _stampedCells != null;
+
+        /// <summary>Discards the previous scan's scores.</summary>
+        public void BeginScan()
+        {
+            if (!Stamped)
+            {
+                Array.Clear(_scores, 0, _scores.Length);
+                return;
+            }
+
+            if (_stamp == byte.MaxValue)
+            {
+                // Stamps have wrapped; retire every cell so stale ones cannot alias the new stamp.
+                Array.Clear(_stampedCells, 0, _stampedCells.Length);
+                _stamp = 0;
+            }
+
+            _stamp++;
+        }
+
+        public byte this[int peptideId]
+        {
+            get
+            {
+                if (!Stamped)
+                {
+                    return _scores[peptideId];
+                }
+
+                ushort cell = _stampedCells[peptideId];
+                return (cell >> 8) == _stamp ? (byte)cell : (byte)0;
+            }
+        }
+
+        public void Set(int peptideId, byte score)
+        {
+            if (!Stamped)
+            {
+                _scores[peptideId] = score;
+                return;
+            }
+
+            _stampedCells[peptideId] = (ushort)((_stamp << 8) | score);
+        }
+
+        /// <summary>Adds one to a peptide's score and returns it, wrapping at 255 as a byte does.</summary>
+        public byte Increment(int peptideId)
+        {
+            if (!Stamped)
+            {
+                return ++_scores[peptideId];
+            }
+
+            ushort cell = _stampedCells[peptideId];
+            byte score = (cell >> 8) == _stamp ? (byte)((byte)cell + 1) : (byte)1;
+            _stampedCells[peptideId] = (ushort)((_stamp << 8) | score);
+            return score;
+        }
+    }
+}

--- a/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationTask.cs
+++ b/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationTask.cs
@@ -60,7 +60,7 @@ namespace TaskLayer
 
         // Modern Search indexing fields
         private List<PeptideWithSetModifications> _peptideIndex;
-        private List<int>[] _fragmentIndex;
+        private MassBinIndex _fragmentIndex;
 
         protected override MyTaskResults RunSpecific(string outputFolder, List<DbForTask> dbFilenameList, List<string> currentRawFileList, string taskId, FileSpecificParameters[] fileSettingsList)
         {

--- a/MetaMorpheus/TaskLayer/GlycoSearchTask/GlycoSearchTask.cs
+++ b/MetaMorpheus/TaskLayer/GlycoSearchTask/GlycoSearchTask.cs
@@ -123,12 +123,12 @@ namespace TaskLayer
 
                     //Only reverse Decoy for glyco search has been tested and are set as fixed parameter.
                     var indexEngine = new IndexingEngine(proteinListSubset, variableModifications, fixedModifications, null, null, null, currentPartition, _glycoSearchParameters.DecoyType, combinedParams, this.FileSpecificParameters, 30000.0, false, dbFilenameList.Select(p => new FileInfo(p.FilePath)).ToList(), TargetContaminantAmbiguity.RemoveContaminant, new List<string> { taskId });
-                    List<int>[] fragmentIndex = null;
-                    List<int>[] precursorIndex = null;
+                    MassBinIndex fragmentIndex = null;
+                    MassBinIndex precursorIndex = null;
                     GenerateIndexes(indexEngine, dbFilenameList, ref peptideIndex, ref fragmentIndex, ref precursorIndex, proteinList, taskId);
 
                     //The second Fragment index is for 'MS1-HCD_MS1-ETD_MS2s' type of data. If LowCID is used for MS1, ion-index is not allowed to use.
-                    List<int>[] secondFragmentIndex = null;
+                    MassBinIndex secondFragmentIndex = null;
 
                     Status("Searching files...", taskId);
                     new GlycoSearchEngine(newCsmsPerMS2ScanPerFile, arrayOfMs2ScansSortedByMass, peptideIndex, fragmentIndex, secondFragmentIndex, currentPartition, combinedParams, this.FileSpecificParameters,

--- a/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
+++ b/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
@@ -1,4 +1,4 @@
-using Chemistry;
+﻿using Chemistry;
 using EngineLayer;
 using EngineLayer.Indexing;
 using MassSpectrometry;
@@ -1304,26 +1304,16 @@ namespace TaskLayer
             return digestionParams;
         }
 
-        private static void WriteFragmentIndex(List<int>[] fragmentIndex, string fragmentIndexFileName)
+        private static void WriteFragmentIndex(MassBinIndex fragmentIndex, string fragmentIndexFileName)
         {
-            var messageTypes = GetSubclassesAndItself(typeof(List<int>[]));
-            var ser = new NetSerializer.Serializer(messageTypes);
-
-            using (var file = File.Create(fragmentIndexFileName))
-            {
-                ser.Serialize(file, fragmentIndex);
-            }
+            // Written as two flat int arrays rather than through NetSerializer: the index holds up to
+            // hundreds of millions of ints, and the per-element serializer overhead dominated the write.
+            fragmentIndex.Write(fragmentIndexFileName);
         }
 
-        private static List<int>[] ReadFragmentIndex(string fragmentIndexFileName)
+        private static MassBinIndex ReadFragmentIndex(string fragmentIndexFileName)
         {
-            var messageTypes = GetSubclassesAndItself(typeof(List<int>[]));
-            var ser = new NetSerializer.Serializer(messageTypes);
-
-            using (var file = File.OpenRead(fragmentIndexFileName))
-            {
-                return (List<int>[])ser.Deserialize(file);
-            }
+            return MassBinIndex.Read(fragmentIndexFileName);
         }
 
         private static string GetExistingFolderWithIndices(IndexingEngine indexEngine, List<DbForTask> dbFilenameList)
@@ -1391,7 +1381,7 @@ namespace TaskLayer
             return folder;
         }
 
-        public void GenerateIndexes(IndexingEngine indexEngine, List<DbForTask> dbFilenameList, ref List<PeptideWithSetModifications> peptideIndex, ref List<int>[] fragmentIndex, ref List<int>[] precursorIndex, List<Protein> allKnownProteins, string taskId)
+        public void GenerateIndexes(IndexingEngine indexEngine, List<DbForTask> dbFilenameList, ref List<PeptideWithSetModifications> peptideIndex, ref MassBinIndex fragmentIndex, ref MassBinIndex precursorIndex, List<Protein> allKnownProteins, string taskId)
         {
             bool successfullyReadIndices = false;
             string pathToFolderWithIndices = GetExistingFolderWithIndices(indexEngine, dbFilenameList);
@@ -1460,7 +1450,7 @@ namespace TaskLayer
             }
         }
 
-        public void GenerateIndexes_PeptideOnly(IndexingEngine indexEngine, List<DbForTask> dbFilenameList, ref List<PeptideWithSetModifications> peptideIndex, ref List<int>[] precursorIndex, List<Protein> allKnownProteins, string taskId)
+        public void GenerateIndexes_PeptideOnly(IndexingEngine indexEngine, List<DbForTask> dbFilenameList, ref List<PeptideWithSetModifications> peptideIndex, ref MassBinIndex precursorIndex, List<Protein> allKnownProteins, string taskId)
         {
             bool successfullyReadIndices = false;
             string pathToFolderWithIndices = GetExistingFolderWithIndices(indexEngine, dbFilenameList);
@@ -1497,7 +1487,7 @@ namespace TaskLayer
             }
         }
 
-        public void GenerateSecondIndexes(IndexingEngine indexEngine, IndexingEngine secondIndexEngine, List<DbForTask> dbFilenameList, ref List<int>[] secondFragmentIndex, List<Protein> allKnownProteins, string taskId)
+        public void GenerateSecondIndexes(IndexingEngine indexEngine, IndexingEngine secondIndexEngine, List<DbForTask> dbFilenameList, ref MassBinIndex secondFragmentIndex, List<Protein> allKnownProteins, string taskId)
         {
             string pathToFolderWithIndices = GetExistingFolderWithIndices(indexEngine, dbFilenameList);
             if (!File.Exists(Path.Combine(pathToFolderWithIndices, SecondFragmentIndexFileName))) //if no indexes exist

--- a/MetaMorpheus/TaskLayer/SearchTask/SearchTask.cs
+++ b/MetaMorpheus/TaskLayer/SearchTask/SearchTask.cs
@@ -390,8 +390,8 @@ namespace TaskLayer
                         var indexEngine = new IndexingEngine(proteinListSubset, variableModifications, fixedModifications, SearchParameters.SilacLabels,
                             SearchParameters.StartTurnoverLabel, SearchParameters.EndTurnoverLabel, currentPartition, SearchParameters.DecoyType, combinedParams, FileSpecificParameters,
                             SearchParameters.MaxFragmentSize, false, dbFilenameList.Select(p => new FileInfo(p.FilePath)).ToList(), SearchParameters.TCAmbiguity, new List<string> { taskId });
-                        List<int>[] fragmentIndex = null;
-                        List<int>[] precursorIndex = null;
+                        MassBinIndex fragmentIndex = null;
+                        MassBinIndex precursorIndex = null;
 
                         lock (indexLock)
                         {
@@ -463,8 +463,8 @@ namespace TaskLayer
                                 ((currentPartition + 1) * proteinList.Count / paramToUse.TotalPartitions) - (currentPartition * proteinList.Count / paramToUse.TotalPartitions))
                                 .ToList(); // assume that only proteins are used in non-specific search
 
-                            List<int>[] fragmentIndex = null;
-                            List<int>[] precursorIndex = null;
+                            MassBinIndex fragmentIndex = null;
+                            MassBinIndex precursorIndex = null;
 
                             Status("Getting fragment dictionary...", new List<string> { taskId });
                             var indexEngine = new IndexingEngine(proteinListSubset, variableModifications, fixedModifications, SearchParameters.SilacLabels,

--- a/MetaMorpheus/TaskLayer/XLSearchTask/XLSearchTask.cs
+++ b/MetaMorpheus/TaskLayer/XLSearchTask/XLSearchTask.cs
@@ -126,12 +126,12 @@ namespace TaskLayer
                         UsefulProteomicsDatabases.DecoyType.Reverse, combinedParams, this.FileSpecificParameters, 30000.0, false,
                         dbFilenameList.Select(p => new FileInfo(p.FilePath)).ToList(), TargetContaminantAmbiguity.RemoveContaminant, new List<string> { taskId });
 
-                    List<int>[] fragmentIndex = null;
-                    List<int>[] precursorIndex = null;
+                    MassBinIndex fragmentIndex = null;
+                    MassBinIndex precursorIndex = null;
                     GenerateIndexes(indexEngine, dbFilenameList, ref peptideIndex, ref fragmentIndex, ref precursorIndex, proteinList, taskId);
 
                     //The second Fragment index is for 'MS1-HCD_MS1-ETD_MS2s' type of data. If LowCID is used for MS1, ion-index is not allowed to use.
-                    List<int>[] secondFragmentIndex = null;
+                    MassBinIndex secondFragmentIndex = null;
                     if (combinedParams.MS2ChildScanDissociationType != DissociationType.LowCID && combinedParams.MS2ChildScanDissociationType!= DissociationType.Unknown
                     && !CrosslinkSearchEngine.DissociationTypeGenerateSameTypeOfIons(combinedParams.DissociationType, combinedParams.MS2ChildScanDissociationType))
                     {
@@ -167,7 +167,7 @@ namespace TaskLayer
                         UsefulProteomicsDatabases.DecoyType.Reverse, combinedParams, this.FileSpecificParameters, 30000.0, false,
                         dbFilenameList.Select(p => new FileInfo(p.FilePath)).ToList(), TargetContaminantAmbiguity.RemoveContaminant, new List<string> { taskId });
 
-                    List<int>[] precursorIndex_a = null;
+                    MassBinIndex precursorIndex_a = null;
                     GenerateIndexes_PeptideOnly(indexEngine_a, dbFilenameList, ref peptideIndex_a, ref precursorIndex_a, proteinList, taskId);
 
                     for (int nextPartition = 0; nextPartition < CommonParameters.TotalPartitions; nextPartition++)
@@ -188,7 +188,7 @@ namespace TaskLayer
                                 UsefulProteomicsDatabases.DecoyType.Reverse, combinedParams, this.FileSpecificParameters, 30000.0, false,
                                 dbFilenameList.Select(p => new FileInfo(p.FilePath)).ToList(), TargetContaminantAmbiguity.RemoveContaminant, new List<string> { taskId });
 
-                            List<int>[] precursorIndex_b = null;
+                            MassBinIndex precursorIndex_b = null;
                             GenerateIndexes_PeptideOnly(indexEngine_b, dbFilenameList, ref peptideIndex_b, ref precursorIndex_b, proteinList, taskId);
 
                         }

--- a/MetaMorpheus/Test/IndexEngineTest.cs
+++ b/MetaMorpheus/Test/IndexEngineTest.cs
@@ -76,6 +76,58 @@ namespace Test
         }
 
         /// <summary>
+        /// The index cache round-trips exactly, and a file this version did not write is rejected
+        /// rather than misread -- MetaMorpheusTask catches that and rebuilds the index.
+        /// </summary>
+        [Test]
+        public static void TestIndexRoundTripsThroughDisk()
+        {
+            var proteinList = new List<Protein>
+            {
+                new Protein("MNNNKQQQMNNNKQQQPEPTIDEKMSSSRTTTKAAAWWWKGGGYYYK", "prot1"),
+                new Protein("MSDKIIHLTDDSFDTDVLKADGAILVDFWAEWCGPCKMIAPILDEIADEYQGKLTVAK", "prot2"),
+            };
+
+            var engine = new IndexingEngine(proteinList, new List<Modification>(), new List<Modification>(), null, null, null, 0,
+                DecoyType.Reverse, new CommonParameters(), null, 30000, false, new List<FileInfo>(),
+                TargetContaminantAmbiguity.RemoveContaminant, new List<string>());
+
+            var written = ((IndexingResults)engine.Run()).FragmentIndex;
+
+            string path = Path.Combine(TestContext.CurrentContext.TestDirectory, "roundTripFragmentIndex.ind");
+            try
+            {
+                written.Write(path);
+                var read = MassBinIndex.Read(path);
+
+                Assert.That(read.Length, Is.EqualTo(written.Length));
+                Assert.That(read.EntryCount, Is.EqualTo(written.EntryCount));
+                Assert.That(read.EntryCount, Is.GreaterThan(0), "index came out empty; the test proves nothing");
+
+                for (int bin = 0; bin < written.Length; bin++)
+                {
+                    if (written.CountInBin(bin) == 0 && read.CountInBin(bin) == 0)
+                    {
+                        continue;
+                    }
+
+                    Assert.That(read[bin].ToArray(), Is.EqualTo(written[bin].ToArray()), $"bin {bin} differs after a round trip");
+                }
+
+                // A file from some other version, or from before this format existed.
+                File.WriteAllBytes(path, new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12 });
+                Assert.That(() => MassBinIndex.Read(path), Throws.InstanceOf<InvalidDataException>());
+            }
+            finally
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+        }
+
+        /// <summary>
         /// Peptide ids ascend within every bin. BinarySearchBinForPrecursorIndex depends on it.
         /// </summary>
         [Test]

--- a/MetaMorpheus/Test/IndexEngineTest.cs
+++ b/MetaMorpheus/Test/IndexEngineTest.cs
@@ -18,6 +18,98 @@ namespace Test
     [TestFixture]
     public static class IndexEngineTest
     {
+        /// <summary>
+        /// The fragment index is built in parallel over contiguous blocks of peptide ids, and the number
+        /// of blocks follows MaxThreadsToUsePerFile. The index that comes out has to be byte-for-byte the
+        /// same regardless -- peptide ids must stay ascending within a bin, because the search binary
+        /// searches a bin by peptide mass and that only holds while ids ascend.
+        /// </summary>
+        [Test]
+        public static void TestIndexIsIdenticalRegardlessOfThreadCount()
+        {
+            var proteinList = new List<Protein>
+            {
+                new Protein("MNNNKQQQMNNNKQQQPEPTIDEKMSSSRTTTKAAAWWWKGGGYYYK", "prot1"),
+                new Protein("MKVLINGYGTIGKRVADAVSQQDDMKVIGVSKTRPDFEARMALQKGYDLYVAIPK", "prot2"),
+                new Protein("MSDKIIHLTDDSFDTDVLKADGAILVDFWAEWCGPCKMIAPILDEIADEYQGKLTVAK", "prot3"),
+            };
+
+            var fixedModifications = new List<Modification>();
+            var variableModifications = new List<Modification>();
+
+            MassBinIndex referenceFragmentIndex = null;
+            List<PeptideWithSetModifications> referencePeptideIndex = null;
+
+            foreach (int threadCount in new[] { 1, 2, 3, 8 })
+            {
+                var commonParameters = new CommonParameters(maxThreadsToUsePerFile: threadCount);
+
+                var engine = new IndexingEngine(proteinList, variableModifications, fixedModifications, null, null, null, 0,
+                    DecoyType.Reverse, commonParameters, null, 30000, false, new List<FileInfo>(),
+                    TargetContaminantAmbiguity.RemoveContaminant, new List<string>());
+
+                var results = (IndexingResults)engine.Run();
+
+                if (referenceFragmentIndex == null)
+                {
+                    referenceFragmentIndex = results.FragmentIndex;
+                    referencePeptideIndex = results.PeptideIndex;
+                    Assert.That(referenceFragmentIndex.EntryCount, Is.GreaterThan(0), "index came out empty; the test proves nothing");
+                    continue;
+                }
+
+                Assert.That(results.PeptideIndex.Count, Is.EqualTo(referencePeptideIndex.Count), $"peptide count differs at {threadCount} threads");
+                Assert.That(results.FragmentIndex.Length, Is.EqualTo(referenceFragmentIndex.Length), $"bin count differs at {threadCount} threads");
+                Assert.That(results.FragmentIndex.EntryCount, Is.EqualTo(referenceFragmentIndex.EntryCount), $"entry count differs at {threadCount} threads");
+
+                for (int bin = 0; bin < referenceFragmentIndex.Length; bin++)
+                {
+                    if (referenceFragmentIndex.CountInBin(bin) == 0 && results.FragmentIndex.CountInBin(bin) == 0)
+                    {
+                        continue;
+                    }
+
+                    Assert.That(results.FragmentIndex[bin].ToArray(), Is.EqualTo(referenceFragmentIndex[bin].ToArray()),
+                        $"bin {bin} differs at {threadCount} threads");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Peptide ids ascend within every bin. BinarySearchBinForPrecursorIndex depends on it.
+        /// </summary>
+        [Test]
+        public static void TestFragmentIndexBinsAreSortedByPeptideId()
+        {
+            var proteinList = new List<Protein>
+            {
+                new Protein("MNNNKQQQMNNNKQQQPEPTIDEKMSSSRTTTKAAAWWWKGGGYYYK", "prot1"),
+                new Protein("MSDKIIHLTDDSFDTDVLKADGAILVDFWAEWCGPCKMIAPILDEIADEYQGKLTVAK", "prot2"),
+            };
+
+            var engine = new IndexingEngine(proteinList, new List<Modification>(), new List<Modification>(), null, null, null, 0,
+                DecoyType.Reverse, new CommonParameters(), null, 30000, false, new List<FileInfo>(),
+                TargetContaminantAmbiguity.RemoveContaminant, new List<string>());
+
+            var results = (IndexingResults)engine.Run();
+
+            int binsChecked = 0;
+            for (int bin = 0; bin < results.FragmentIndex.Length; bin++)
+            {
+                ReadOnlySpan<int> ids = results.FragmentIndex[bin];
+                for (int i = 1; i < ids.Length; i++)
+                {
+                    Assert.That(ids[i], Is.GreaterThan(ids[i - 1]), $"bin {bin} is not ascending");
+                }
+                if (ids.Length > 1)
+                {
+                    binsChecked++;
+                }
+            }
+
+            Assert.That(binsChecked, Is.GreaterThan(0), "no multi-entry bins; the test proves nothing");
+        }
+
         [Test]
         public static void TestIndexEngine()
         {

--- a/MetaMorpheus/Test/IndexEngineTest.cs
+++ b/MetaMorpheus/Test/IndexEngineTest.cs
@@ -75,7 +75,7 @@ namespace Test
 
                     // look up the peptides that have fragments with this mass
                     // the result of the lookup is a list of peptide IDs that have this fragment mass
-                    List<int> fragmentBin = results.FragmentIndex[integerMassRepresentation];
+                    ReadOnlySpan<int> fragmentBin = results.FragmentIndex[integerMassRepresentation];
 
                     // this list should contain this peptide!
                     Assert.That(fragmentBin.Contains(positionInPeptideIndex));
@@ -191,7 +191,7 @@ namespace Test
 
                     // look up the peptides that have fragments with this mass
                     // the result of the lookup is a list of peptide IDs that have this fragment mass
-                    List<int> fragmentBin = results.FragmentIndex[integerMassRepresentation];
+                    ReadOnlySpan<int> fragmentBin = results.FragmentIndex[integerMassRepresentation];
 
                     // this list should contain this peptide!
                     Assert.That(fragmentBin.Contains(positionInPeptideIndex));

--- a/MetaMorpheus/Test/SearchEngineTests.cs
+++ b/MetaMorpheus/Test/SearchEngineTests.cs
@@ -577,7 +577,7 @@ namespace Test
             List<int> filledIndices = new List<int>();
             for (int i = 0; i < indexResults.FragmentIndex.Length; i++)
             {
-                if (indexResults.FragmentIndex[i] != null)
+                if (indexResults.FragmentIndex.CountInBin(i) > 0)
                 {
                     filledIndices.Add(i);
                 }

--- a/MetaMorpheus/Test/XLTest.cs
+++ b/MetaMorpheus/Test/XLTest.cs
@@ -1,4 +1,4 @@
-using Chemistry;
+﻿using Chemistry;
 using EngineLayer;
 using EngineLayer.CrosslinkSearch;
 using EngineLayer.FdrAnalysis;
@@ -177,8 +177,7 @@ namespace Test
 
             var indexResults = (IndexingResults)indexEngine.Run();
 
-            var indexedFragments = indexResults.FragmentIndex.Where(p => p != null).SelectMany(v => v).ToList();
-            Assert.That(indexedFragments.Count, Is.EqualTo(82));
+            Assert.That(indexResults.FragmentIndex.EntryCount, Is.EqualTo(82));
             Assert.That(indexResults.PeptideIndex.Count, Is.EqualTo(3));
 
             //Get MS2 scans.
@@ -926,7 +925,7 @@ namespace Test
         {
             var commonParameters = new CommonParameters(digestionParams: new RnaDigestionParams());
 
-            Assert.That(() => new CrosslinkSearchEngine([], [], [], [], [], 1, commonParameters, [], new Crosslinker(), 1, false, false, false, false, [], [], 1, [], []),
+            Assert.That(() => new CrosslinkSearchEngine([], [], [], null, null, 1, commonParameters, [], new Crosslinker(), 1, false, false, false, false, [], [], 1, [], []),
                 Throws.TypeOf<ArgumentException>()
                     .With.Message.Contain("Cross-link search engine does not currently support digestion of type"));
         }


### PR DESCRIPTION
Rewrites the fragment/precursor index as flat arrays, fragments peptides in parallel while building it, and takes two allocations out of the per-scan scoring loop.

Results are unchanged: **1833 tests pass, 0 fail**. The full suite was run after each commit, not just at the end.

## Why

The fragment index was a `List<int>[]` with one bin per 0.001 Da. At the default 30000 Da ceiling that is 30,000,001 bins, so the reference array alone cost 240 MB before a single peptide id was stored, and every occupied bin added a `List` object plus its own doubling `int[]`. Millions of small objects for the GC to trace, and a pointer chase on every bin lookup in the search inner loop. It is also what the `OutOfMemoryException` handler telling users to fall back to Classic Search was apologizing for.

Separately, the fragment/bin pass ran single-threaded even though the digestion immediately above it was already parallel.

## Measured

Index build only, on a 64-core machine, comparing the old layout against the new one from the same sorted peptide list.

| workload | entries | occupied bins | entries/bin | old to new (1 thread) | new (64 threads) | index heap |
|---|---|---|---|---|---|---|
| human, **top-down** ETD | 48.9M | 18.0M (60.1%) | **2.7** | 14.0 s to 5.4 s | **2.1 s** (6.68x) | 1527 to **301 MB** (5.08x) |
| yeast, bottom-up | 243.7M | n/a | n/a | 43.3 s to 14.6 s | **7.3 s** (5.91x) | 1912 to 1044 MB (1.83x) |
| human, bottom-up | 316.2M | 7.1M (23.8%) | 44 | 46.3 s to 17.6 s | **9.0 s** (5.16x) | 2355 to 1321 MB (1.78x) |
| human XML + 2 var mods, one of 4 partitions | 1.08B | 7.2M (24.0%) | 150 | 100.1 s to 58.6 s | **31.2 s** (3.21x) | 6532 to 4236 MB (1.54x) |

Entry counts identical in every run. Databases: `uniprot-yeast-filtered-reviewed_yes.fasta.gz` and UniProt human (53,722 and 104,303 proteins with decoys).

**The win tracks bin sparsity, not database size.** When bins hold ~150 entries a `List` amortizes its header over 150 ints and the old layout is merely wasteful. When bins hold 2.7 entries it spends more on object headers than on data. Top-down spreads proteoform fragments across 60% of the mass range at 2.7 entries per bin, which is why memory drops 5x there and 1.8x for tryptic peptides -- the change helps most exactly where the index scales worst.

Worth noting `Test/TopDownTestData/TopDownSearchToml.toml` sets `SearchType = "Classic"`, so top-down does not build a fragment index at all today. A 1.5 GB index for a 107k-proteoform search is a plausible reason Modern was never the default there; 301 MB may change that calculus.

This is a win on index construction and memory, not a 5x faster search end to end -- how much it shows up depends on what share of a run goes into indexing, which varies with file count and index-cache reuse.

## What had to be preserved

Three invariants govern this change, and each has a test:

- **Peptide ids ascend within a bin.** `BinarySearchBinForPrecursorIndex` searches a bin *by peptide mass*, which only works because peptides are mass-sorted, so id order is mass order. The build records emissions in peptide order and counting-sorts them stably.
- **The parallel build must equal the sequential one.** Blocks are contiguous and their emissions concatenated in block order, so the index does not depend on thread count. `TestIndexIsIdenticalRegardlessOfThreadCount` builds the same database at 1, 2, 3 and 8 threads and compares every bin.
- **`OrderByDescending` is a stable sort.** Ties decide which peptide becomes the PSM, so the counting sort replacing it is stable on purpose. An unstable sort would have changed results silently.

The precursor index keeps its two waves -- base masses, then interior terminal mods -- in that order, because it is iterated rather than searched, so its within-bin order also feeds tie-breaks.

## Known regression: a 2.1B entry ceiling

Holding every entry in one `int[]` caps an index at `int.MaxValue` entries. `List<int>[]` had no such cap -- each bin carried its own list, so only free memory set the limit.

The cap is reachable, not theoretical. Human UniProt XML with oxidation and acetylation as variable mods, unpartitioned:

| | result |
|---|---|
| old `List<int>[]` | succeeds: 367.6 s, **22.6 GB** heap, 3,948,838,078 entries |
| new CSR | refused |

So on a large-memory machine there is a class of search the old code built and this one will not.

Mitigating it: partitioning is how MetaMorpheus already bounds index size, and the same database at 4 partitions builds fine at 1.08B entries each. **Partitioned new code beats unpartitioned old code on both axes** -- 4 x 31.2 s = 125 s of index building against 367.6 s, and 4.2 GB peak against 22.6 GB. The workaround is faster and lighter than the behaviour it replaces.

`Build` therefore throws a `MetaMorpheusException` naming the entry count, the limit, and the partition multiplier required:

> This database needs 3,948,838,078 fragment index entries, more than the 2,147,483,647 a single index can hold. Multiply the number of database partitions by at least 2, or reduce the maximum fragment mass, the number of variable modifications, or the missed cleavages. Classic Search does not build a fragment index at all and has no such limit.

Lifting the cap would mean segmenting the entry array on bin boundaries so no bin straddles a segment, at the cost of an extra indirection on every bin lookup. Left as a follow-up.

## Scoring loop

`Array.Clear` over the whole peptide index between scans is O(peptides) of bookkeeping per scan whatever the scan touched. `ScanScoringTable` instead stamps each cell with the scan it belongs to and reads a stale stamp as zero, making scan setup O(1) apart from a clear every 255 scans.

That is **not** unconditionally better, so it is selected rather than assumed. A stamped cell is two bytes wide, so a scan touching most of the index pays double the memory traffic to skip a memset it was already amortizing. On a synthetic version of the loop:

| touched fraction | stamping vs clearing |
|---|---|
| 0.1% (normal ppm tolerance) | 8-13x faster |
| 1% | 1.8x faster |
| 10% | 0.8x -- slower |
| 100% (open search) | 0.6x -- slower |

Open searches therefore keep clearing. Crosslink and glyco search in `OpenSearchMode` and are behaviorally untouched.

`OrderByDescending` on the coarse scores ran once per scan in three engines, allocating a LINQ ordering and a key array each time. Coarse scores are bytes, so `DescendingScoreSorter` counting-sorts them in two linear passes with no per-scan allocation.

## Index cache format

The cache is now two flat arrays instead of NetSerializer over millions of `List` objects. Writing the offset table verbatim would have cost 4 bytes per bin regardless of density -- 114 MB for a small database where the old format wrote ~36 MB -- so only occupied bins are stored, as a varint gap plus a varint count. That same small database now writes well under a megabyte.

Reads validate magic, version, bin ids and that counts add up, so a truncated or foreign file raises `InvalidDataException`. `MetaMorpheusTask` already treats a throw there as "rebuild the index", so **existing cached indexes are regenerated on first run** rather than misread.

## Other limits

- `MassBinIndex.Build` is now the bottleneck in index construction -- count and scatter are sequential, roughly 7 s of the 7.3 s parallel yeast stage, and the reason the parallel speedup fades as bins get denser. Parallelizing the scatter needs per-block-per-bin offsets, a ~2 GB table at 16 threads, so it is not a straightforward follow-up.
- Small databases build ~70 ms slower, because the offset table is sized by bin count (30M) rather than entry count, so it pays a fixed prefix sum the old layout did not. Irrelevant against a real search.

## Scope

MetaMorpheus only -- no mzLib change, no version bump, no repackaging. mzLib carries the same array-of-lists shape in `MassSpectrometry/PeakIndexing/IndexingEngine.cs`, but at ~200k bins rather than 30M and with reference-typed payloads, so the same treatment would return far less there; the real win in that one would be struct peaks, which is a public-API change and a separate discussion.
