### PR TITLE
Let modern search index nucleic acids (RNA/oligos)

### DIFF
--- a/MetaMorpheus/EngineLayer/CrosslinkSearch/CrosslinkSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/CrosslinkSearch/CrosslinkSearchEngine.cs
@@ -1,6 +1,7 @@
 ﻿using EngineLayer.ModernSearch;
 using MassSpectrometry;
 using MzLibUtil;
+using Omics;
 using Omics.Fragmentation;
 using Proteomics.ProteolyticDigestion;
 using System;
@@ -38,14 +39,22 @@ namespace EngineLayer.CrosslinkSearch
         private readonly double[] PrecursorMassTable;
         private readonly double[] NextPrecursorMassTable;
 
-        public CrosslinkSearchEngine(List<CrosslinkSpectralMatch>[] globalCsms, Ms2ScanWithSpecificMass[] listOfSortedms2Scans, List<PeptideWithSetModifications> peptideIndex,
+        /// <summary>
+        /// Cross-link search is proteomics-only (it already refuses non-protein digestion below), so it
+        /// keeps a peptide-typed view of the index that ModernSearchEngine now holds as
+        /// IBioPolymerWithSetMods. Same objects, narrower type.
+        /// </summary>
+        protected new readonly List<PeptideWithSetModifications> PeptideIndex;
+
+        public CrosslinkSearchEngine(List<CrosslinkSpectralMatch>[] globalCsms, Ms2ScanWithSpecificMass[] listOfSortedms2Scans, IEnumerable<IBioPolymerWithSetMods> peptideIndex,
             List<int>[] fragmentIndex, List<int>[] secondFragmentIndex, int currentPartition, CommonParameters commonParameters, 
             List<(string fileName, CommonParameters fileSpecificParameters)> fileSpecificParameters,
             Crosslinker crosslinker, int CrosslinkSearchTopNum, bool CleaveAtCrosslinkSite, bool quench_H2O, bool quench_NH2, bool quench_Tris, List<string> nestedIds, 
             List<(int, int, int)>[] candidates, int nextPartition, 
-            List<PeptideWithSetModifications> nextPeptideIndex, List<List<(double, int, double)>> precursorss)
+            IEnumerable<IBioPolymerWithSetMods> nextPeptideIndex, List<List<(double, int, double)>> precursorss)
             : base(null, listOfSortedms2Scans, peptideIndex, fragmentIndex, currentPartition, commonParameters, fileSpecificParameters, new OpenSearchMode(), 0, nestedIds)
         {
+            PeptideIndex = peptideIndex.Cast<PeptideWithSetModifications>().ToList();
             // We are going to make the assumption that the XL search engine is only ran with proteins. If implemented for other BioPolymers in the future, this should be revised. 
             if (commonParameters.DigestionParams is not DigestionParams)
                 throw new ArgumentException($"Cross-link search engine does not currently support digestion of type {commonParameters.DigestionParams.GetType().FullName}.");
@@ -60,18 +69,18 @@ namespace EngineLayer.CrosslinkSearch
 
             this.Candidates = candidates;
             this.NextPartition = nextPartition + 1;
-            this.NextPeptideIndex = nextPeptideIndex;
+            this.NextPeptideIndex = nextPeptideIndex?.Cast<PeptideWithSetModifications>().ToList();
 
             Precursorss = precursorss;
 
-            PrecursorMassTable = peptideIndex.Select(p => p.MonoisotopicMass).ToArray();
+            PrecursorMassTable = PeptideIndex.Select(p => p.MonoisotopicMass).ToArray();
             if (currentPartition == nextPartition || nextPartition == -1)
             {
                 NextPrecursorMassTable = PrecursorMassTable;
             }
             else
             {
-                NextPrecursorMassTable = nextPeptideIndex.Select(p => p.MonoisotopicMass).ToArray();
+                NextPrecursorMassTable = NextPeptideIndex.Select(p => p.MonoisotopicMass).ToArray();
             }
 
             SecondFragmentIndex = secondFragmentIndex;
@@ -141,7 +150,7 @@ namespace EngineLayer.CrosslinkSearch
                     var high_bound_limitation = scan.PrecursorMass + 5;
 
                     // first-pass scoring
-                    IndexedScoring(FragmentIndex, allBinsToSearch, scoringTable, byteScoreCutoff, idsOfPeptidesPossiblyObserved, scan.PrecursorMass, Double.NegativeInfinity, high_bound_limitation, PeptideIndex, MassDiffAcceptor, 0, CommonParameters.DissociationType);
+                    IndexedScoring(FragmentIndex, allBinsToSearch, scoringTable, byteScoreCutoff, idsOfPeptidesPossiblyObserved, scan.PrecursorMass, Double.NegativeInfinity, high_bound_limitation, base.PeptideIndex, MassDiffAcceptor, 0, CommonParameters.DissociationType);
 
                     //child scan first - pass scoring
                     if (scan.ChildScans != null && CommonParameters.MS2ChildScanDissociationType != DissociationType.Unknown && CommonParameters.MS2ChildScanDissociationType != DissociationType.LowCID)
@@ -157,7 +166,7 @@ namespace EngineLayer.CrosslinkSearch
                             childBinsToSearch.AddRange(x);
                         }
 
-                        IndexedScoring(SecondFragmentIndex, childBinsToSearch, secondScoringTable, byteScoreCutoff, childIdsOfPeptidesPossiblyObserved, scan.PrecursorMass, Double.NegativeInfinity, high_bound_limitation, PeptideIndex, MassDiffAcceptor, 0, CommonParameters.MS2ChildScanDissociationType);
+                        IndexedScoring(SecondFragmentIndex, childBinsToSearch, secondScoringTable, byteScoreCutoff, childIdsOfPeptidesPossiblyObserved, scan.PrecursorMass, Double.NegativeInfinity, high_bound_limitation, base.PeptideIndex, MassDiffAcceptor, 0, CommonParameters.MS2ChildScanDissociationType);
 
                         foreach (var childId in childIdsOfPeptidesPossiblyObserved)
                         {

--- a/MetaMorpheus/EngineLayer/GlycoSearch/GlycoSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/GlycoSearchEngine.cs
@@ -1,5 +1,6 @@
 ﻿using EngineLayer.ModernSearch;
 using MzLibUtil;
+using Omics;
 using Omics.Fragmentation;
 using Proteomics.ProteolyticDigestion;
 using System;
@@ -30,6 +31,12 @@ namespace EngineLayer.GlycoSearch
 
         private readonly List<int>[] SecondFragmentIndex;
 
+        /// <summary>
+        /// Glyco search is proteomics-only, so it keeps a peptide-typed view of the index that
+        /// ModernSearchEngine now holds as IBioPolymerWithSetMods. Same objects, narrower type.
+        /// </summary>
+        protected new readonly List<PeptideWithSetModifications> PeptideIndex;
+
         protected string[] Motifs
         {
             get
@@ -43,11 +50,12 @@ namespace EngineLayer.GlycoSearch
         }
 
         // The constructor for GlycoSearchEngine, we can load the parameter for the searhcing like mode, topN, maxOGlycanNum, oxoniumIonFilter, datsbase, etc.
-        public GlycoSearchEngine(List<GlycoSpectralMatch>[] globalCsms, Ms2ScanWithSpecificMass[] listOfSortedms2Scans, List<PeptideWithSetModifications> peptideIndex,
+        public GlycoSearchEngine(List<GlycoSpectralMatch>[] globalCsms, Ms2ScanWithSpecificMass[] listOfSortedms2Scans, IEnumerable<IBioPolymerWithSetMods> peptideIndex,
             List<int>[] fragmentIndex, List<int>[] secondFragmentIndex, int currentPartition, CommonParameters commonParameters, List<(string fileName, CommonParameters fileSpecificParameters)> fileSpecificParameters,
              string oglycanDatabase, string nglycanDatabase, GlycoSearchType glycoSearchType, int glycoSearchTopNum, int maxOGlycanNum, bool oxoniumIonFilter, List<string> nestedIds)
             : base(null, listOfSortedms2Scans, peptideIndex, fragmentIndex, currentPartition, commonParameters, fileSpecificParameters, new OpenSearchMode(), 0, nestedIds)
         {
+            this.PeptideIndex = peptideIndex.Cast<PeptideWithSetModifications>().ToList();
             this.GlobalGsms = globalCsms;
             this.GlycoSearchType = glycoSearchType;
             this.TopN = glycoSearchTopNum;
@@ -149,7 +157,7 @@ namespace EngineLayer.GlycoSearch
                     var high_bound_limitation = scan.PrecursorMass + 1;
 
                     // first-pass scoring
-                    IndexedScoring(FragmentIndex, allBinsToSearch, scoringTable, byteScoreCutoff, idsOfPeptidesPossiblyObserved, scan.PrecursorMass, Double.NegativeInfinity, high_bound_limitation, PeptideIndex, MassDiffAcceptor, 0, CommonParameters.DissociationType);
+                    IndexedScoring(FragmentIndex, allBinsToSearch, scoringTable, byteScoreCutoff, idsOfPeptidesPossiblyObserved, scan.PrecursorMass, Double.NegativeInfinity, high_bound_limitation, base.PeptideIndex, MassDiffAcceptor, 0, CommonParameters.DissociationType);
 
                     //child scan first-pass scoring
                     //List<int> childBinsToSearch = null;
@@ -166,7 +174,7 @@ namespace EngineLayer.GlycoSearch
                     //        childBinsToSearch.AddRange(x);
                     //    }
 
-                    //    IndexedScoring(SecondFragmentIndex, childBinsToSearch, secondScoringTable, byteScoreCutoff, childIdsOfPeptidesPossiblyObserved, scan.PrecursorMass, Double.NegativeInfinity, high_bound_limitation, PeptideIndex, MassDiffAcceptor, 0, CommonParameters.MS2ChildScanDissociationType);
+                    //    IndexedScoring(SecondFragmentIndex, childBinsToSearch, secondScoringTable, byteScoreCutoff, childIdsOfPeptidesPossiblyObserved, scan.PrecursorMass, Double.NegativeInfinity, high_bound_limitation, base.PeptideIndex, MassDiffAcceptor, 0, CommonParameters.MS2ChildScanDissociationType);
 
                     //    foreach (var childId in childIdsOfPeptidesPossiblyObserved)
                     //    {
@@ -794,3 +802,4 @@ namespace EngineLayer.GlycoSearch
 
     }
 }
+

--- a/MetaMorpheus/EngineLayer/Indexing/IndexingEngine.cs
+++ b/MetaMorpheus/EngineLayer/Indexing/IndexingEngine.cs
@@ -192,9 +192,23 @@ namespace EngineLayer.Indexing
                 }
 
                 //Add terminal mods if needed (do it here rather than earlier so that we don't have to fragment twice)
-                // Only reachable for the "single" proteases, which are protein-only, so the cast is safe.
-                if (addInteriorTerminalModsToPrecursorIndex && peptides[peptideId] is PeptideWithSetModifications peptideForTerminalMods)
+                // The "single" agents are NOT protein-only: mzLib's rnases.tsv ships RNases named
+                // singleN and singleC, which the Name.Contains("single") test above matches. What makes
+                // this reachable only for peptides is the refusal in SearchTask.RunSpecific -- a
+                // non-specific search rejects a nucleic acid database before it gets here. That guard
+                // lives in another file, so throw rather than skip if it is ever relaxed: silently
+                // omitting interior terminal mods would cost identifications with nothing reporting why.
+                if (addInteriorTerminalModsToPrecursorIndex)
                 {
+                    if (peptides[peptideId] is not PeptideWithSetModifications peptideForTerminalMods)
+                    {
+                        throw new MetaMorpheusException(
+                            "Interior terminal modifications are only implemented for peptides, but a " +
+                            $"{peptides[peptideId].GetType().Name} reached the precursor index under digestion agent " +
+                            $"'{CommonParameters.DigestionParams.DigestionAgent.Name}'. Non-specific search is " +
+                            "supposed to refuse a nucleic acid database before indexing.");
+                    }
+
                     AddInteriorTerminalModsToPrecursorIndex(precursorIndex, fragments, peptideForTerminalMods, peptideId, terminalModifications);
                 }
 

--- a/MetaMorpheus/EngineLayer/Indexing/IndexingEngine.cs
+++ b/MetaMorpheus/EngineLayer/Indexing/IndexingEngine.cs
@@ -21,7 +21,7 @@ namespace EngineLayer.Indexing
         private static readonly double WaterMonoisotopicMass = PeriodicTable.GetElement("H").PrincipalIsotope.AtomicMass * 2 + PeriodicTable.GetElement("O").PrincipalIsotope.AtomicMass;
 
         private const int FragmentBinsPerDalton = 1000;
-        private readonly List<Protein> ProteinList;
+        private readonly List<IBioPolymer> BioPolymerList;
         private readonly List<Modification> FixedModifications;
         private readonly List<Modification> VariableModifications;
         private readonly List<SilacLabel> SilacLabels;
@@ -33,13 +33,18 @@ namespace EngineLayer.Indexing
         public readonly List<FileInfo> ProteinDatabases;
         public readonly TargetContaminantAmbiguity TcAmbiguity;
 
-        public IndexingEngine(List<Protein> proteinList, List<Modification> variableModifications, List<Modification> fixedModifications,
+        /// <summary>
+        /// Takes IEnumerable rather than List so that a List&lt;Protein&gt; still binds here by
+        /// covariance -- the protein callers need no change, and there is no overload to be ambiguous
+        /// about when someone passes an empty collection expression.
+        /// </summary>
+        public IndexingEngine(IEnumerable<IBioPolymer> bioPolymerList, List<Modification> variableModifications, List<Modification> fixedModifications,
             List<SilacLabel> silacLabels, SilacLabel startLabel, SilacLabel endLabel, int currentPartition, DecoyType decoyType,
-            CommonParameters commonParams, List<(string fileName, CommonParameters fileSpecificParameters)> fileSpecificParameters, 
+            CommonParameters commonParams, List<(string fileName, CommonParameters fileSpecificParameters)> fileSpecificParameters,
             double maxFragmentSize, bool generatePrecursorIndex, List<FileInfo> proteinDatabases, TargetContaminantAmbiguity tcAmbiguity, List<string> nestedIds)
             : base(commonParams, fileSpecificParameters, nestedIds)
         {
-            ProteinList = proteinList;
+            BioPolymerList = bioPolymerList as List<IBioPolymer> ?? bioPolymerList.ToList();
             VariableModifications = variableModifications;
             FixedModifications = fixedModifications;
             SilacLabels = silacLabels;
@@ -63,7 +68,7 @@ namespace EngineLayer.Indexing
             sb.AppendLine("Partitions: " + CurrentPartition + "/" + CommonParameters.TotalPartitions);
             sb.AppendLine("Precursor Index: " + GeneratePrecursorIndex);
             sb.AppendLine("Search Decoys: " + DecoyType);
-            sb.AppendLine("Number of proteins: " + ProteinList.Count);
+            sb.AppendLine("Number of proteins: " + BioPolymerList.Count);
             sb.AppendLine("Number of fixed mods: " + FixedModifications.Count);
             sb.AppendLine("Number of variable mods: " + VariableModifications.Count);
             sb.AppendLine("Dissociation Type: " + CommonParameters.DissociationType);
@@ -83,7 +88,7 @@ namespace EngineLayer.Indexing
                 sb.AppendLine("specificProtease: " + digestionParam.SpecificProtease);
             sb.AppendLine("maximumFragmentSize" + (int)Math.Round(MaxFragmentSize));
 
-            sb.Append("Localizeable mods: " + ProteinList.Select(b => b.OneBasedPossibleLocalizedModifications.Count).Sum());
+            sb.Append("Localizeable mods: " + BioPolymerList.Select(b => b.OneBasedPossibleLocalizedModifications.Count).Sum());
             return sb.ToString();
         }
 
@@ -93,26 +98,25 @@ namespace EngineLayer.Indexing
             int oldPercentProgress = 0;
 
             // digest database
-            List<PeptideWithSetModifications> peptides = new List<PeptideWithSetModifications>();
+            // IBioPolymer.Digest covers proteins and nucleic acids alike, and already carries the SILAC
+            // parameters, so the index no longer needs to know which kind of polymer it is holding.
+            List<IBioPolymerWithSetMods> peptides = new List<IBioPolymerWithSetMods>();
 
-            if (CommonParameters.DigestionParams is not DigestionParams digestionParams)
-                throw new MetaMorpheusException("Digestion parameters must be of type DigestionParams. Not yet implemented for Rna Digestion");
-            
             int maxThreadsPerFile = CommonParameters.MaxThreadsToUsePerFile;
             int[] threads = Enumerable.Range(0, maxThreadsPerFile).ToArray();
             Parallel.ForEach(threads, (i) =>
             {
-                List<PeptideWithSetModifications> localPeptides = new List<PeptideWithSetModifications>();
+                List<IBioPolymerWithSetMods> localPeptides = new List<IBioPolymerWithSetMods>();
 
-                for (; i < ProteinList.Count; i += maxThreadsPerFile)
+                for (; i < BioPolymerList.Count; i += maxThreadsPerFile)
                 {
                     // Stop loop if canceled
                     if (GlobalVariables.StopLoops) { return; }
 
-                    localPeptides.AddRange(ProteinList[i].Digest(digestionParams, FixedModifications, VariableModifications, SilacLabels, TurnoverLabels));
+                    localPeptides.AddRange(BioPolymerList[i].Digest(CommonParameters.DigestionParams, FixedModifications, VariableModifications, SilacLabels, TurnoverLabels));
 
                     progress++;
-                    var percentProgress = (int)((progress / ProteinList.Count) * 100);
+                    var percentProgress = (int)((progress / BioPolymerList.Count) * 100);
 
                     if (percentProgress > oldPercentProgress)
                     {
@@ -188,9 +192,10 @@ namespace EngineLayer.Indexing
                 }
 
                 //Add terminal mods if needed (do it here rather than earlier so that we don't have to fragment twice)
-                if (addInteriorTerminalModsToPrecursorIndex)
+                // Only reachable for the "single" proteases, which are protein-only, so the cast is safe.
+                if (addInteriorTerminalModsToPrecursorIndex && peptides[peptideId] is PeptideWithSetModifications peptideForTerminalMods)
                 {
-                    AddInteriorTerminalModsToPrecursorIndex(precursorIndex, fragments, peptides[peptideId], peptideId, terminalModifications);
+                    AddInteriorTerminalModsToPrecursorIndex(precursorIndex, fragments, peptideForTerminalMods, peptideId, terminalModifications);
                 }
 
                 progress++;
@@ -206,7 +211,7 @@ namespace EngineLayer.Indexing
             return new IndexingResults(peptides, fragmentIndex, precursorIndex, this);
         }
 
-        private List<int>[] CreateNewPrecursorIndex(List<PeptideWithSetModifications> peptidesSortedByMass)
+        private List<int>[] CreateNewPrecursorIndex(List<IBioPolymerWithSetMods> peptidesSortedByMass)
         {
             // create precursor index
             List<int>[] precursorIndex = null;

--- a/MetaMorpheus/EngineLayer/Indexing/IndexingResults.cs
+++ b/MetaMorpheus/EngineLayer/Indexing/IndexingResults.cs
@@ -1,4 +1,5 @@
-﻿using Omics.Fragmentation;
+﻿using Omics;
+using Omics.Fragmentation;
 using Proteomics.ProteolyticDigestion;
 using System.Collections.Generic;
 using System.Text;
@@ -7,7 +8,7 @@ namespace EngineLayer.Indexing
 {
     public class IndexingResults : MetaMorpheusEngineResults
     {
-        public IndexingResults(List<PeptideWithSetModifications> peptideIndex, List<int>[] fragmentIndex, List<int>[] precursorIndex, IndexingEngine indexParams) : base(indexParams)
+        public IndexingResults(List<IBioPolymerWithSetMods> peptideIndex, List<int>[] fragmentIndex, List<int>[] precursorIndex, IndexingEngine indexParams) : base(indexParams)
         {
             PeptideIndex = peptideIndex;
             FragmentIndex = fragmentIndex;
@@ -16,7 +17,7 @@ namespace EngineLayer.Indexing
 
         public List<int>[] FragmentIndex { get; private set; }
         public List<int>[] PrecursorIndex { get; private set; }
-        public List<PeptideWithSetModifications> PeptideIndex { get; private set; }
+        public List<IBioPolymerWithSetMods> PeptideIndex { get; private set; }
 
         public override string ToString()
         {
@@ -32,3 +33,4 @@ namespace EngineLayer.Indexing
         }
     }
 }
+

--- a/MetaMorpheus/EngineLayer/ModernSearch/ModernSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/ModernSearch/ModernSearchEngine.cs
@@ -1,5 +1,6 @@
 ﻿using Chemistry;
 using MassSpectrometry;
+using Omics;
 using Omics.Fragmentation;
 using Proteomics.ProteolyticDigestion;
 using System;
@@ -15,19 +16,19 @@ namespace EngineLayer.ModernSearch
         protected List<int>[] FragmentIndex { get; private set; }
         protected readonly SpectralMatch[] PeptideSpectralMatches;
         protected readonly Ms2ScanWithSpecificMass[] ListOfSortedMs2Scans;
-        protected readonly List<PeptideWithSetModifications> PeptideIndex;
+        protected readonly List<IBioPolymerWithSetMods> PeptideIndex;
         protected readonly int CurrentPartition;
         protected readonly MassDiffAcceptor MassDiffAcceptor;
         protected readonly DissociationType DissociationType;
         protected readonly double MaxMassThatFragmentIonScoreIsDoubled;
 
-        public ModernSearchEngine(SpectralMatch[] globalPsms, Ms2ScanWithSpecificMass[] listOfSortedms2Scans, List<PeptideWithSetModifications> peptideIndex,
+        public ModernSearchEngine(SpectralMatch[] globalPsms, Ms2ScanWithSpecificMass[] listOfSortedms2Scans, IEnumerable<IBioPolymerWithSetMods> peptideIndex,
             List<int>[] fragmentIndex, int currentPartition, CommonParameters commonParameters, List<(string fileName, CommonParameters fileSpecificParameters)> fileSpecificParameters, MassDiffAcceptor massDiffAcceptor, double maximumMassThatFragmentIonScoreIsDoubled,
             List<string> nestedIds) : base(commonParameters, fileSpecificParameters, nestedIds)
         {
             PeptideSpectralMatches = globalPsms;
             ListOfSortedMs2Scans = listOfSortedms2Scans;
-            PeptideIndex = peptideIndex;
+            PeptideIndex = peptideIndex as List<IBioPolymerWithSetMods> ?? peptideIndex.ToList();
             FragmentIndex = fragmentIndex;
             CurrentPartition = currentPartition + 1;
             MassDiffAcceptor = massDiffAcceptor;
@@ -252,7 +253,7 @@ namespace EngineLayer.ModernSearch
         /// Returns the bin-index of the first peptide with a mass less than or equal to the specified mass. Returns 0 if there 
         /// are no peptides with masses smaller than the specified mass.
         /// </summary>
-        protected static int BinarySearchBinForPrecursorIndex(List<int> bin, double peptideMassToLookFor, List<PeptideWithSetModifications> peptideIndex)
+        protected static int BinarySearchBinForPrecursorIndex(List<int> bin, double peptideMassToLookFor, List<IBioPolymerWithSetMods> peptideIndex)
         {
             int m = 0;
             int l = 0;
@@ -338,7 +339,7 @@ namespace EngineLayer.ModernSearch
         /// </summary>
         protected SpectralMatch FineScorePeptide(int id, Ms2ScanWithSpecificMass scan, int scanIndex, List<Product> peptideTheorProducts)
         {
-            PeptideWithSetModifications peptide = PeptideIndex[id];
+            IBioPolymerWithSetMods peptide = PeptideIndex[id];
 
             peptide.Fragment(CommonParameters.DissociationType, FragmentationTerminus.Both, peptideTheorProducts, CommonParameters.FragmentationParameters);
 
@@ -356,7 +357,11 @@ namespace EngineLayer.ModernSearch
             {
                 if (PeptideSpectralMatches[scanIndex] == null)
                 {
-                    PeptideSpectralMatches[scanIndex] = new PeptideSpectralMatch(peptide, notch, thisScore, scanIndex, scan, CommonParameters, matchedIons);
+                    // Same match-type switch ClassicSearchEngine makes, so a modern search over a
+                    // nucleic acid database reports oligos as OSMs instead of mislabelling them PSMs.
+                    PeptideSpectralMatches[scanIndex] = GlobalVariables.AnalyteType == AnalyteType.Oligo
+                        ? new OligoSpectralMatch(peptide, notch, thisScore, scanIndex, scan, CommonParameters, matchedIons)
+                        : new PeptideSpectralMatch(peptide, notch, thisScore, scanIndex, scan, CommonParameters, matchedIons);
                 }
                 else
                 {
@@ -399,7 +404,7 @@ namespace EngineLayer.ModernSearch
         /// Deprecated.
         /// </summary>
         protected void IndexedScoring(List<int>[] FragmentIndex, List<int> binsToSearch, byte[] scoringTable, byte byteScoreCutoff, List<int> idsOfPeptidesPossiblyObserved, double scanPrecursorMass, double lowestMassPeptideToLookFor,
-            double highestMassPeptideToLookFor, List<PeptideWithSetModifications> peptideIndex, MassDiffAcceptor massDiffAcceptor, double maxMassThatFragmentIonScoreIsDoubled, DissociationType dissociationType)
+            double highestMassPeptideToLookFor, List<IBioPolymerWithSetMods> peptideIndex, MassDiffAcceptor massDiffAcceptor, double maxMassThatFragmentIonScoreIsDoubled, DissociationType dissociationType)
         {
             // get all theoretical fragments this experimental fragment could be
             for (int i = 0; i < binsToSearch.Count; i++) //binsToSearch is the list of fragment in Spectra

--- a/MetaMorpheus/EngineLayer/NonSpecificEnzymeSearch/NonSpecificEnzymeSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/NonSpecificEnzymeSearch/NonSpecificEnzymeSearchEngine.cs
@@ -2,6 +2,7 @@
 using EngineLayer.FdrAnalysis;
 using EngineLayer.ModernSearch;
 using Proteomics;
+using Omics;
 using Omics.Fragmentation;
 using Proteomics.ProteolyticDigestion;
 using System;
@@ -28,11 +29,18 @@ namespace EngineLayer.NonSpecificEnzymeSearch
         readonly List<Modification> VariableTerminalModifications;
         readonly List<int>[] CoisolationIndex;
 
+        /// <summary>
+        /// Non-specific search is proteomics-only, so it keeps a peptide-typed view of the index that
+        /// ModernSearchEngine now holds as IBioPolymerWithSetMods. Same objects, narrower type.
+        /// </summary>
+        protected new readonly List<PeptideWithSetModifications> PeptideIndex;
+
         public NonSpecificEnzymeSearchEngine(SpectralMatch[][] globalPsms, Ms2ScanWithSpecificMass[] listOfSortedms2Scans, List<int>[] coisolationIndex,
-            List<PeptideWithSetModifications> peptideIndex, List<int>[] fragmentIndex, List<int>[] precursorIndex, int currentPartition,
+            IEnumerable<IBioPolymerWithSetMods> peptideIndex, List<int>[] fragmentIndex, List<int>[] precursorIndex, int currentPartition,
             CommonParameters commonParameters, List<(string fileName, CommonParameters fileSpecificParameters)> fileSpecificParameters, List<Modification> variableModifications, MassDiffAcceptor massDiffAcceptor, double maximumMassThatFragmentIonScoreIsDoubled, List<string> nestedIds)
             : base(null, listOfSortedms2Scans, peptideIndex, fragmentIndex, currentPartition, commonParameters, fileSpecificParameters, massDiffAcceptor, maximumMassThatFragmentIonScoreIsDoubled, nestedIds)
         {
+            PeptideIndex = peptideIndex.Cast<PeptideWithSetModifications>().ToList();
             CoisolationIndex = coisolationIndex;
             PrecursorIndex = precursorIndex;
             MinimumPeptideLength = commonParameters.DigestionParams.MinLength;

--- a/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationTask.cs
+++ b/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationTask.cs
@@ -59,7 +59,7 @@ namespace TaskLayer
         private List<DbForTask> _dbFilenameList;
 
         // Modern Search indexing fields
-        private List<PeptideWithSetModifications> _peptideIndex;
+        private List<IBioPolymerWithSetMods> _peptideIndex;
         private List<int>[] _fragmentIndex;
 
         protected override MyTaskResults RunSpecific(string outputFolder, List<DbForTask> dbFilenameList, List<string> currentRawFileList, string taskId, FileSpecificParameters[] fileSettingsList)

--- a/MetaMorpheus/TaskLayer/EverythingRunnerEngine.cs
+++ b/MetaMorpheus/TaskLayer/EverythingRunnerEngine.cs
@@ -1,4 +1,4 @@
-using EngineLayer;
+﻿using EngineLayer;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -86,6 +86,24 @@ namespace TaskLayer
                 }
                
                 var ok = TaskList[i];
+
+                // Non-specific search is built around proteases -- terminal mod placement, the "single"
+                // agents, the FDR categories -- none of which have a nucleic acid counterpart yet.
+                // Refused here rather than only in SearchTask because a MetaMorpheusException out of
+                // RunSpecific is dumped into results.txt with a stack trace and rethrown, and the GUI
+                // routes the faulted task to EverythingRunnerExceptionHandler -- so the user is told
+                // MetaMorpheus crashed and invited to file a bug, and never sees the message that says
+                // what to do instead. The throw in SearchTask stays as a backstop for a caller invoking
+                // RunTask directly.
+                if (ok.Item2 is SearchTask nonSpecificCandidate
+                    && nonSpecificCandidate.SearchParameters.SearchType == SearchType.NonSpecific
+                    && GlobalVariables.AnalyteType == AnalyteType.Oligo)
+                {
+                    Warn("Cannot proceed. Non-specific search is only implemented for proteins. " +
+                         "Use Classic or Modern search for nucleic acid databases.");
+                    FinishedAllTasks(OutputFolder);
+                    return;
+                }
 
                 // reset product types for custom fragmentation
                 ok.Item2.CommonParameters.SetCustomProductTypes();

--- a/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
+++ b/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
@@ -1,4 +1,4 @@
-using Chemistry;
+﻿using Chemistry;
 using EngineLayer;
 using EngineLayer.Indexing;
 using MassSpectrometry;
@@ -1271,8 +1271,15 @@ namespace TaskLayer
             }
         }
 
+        /// <summary>
+        /// Cast rather than OfType, to match the write side one method up. Both respond to the same
+        /// violated precondition -- a cached index is only reachable when indexIsCacheable, which is
+        /// AnalyteType != Oligo -- and they must fail the same way. OfType here would drop the oligos
+        /// and carry on with whatever proteins remained, returning a plausible index silently built
+        /// from a subset of the database; the write side already throws on the first oligo.
+        /// </summary>
         private static List<IBioPolymerWithSetMods> ReadPeptideIndex(string peptideIndexFileName, IEnumerable<IBioPolymer> allKnownBioPolymers)
-            => ReadPeptideIndex(peptideIndexFileName, allKnownBioPolymers.OfType<Protein>().ToList())
+            => ReadPeptideIndex(peptideIndexFileName, allKnownBioPolymers.Cast<Protein>().ToList())
                 .Cast<IBioPolymerWithSetMods>().ToList();
 
         private static List<PeptideWithSetModifications> ReadPeptideIndex(string peptideIndexFileName, List<Protein> allKnownProteins)

--- a/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
+++ b/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
@@ -1250,6 +1250,9 @@ namespace TaskLayer
             Warn($"{engineName} engine Crashed! Error written to {outPath}");
         }
 
+        private static void WritePeptideIndex(List<IBioPolymerWithSetMods> peptideIndex, string peptideIndexFileName)
+            => WritePeptideIndex(peptideIndex.Cast<PeptideWithSetModifications>().ToList(), peptideIndexFileName);
+
         private static void WritePeptideIndex(List<PeptideWithSetModifications> peptideIndex, string peptideIndexFileName)
         {
             var messageTypes = GetSubclassesAndItself(typeof(List<PeptideWithSetModifications>));
@@ -1260,6 +1263,10 @@ namespace TaskLayer
                 ser.Serialize(file, peptideIndex);
             }
         }
+
+        private static List<IBioPolymerWithSetMods> ReadPeptideIndex(string peptideIndexFileName, IEnumerable<IBioPolymer> allKnownBioPolymers)
+            => ReadPeptideIndex(peptideIndexFileName, allKnownBioPolymers.OfType<Protein>().ToList())
+                .Cast<IBioPolymerWithSetMods>().ToList();
 
         private static List<PeptideWithSetModifications> ReadPeptideIndex(string peptideIndexFileName, List<Protein> allKnownProteins)
         {
@@ -1391,10 +1398,30 @@ namespace TaskLayer
             return folder;
         }
 
-        public void GenerateIndexes(IndexingEngine indexEngine, List<DbForTask> dbFilenameList, ref List<PeptideWithSetModifications> peptideIndex, ref List<int>[] fragmentIndex, ref List<int>[] precursorIndex, List<Protein> allKnownProteins, string taskId)
+        /// <summary>
+        /// Convenience overload for the protein-only tasks (cross-link, glyco, calibration, non-specific),
+        /// which index peptides and want them back typed as peptides. Distinguished by the ref parameter,
+        /// so it cannot be ambiguous with the general one.
+        /// </summary>
+        public void GenerateIndexes(IndexingEngine indexEngine, List<DbForTask> dbFilenameList, ref List<PeptideWithSetModifications> peptideIndex,
+            ref List<int>[] fragmentIndex, ref List<int>[] precursorIndex, IEnumerable<IBioPolymer> allKnownProteins, string taskId)
+        {
+            List<IBioPolymerWithSetMods> bioPolymerIndex = null;
+            GenerateIndexes(indexEngine, dbFilenameList, ref bioPolymerIndex, ref fragmentIndex, ref precursorIndex, allKnownProteins, taskId);
+            peptideIndex = bioPolymerIndex?.Cast<PeptideWithSetModifications>().ToList();
+        }
+
+        public void GenerateIndexes(IndexingEngine indexEngine, List<DbForTask> dbFilenameList, ref List<IBioPolymerWithSetMods> peptideIndex, ref List<int>[] fragmentIndex, ref List<int>[] precursorIndex, IEnumerable<IBioPolymer> allKnownProteins, string taskId)
         {
             bool successfullyReadIndices = false;
-            string pathToFolderWithIndices = GetExistingFolderWithIndices(indexEngine, dbFilenameList);
+
+            // The on-disk peptide index only round-trips peptides: OligoWithSetMods is neither
+            // [Serializable] nor able to restore its parent the way SetNonSerializedPeptideInfo does for
+            // PeptideWithSetModifications. Nucleic acid databases are small, so build in memory each
+            // time rather than block oligo searches on an mzLib serialization change.
+            bool indexIsCacheable = GlobalVariables.AnalyteType != AnalyteType.Oligo;
+
+            string pathToFolderWithIndices = indexIsCacheable ? GetExistingFolderWithIndices(indexEngine, dbFilenameList) : null;
 
             if (pathToFolderWithIndices != null) //if indexes exist
             {
@@ -1427,6 +1454,16 @@ namespace TaskLayer
 
             if (!successfullyReadIndices) //if we didn't find indexes with the same params
             {
+                if (!indexIsCacheable)
+                {
+                    Status("Running Index Engine...", new List<string> { taskId });
+                    var inMemoryResults = (IndexingResults)indexEngine.Run();
+                    peptideIndex = inMemoryResults.PeptideIndex;
+                    fragmentIndex = inMemoryResults.FragmentIndex;
+                    precursorIndex = inMemoryResults.PrecursorIndex;
+                    return;
+                }
+
                 var output_folderForIndices = GenerateOutputFolderForIndices(dbFilenameList);
                 Status("Writing params...", new List<string> { taskId });
                 var paramsFile = Path.Combine(output_folderForIndices, IndexEngineParamsFileName);

--- a/MetaMorpheus/TaskLayer/SearchTask/SearchTask.cs
+++ b/MetaMorpheus/TaskLayer/SearchTask/SearchTask.cs
@@ -378,13 +378,11 @@ namespace TaskLayer
                 // modern search
                 if (SearchParameters.SearchType == SearchType.Modern)
                 {
-                    // Assume modern search is for proteins. 
-                    var proteinList = bioPolymerList.Cast<Protein>().ToList();
                     for (int currentPartition = 0; currentPartition < combinedParams.TotalPartitions; currentPartition++)
                     {
-                        List<PeptideWithSetModifications> peptideIndex = null;
-                        List<Protein> proteinListSubset = proteinList.GetRange(currentPartition * proteinList.Count / combinedParams.TotalPartitions,
-                            ((currentPartition + 1) * proteinList.Count / combinedParams.TotalPartitions) - (currentPartition * proteinList.Count / combinedParams.TotalPartitions));
+                        List<IBioPolymerWithSetMods> peptideIndex = null;
+                        List<IBioPolymer> proteinListSubset = bioPolymerList.GetRange(currentPartition * bioPolymerList.Count / combinedParams.TotalPartitions,
+                            ((currentPartition + 1) * bioPolymerList.Count / combinedParams.TotalPartitions) - (currentPartition * bioPolymerList.Count / combinedParams.TotalPartitions));
 
                         Status("Getting fragment dictionary...", new List<string> { taskId });
                         var indexEngine = new IndexingEngine(proteinListSubset, variableModifications, fixedModifications, SearchParameters.SilacLabels,
@@ -395,7 +393,7 @@ namespace TaskLayer
 
                         lock (indexLock)
                         {
-                            GenerateIndexes(indexEngine, dbFilenameList, ref peptideIndex, ref fragmentIndex, ref precursorIndex, proteinList, taskId);
+                            GenerateIndexes(indexEngine, dbFilenameList, ref peptideIndex, ref fragmentIndex, ref precursorIndex, bioPolymerList, taskId);
                         }
 
                         Status("Searching files...", taskId);
@@ -452,6 +450,16 @@ namespace TaskLayer
                     //foreach terminus we're going to look at
                     foreach (CommonParameters paramToUse in paramsToUse)
                     {
+                        // Non-specific search is built around proteases -- terminal mod placement, the
+                        // "single" agents, the FDR categories -- none of which have a nucleic acid
+                        // counterpart yet. Say so, rather than letting the cast below throw a bare
+                        // InvalidCastException that names Protein and RNA and explains neither.
+                        if (bioPolymerList.Any(p => p is not Protein))
+                        {
+                            throw new MetaMorpheusException(
+                                "Non-specific search is only implemented for proteins. Use Classic or Modern search for nucleic acid databases.");
+                        }
+
                         var proteinList = bioPolymerList.Cast<Protein>().ToList();
 
                         //foreach database partition

--- a/MetaMorpheus/Test/Transcriptomics/RnaSpecificTypeSwitches.cs
+++ b/MetaMorpheus/Test/Transcriptomics/RnaSpecificTypeSwitches.cs
@@ -2,6 +2,9 @@
 using System.Collections.Generic;
 using System.IO;
 using EngineLayer;
+using System.Linq;
+using Transcriptomics;
+using Omics;
 using EngineLayer.Indexing;
 using NUnit.Framework;
 using Omics.Digestion;
@@ -43,12 +46,19 @@ public class RnaSpecificTypeSwitches
     }
 
     [Test]
-    public static void IndexingEngine_ThrowsOnRNA()
+    public static void IndexingEngine_IndexesRNA()
     {
-        var indexEngine = new IndexingEngine([], [], [], null, null, null,
-            1, DecoyType.Reverse, new CommonParameters(digestionParams: new RnaDigestionParams()), [], 14, false, new List<FileInfo>(), TargetContaminantAmbiguity.RemoveContaminant, new List<string>());
+        // Used to assert IndexingEngine_ThrowsOnRNA: the engine refused RnaDigestionParams outright with
+        // "Not yet implemented for Rna Digestion". It now digests nucleic acids like any other biopolymer.
+        List<IBioPolymer> rna = [new RNA("GUACUG")];
 
-        Assert.Throws<MetaMorpheusException>(() => indexEngine.Run());
+        var indexEngine = new IndexingEngine(rna, [], [], null, null, null,
+            1, DecoyType.None, new CommonParameters(digestionParams: new RnaDigestionParams()), [], 14, false, new List<FileInfo>(), TargetContaminantAmbiguity.RemoveContaminant, new List<string>());
+
+        var results = (IndexingResults)indexEngine.Run();
+
+        Assert.That(results.PeptideIndex, Is.Not.Empty);
+        Assert.That(results.PeptideIndex.First(), Is.InstanceOf<OligoWithSetMods>());
     }
 
     [Test]

--- a/MetaMorpheus/Test/Transcriptomics/TestRnaModernSearch.cs
+++ b/MetaMorpheus/Test/Transcriptomics/TestRnaModernSearch.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using EngineLayer;
@@ -157,6 +157,66 @@ namespace Test.Transcriptomics
                 Assert.That(thrown.Message, Does.Contain("only implemented for proteins"));
                 Assert.That(thrown.Message, Does.Contain("Classic or Modern"),
                     "the message has to say what to do instead, not just what failed");
+            }
+            finally
+            {
+                GlobalVariables.AnalyteType = original;
+                if (Directory.Exists(outputDir)) Directory.Delete(outputDir, true);
+            }
+        }
+
+        /// <summary>
+        /// The refusal a user actually meets. SearchTask still throws -- the test above pins that as a
+        /// backstop for a caller invoking RunTask directly -- but a MetaMorpheusException out of
+        /// RunSpecific is written into results.txt with a stack trace and rethrown, and the GUI routes
+        /// the faulted task to EverythingRunnerExceptionHandler, which offers to report a crash. So the
+        /// message telling the user to switch to Classic or Modern is the one thing they never see.
+        ///
+        /// EverythingRunnerEngine refuses first, next to the existing "No protein database files
+        /// selected" gates, and the assertion is on Warnings rather than on a thrown exception --
+        /// which is what makes it a refusal rather than a crash.
+        /// </summary>
+        [Test]
+        [NonParallelizable]
+        public static void NonSpecificSearch_OverANucleicAcidDatabase_IsRefusedByTheRunnerNotThrown()
+        {
+            var original = GlobalVariables.AnalyteType;
+            string outputDir = Path.Combine(TestContext.CurrentContext.TestDirectory, "RnaNonSpecificRunnerRefused");
+            if (Directory.Exists(outputDir)) Directory.Delete(outputDir, true);
+            Directory.CreateDirectory(outputDir);
+
+            try
+            {
+                GlobalVariables.AnalyteType = AnalyteType.Oligo;
+
+                var task = new SearchTask
+                {
+                    CommonParameters = new CommonParameters(
+                        digestionParams: new RnaDigestionParams(
+                            rnase: "top-down", fragmentationTerminus: FragmentationTerminus.N)),
+                    SearchParameters = new RnaSearchParameters { SearchType = SearchType.NonSpecific }
+                };
+
+                var databases = new List<DbForTask>
+                {
+                    new(Path.Combine(TestContext.CurrentContext.TestDirectory,
+                        "Transcriptomics", "TestData", "6mer.fasta"), false)
+                };
+
+                var runner = new EverythingRunnerEngine(
+                    new List<(string, MetaMorpheusTask)> { ("RefuseNonSpecific", task) },
+                    new List<string> { SixmerFilePath },
+                    databases,
+                    outputDir);
+
+                Assert.DoesNotThrow(() => runner.Run(), "the runner refuses; it does not fault the task");
+
+                Assert.That(runner.Warnings.Any(w => w.Contains("only implemented for proteins")),
+                    "the refusal has to reach the user as a warning");
+                Assert.That(runner.Warnings.Any(w => w.Contains("Classic or Modern")),
+                    "the message has to say what to do instead, not just what failed");
+                Assert.That(Directory.Exists(Path.Combine(outputDir, "RefuseNonSpecific")), Is.False,
+                    "refused before the task ran, so it never got an output folder");
             }
             finally
             {

--- a/MetaMorpheus/Test/Transcriptomics/TestRnaModernSearch.cs
+++ b/MetaMorpheus/Test/Transcriptomics/TestRnaModernSearch.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using EngineLayer;
+using EngineLayer.DatabaseLoading;
 using EngineLayer.Indexing;
 using EngineLayer.ModernSearch;
 using MassSpectrometry;
@@ -14,6 +15,7 @@ using TaskLayer;
 using Transcriptomics;
 using Transcriptomics.Digestion;
 using UsefulProteomicsDatabases;
+using UsefulProteomicsDatabases.Transcriptomics;
 
 namespace Test.Transcriptomics
 {
@@ -92,6 +94,72 @@ namespace Test.Transcriptomics
 
             Assert.That(multiEntryBins, Is.GreaterThan(0), "no multi-entry bins; the test proves nothing");
             Assert.That(results.PeptideIndex.Select(p => p.MonoisotopicMass), Is.Ordered, "index is not sorted by mass");
+        }
+
+        /// <summary>
+        /// The index cache is skipped for oligos, and this is the branch that decides it.
+        ///
+        /// The on-disk index only round-trips peptides: OligoWithSetMods is neither [Serializable] nor
+        /// able to restore its parent the way SetNonSerializedPeptideInfo does for
+        /// PeptideWithSetModifications, so a cached oligo index would come back unusable. GenerateIndexes
+        /// therefore builds in memory when the analyte type is Oligo.
+        ///
+        /// Asserting the index came back is not enough -- it comes back either way. What separates the
+        /// two paths is that the cacheable one WRITES, into a "DatabaseIndex" folder beside the database
+        /// file. So the database is copied somewhere of its own first and the test asserts nothing
+        /// appeared next to it; watching a folder GenerateIndexes was never given would have asserted
+        /// nothing at all. Verified against a build with the branch forced the other way, which writes
+        /// the folder and fails this.
+        /// </summary>
+        [Test]
+        [NonParallelizable]
+        public static void GenerateIndexes_ForOligos_BuildsInMemoryAndCachesNothing()
+        {
+            var original = GlobalVariables.AnalyteType;
+            string databaseFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, "OligoIndexNotCached");
+            if (Directory.Exists(databaseFolder)) Directory.Delete(databaseFolder, true);
+            Directory.CreateDirectory(databaseFolder);
+
+            try
+            {
+                GlobalVariables.AnalyteType = AnalyteType.Oligo;
+
+                // A copy of its own, so "was anything cached" is a question about this run only. The
+                // shared TestData folder would answer it with somebody else's leftovers.
+                string dbPath = Path.Combine(databaseFolder, "20mer1.fasta");
+                File.Copy(Path.Combine(TestContext.CurrentContext.TestDirectory,
+                    "Transcriptomics", "TestData", "20mer1.fasta"), dbPath);
+
+                var commonParameters = RnaCommonParameters;
+                var targets = RnaDbLoader.LoadRnaFasta(dbPath, true, DecoyType.None, false, out _)
+                    .Cast<IBioPolymer>().ToList();
+                Assert.That(targets, Is.Not.Empty, "premise: the fixture database has entries");
+
+                var indexEngine = new IndexingEngine(targets, [], [], null, null, null, 0, DecoyType.None,
+                    commonParameters, null, 30000, false, new List<FileInfo>(),
+                    TargetContaminantAmbiguity.RemoveContaminant, new List<string>());
+
+                var task = new SearchTask { CommonParameters = commonParameters };
+                List<IBioPolymerWithSetMods> oligoIndex = null;
+                List<int>[] fragmentIndex = null;
+                List<int>[] precursorIndex = null;
+
+                task.GenerateIndexes(indexEngine, new List<DbForTask> { new DbForTask(dbPath, false) },
+                    ref oligoIndex, ref fragmentIndex, ref precursorIndex, targets, "TestTaskId");
+
+                Assert.That(oligoIndex, Is.Not.Null.And.Not.Empty, "no oligos came back from the index");
+                Assert.That(oligoIndex.First(), Is.InstanceOf<OligoWithSetMods>());
+                Assert.That(fragmentIndex.Count(bin => bin != null), Is.GreaterThan(0), "no fragments were binned");
+
+                // The part that distinguishes the two paths.
+                Assert.That(Directory.Exists(Path.Combine(databaseFolder, MetaMorpheusTask.IndexFolderName)), Is.False,
+                    "an oligo index must not be cached to disk -- it cannot be read back");
+            }
+            finally
+            {
+                GlobalVariables.AnalyteType = original;
+                if (Directory.Exists(databaseFolder)) Directory.Delete(databaseFolder, true);
+            }
         }
 
         /// <summary>

--- a/MetaMorpheus/Test/Transcriptomics/TestRnaModernSearch.cs
+++ b/MetaMorpheus/Test/Transcriptomics/TestRnaModernSearch.cs
@@ -9,6 +9,7 @@ using MassSpectrometry;
 using MzLibUtil;
 using NUnit.Framework;
 using Omics;
+using Omics.Fragmentation;
 using Omics.Modifications;
 using Readers;
 using TaskLayer;
@@ -94,6 +95,74 @@ namespace Test.Transcriptomics
 
             Assert.That(multiEntryBins, Is.GreaterThan(0), "no multi-entry bins; the test proves nothing");
             Assert.That(results.PeptideIndex.Select(p => p.MonoisotopicMass), Is.Ordered, "index is not sorted by mass");
+        }
+
+        /// <summary>
+        /// Non-specific search refuses a nucleic acid database with an explanation, rather than casting
+        /// and letting the runtime say it.
+        ///
+        /// It is built around proteases -- terminal mod placement, the "single" agents, the FDR
+        /// categories -- and none of those has an oligo counterpart yet. Without the guard the next line
+        /// is `bioPolymerList.Cast&lt;Protein&gt;()`, which throws InvalidCastException naming Protein and
+        /// RNA and explaining neither. The distinction the test pins is not that it fails, but that it
+        /// fails as a MetaMorpheusException carrying a message a user can act on.
+        ///
+        /// RunTask writes the failure into results.txt and rethrows, so the exception is observable here.
+        /// </summary>
+        [Test]
+        [NonParallelizable]
+        public static void NonSpecificSearch_RefusesANucleicAcidDatabase()
+        {
+            var original = GlobalVariables.AnalyteType;
+            string outputDir = Path.Combine(TestContext.CurrentContext.TestDirectory, "RnaNonSpecificRefused");
+            if (Directory.Exists(outputDir)) Directory.Delete(outputDir, true);
+            Directory.CreateDirectory(outputDir);
+
+            try
+            {
+                GlobalVariables.AnalyteType = AnalyteType.Oligo;
+
+                var task = new SearchTask
+                {
+                    CommonParameters = new CommonParameters(
+                        dissociationType: DissociationType.CID,
+                        deconvolutionMaxAssumedChargeState: -20,
+                        precursorMassTolerance: new PpmTolerance(10),
+                        productMassTolerance: new PpmTolerance(20),
+                        scoreCutoff: 5,
+                        totalPartitions: 1,
+                        maxThreadsToUsePerFile: 1,
+                        digestionParams: new RnaDigestionParams(
+                            rnase: "top-down", fragmentationTerminus: FragmentationTerminus.N)),
+                    SearchParameters = new RnaSearchParameters
+                    {
+                        SearchType = SearchType.NonSpecific,
+                        DecoyType = DecoyType.None,
+                        MassDiffAcceptorType = MassDiffAcceptorType.Custom,
+                        CustomMdac = "Custom interval [-5,5]",
+                        DisposeOfFileWhenDone = true
+                    }
+                };
+
+                var databases = new List<DbForTask>
+                {
+                    new(Path.Combine(TestContext.CurrentContext.TestDirectory,
+                        "Transcriptomics", "TestData", "6mer.fasta"), false)
+                };
+                var spectra = new List<string> { SixmerFilePath };
+
+                var thrown = Assert.Throws<MetaMorpheusException>(
+                    () => task.RunTask(outputDir, databases, spectra, "RefuseNonSpecific"));
+
+                Assert.That(thrown.Message, Does.Contain("only implemented for proteins"));
+                Assert.That(thrown.Message, Does.Contain("Classic or Modern"),
+                    "the message has to say what to do instead, not just what failed");
+            }
+            finally
+            {
+                GlobalVariables.AnalyteType = original;
+                if (Directory.Exists(outputDir)) Directory.Delete(outputDir, true);
+            }
         }
 
         /// <summary>

--- a/MetaMorpheus/Test/Transcriptomics/TestRnaModernSearch.cs
+++ b/MetaMorpheus/Test/Transcriptomics/TestRnaModernSearch.cs
@@ -1,0 +1,140 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using EngineLayer;
+using EngineLayer.Indexing;
+using EngineLayer.ModernSearch;
+using MassSpectrometry;
+using MzLibUtil;
+using NUnit.Framework;
+using Omics;
+using Omics.Modifications;
+using Readers;
+using TaskLayer;
+using Transcriptomics;
+using Transcriptomics.Digestion;
+using UsefulProteomicsDatabases;
+
+namespace Test.Transcriptomics
+{
+    /// <summary>
+    /// Modern (index-based) search over a nucleic acid database. The classic-search equivalents live in
+    /// TestRnaSearchEngine and SearchTaskWithRna; these assert the indexed path reaches the same answer.
+    /// </summary>
+    [TestFixture]
+    public class TestRnaModernSearch
+    {
+        private static readonly string SixmerFilePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "Transcriptomics", "TestData", "GUACUG_NegativeMode_Sliced.mzML");
+
+        private static CommonParameters RnaCommonParameters => new CommonParameters(
+            dissociationType: DissociationType.CID,
+            deconvolutionMaxAssumedChargeState: -20,
+            deconvolutionIntensityRatio: 3,
+            deconvolutionMassTolerance: new PpmTolerance(20),
+            precursorMassTolerance: new PpmTolerance(10),
+            productMassTolerance: new PpmTolerance(20),
+            scoreCutoff: 5,
+            totalPartitions: 1,
+            maxThreadsToUsePerFile: 1,
+            doPrecursorDeconvolution: true,
+            useProvidedPrecursorInfo: false,
+            digestionParams: new RnaDigestionParams());
+
+        /// <summary>
+        /// The index used to refuse RNA outright: IndexingEngine threw "Not yet implemented for Rna
+        /// Digestion" and SearchTask cast the biopolymer list to Protein. It now digests and fragments
+        /// oligos like any other biopolymer.
+        /// </summary>
+        [Test]
+        public static void IndexingEngine_IndexesOligos()
+        {
+            var commonParameters = RnaCommonParameters;
+            List<IBioPolymer> targets = [new RNA("GUACUG")];
+
+            var indexEngine = new IndexingEngine(targets, [], [], null, null, null, 0, DecoyType.None,
+                commonParameters, null, 30000, false, new List<FileInfo>(),
+                TargetContaminantAmbiguity.RemoveContaminant, new List<string>());
+
+            var results = (IndexingResults)indexEngine.Run();
+
+            Assert.That(results.PeptideIndex, Is.Not.Empty, "no oligos were digested into the index");
+            Assert.That(results.PeptideIndex.First(), Is.InstanceOf<OligoWithSetMods>());
+            Assert.That(results.FragmentIndex.Count(bin => bin != null), Is.GreaterThan(0), "no fragments were binned");
+        }
+
+        /// <summary>
+        /// Peptide ids must ascend within a fragment bin: the search binary-searches a bin by mass, and
+        /// that only holds because the index is sorted by mass. True for oligos as much as for peptides.
+        /// </summary>
+        [Test]
+        public static void OligoIndex_BinsAreSortedByOligoId()
+        {
+            List<IBioPolymer> targets = [new RNA("GUACUGGUACUGAAUUCC"), new RNA("CAUGCAUGCAUGAAUU")];
+
+            var indexEngine = new IndexingEngine(targets, [], [], null, null, null, 0, DecoyType.Reverse,
+                RnaCommonParameters, null, 30000, false, new List<FileInfo>(),
+                TargetContaminantAmbiguity.RemoveContaminant, new List<string>());
+
+            var results = (IndexingResults)indexEngine.Run();
+
+            int multiEntryBins = 0;
+            foreach (var bin in results.FragmentIndex.Where(b => b != null))
+            {
+                for (int i = 1; i < bin.Count; i++)
+                {
+                    Assert.That(bin[i], Is.GreaterThan(bin[i - 1]), "a fragment bin is not ascending by oligo id");
+                }
+                if (bin.Count > 1)
+                {
+                    multiEntryBins++;
+                }
+            }
+
+            Assert.That(multiEntryBins, Is.GreaterThan(0), "no multi-entry bins; the test proves nothing");
+            Assert.That(results.PeptideIndex.Select(p => p.MonoisotopicMass), Is.Ordered, "index is not sorted by mass");
+        }
+
+        /// <summary>
+        /// The payoff: modern search finds the same sixmer classic search finds, and reports it as an
+        /// OligoSpectralMatch rather than mislabelling it a PSM.
+        /// </summary>
+        [Test]
+        public static void ModernSearch_FindsSimpleSixmer()
+        {
+            var commonParameters = RnaCommonParameters;
+            var searchParameters = new RnaSearchParameters
+            {
+                MassDiffAcceptorType = MassDiffAcceptorType.Custom,
+                CustomMdac = "Custom interval [-5,5]",
+            };
+
+            var dataFile = MsDataFileReader.GetDataFile(SixmerFilePath);
+            var ms2Scans = MetaMorpheusTask.GetMs2Scans(dataFile, SixmerFilePath, commonParameters)
+                .OrderBy(b => b.PrecursorMass)
+                .ToArray();
+
+            MassDiffAcceptor massDiffAcceptor = SearchTask.GetMassDiffAcceptor(commonParameters.PrecursorMassTolerance,
+                searchParameters.MassDiffAcceptorType, searchParameters.CustomMdac);
+
+            List<IBioPolymer> targets = [new RNA("GUACUG")];
+
+            var indexEngine = new IndexingEngine(targets, [], [], null, null, null, 0, DecoyType.None,
+                commonParameters, null, 30000, false, new List<FileInfo>(),
+                TargetContaminantAmbiguity.RemoveContaminant, new List<string>());
+            var indexResults = (IndexingResults)indexEngine.Run();
+
+            var osms = new SpectralMatch[ms2Scans.Length];
+            new ModernSearchEngine(osms, ms2Scans, indexResults.PeptideIndex, indexResults.FragmentIndex, 0,
+                commonParameters, null, massDiffAcceptor, 0, ["modern rna search"]).Run();
+
+            var matches = osms.Where(p => p != null).OrderByDescending(p => p.Score).ToList();
+
+            Assert.That(matches, Is.Not.Empty, "modern search found no matches for the GUACUG sixmer");
+
+            var match = matches.First();
+            Assert.That(match, Is.TypeOf<OligoSpectralMatch>(), "match is not an OligoSpectralMatch");
+            Assert.That(match.BaseSequence, Is.EqualTo("GUACUG"));
+            Assert.That(match.Score, Is.GreaterThan(22), "modern score is below what classic search reaches");
+        }
+    }
+}


### PR DESCRIPTION
Modern (index-based) search could not run against a nucleic acid database. This makes it work, and adds tests proving it reaches the same answer classic search does.

**1833 tests pass, 0 fail.** 1830 were already there; the fourth new test replaces one that asserted the old refusal.

## What failed, exactly

Two blockers, in the order a user hits them. Both reproduced before changing anything.

**First**, `SearchTask`'s modern branch cast the biopolymer list to `Protein`:

```
InvalidCastException: Unable to cast object of type 'Transcriptomics.RNA'
to type 'Proteomics.Protein'
    at System.Linq.Enumerable.CastICollectionIterator`1.ToList()
    SearchTask.cs:382 — bioPolymerList.Cast<Protein>().ToList()
```

The line above it read `// Assume modern search is for proteins.` The message names two types and explains neither, which is a bad first thing to hit.

**Second**, behind it, `IndexingEngine` refused non-protein digestion outright:

```
MetaMorpheusException: Digestion parameters must be of type DigestionParams.
Not yet implemented for Rna Digestion
    IndexingEngine.cs:98
```

`IndexingEngine` was typed `List<Protein>` in and `List<PeptideWithSetModifications>` out.

**A third thing worth knowing**, which is not a bug but is confusing: `RnaSearchParameters`'s constructor sets `SearchType = SearchType.Classic`. Anyone who sets `SearchType` *before* constructing it has the value silently overwritten. That behaviour is unchanged here — flagged because it can look like the fix did not take.

## This was a decision, not an oversight

`Test/Transcriptomics/RnaSpecificTypeSwitches.cs` contained:

```csharp
[Test]
public static void IndexingEngine_ThrowsOnRNA()
{
    var indexEngine = new IndexingEngine(..., new RnaDigestionParams(), ...);
    Assert.Throws<MetaMorpheusException>(() => indexEngine.Run());
}
```

Someone deliberately pinned the refusal. **This PR reverses that decision**, so the test becomes `IndexingEngine_IndexesRNA`. That inversion is the single line in this diff most deserving of a second opinion — if the refusal was protecting something I have not found, this is where it gets discussed.

## Why the change is small: the seams already existed

Almost nothing had to be invented. mzLib and the match layer were already generic:

| seam | state before this PR |
|---|---|
| `IBioPolymer.Digest(IDigestionParams, fixed, variable, silacLabels, turnoverLabels, topDown)` | already generic — **and already carries the SILAC parameters**, so one call serves proteins and nucleic acids |
| `IBioPolymerWithSetMods` | already exposes `Fragment(...)` and, via `IHasChemicalFormula`, `MonoisotopicMass` — everything the index reads |
| `SpectralMatch`, `PeptideSpectralMatch`, `OligoSpectralMatch` | **all three constructors already take `IBioPolymerWithSetMods`** |
| `ClassicSearchEngine` | already takes `List<IBioPolymer>`, already switches on `GlobalVariables.AnalyteType` to pick the match type |

So the work is type-widening plus copying a switch that classic search already makes. No new abstraction is introduced.

## The parameters are `IEnumerable`, and that is deliberate

The obvious move is a `List<Protein>` convenience overload next to a `List<IBioPolymer>` one, mirroring `ClassicSearchEngine`'s pair of constructors. **I tried that first and it is wrong here.** `List<T>` is invariant, so the overload is genuinely needed for the ~45 existing protein call sites — but it makes an empty collection expression ambiguous, and three existing tests broke with:

```
CS0121: The call is ambiguous between IndexingEngine(List<Protein>, ...)
        and IndexingEngine(List<IBioPolymer>, ...)
```

from `new IndexingEngine([], [], [], ...)`. `null` would have been ambiguous too. That is a wart every future caller would meet.

Taking `IEnumerable<IBioPolymer>` instead solves it properly: `IEnumerable<T>` is **covariant**, so `List<Protein>` binds implicitly, there is no overload, and nothing is ambiguous. The constructor materializes with `as List<...> ?? .ToList()`, so passing a `List` costs no copy.

The same reasoning applies to the three derived engines. Their constructors now take `IEnumerable<IBioPolymerWithSetMods>`, which is why **~20 protein call sites in `SearchEngineTests` and `XLTest` needed zero edits** — `List<PeptideWithSetModifications>` binds by covariance too.

The one place an overload survives is `GenerateIndexes`, because a `ref` parameter cannot be covariant. Overloads on a `ref` parameter type cannot be ambiguous (a `ref` argument must be a typed variable, never `null` or `[]`), so the wart above cannot recur there.

## Crosslink, glyco and non-specific stay proteomics-only

These are built around proteases and glycans — terminal mod placement, the "single" digestion agents, glycan boxes, the FDR categories. None has a nucleic acid counterpart, and `CrosslinkSearchEngine` already threw on non-protein digestion of its own accord. Generifying them speculatively would be a much larger change with nothing exercising it.

Each therefore keeps a peptide-typed view of the index that `ModernSearchEngine` now holds generically:

```csharp
protected new readonly List<PeptideWithSetModifications> PeptideIndex;
```

Two things to know about that:

- **It shadows the base field with `new`.** Same objects, narrower type; the derived bodies bind to the derived field and needed no other edits. Shadowing is a smell in general, so it is called out here rather than hidden — the alternative was rewriting several hundred lines of crosslink and glyco internals for no behavioural gain.
- **Where those engines call *base* methods** (`IndexedScoring`) they pass `base.PeptideIndex` explicitly, since the base signature wants the generic list. Three call sites, in crosslink and glyco.

Non-specific search now fails with a sentence instead of a cast exception:

> Non-specific search is only implemented for proteins. Use Classic or Modern search for nucleic acid databases.

That is the one behavioural change for proteins-adjacent paths, and it only fires on input that previously crashed anyway.

## The index cache is skipped for oligos

This is the only place the fix is a workaround rather than a fix, so it deserves the detail.

The on-disk peptide index round-trips through NetSerializer and is then relinked:

```csharp
peptide.SetNonSerializedPeptideInfo(GlobalVariables.AllModsKnownDictionary, proteinDictionary, storedDigestParams);
```

In mzLib, `PeptideWithSetModifications` is `[Serializable]` and has that method. **`OligoWithSetMods` has neither.** So the cache cannot hold oligos without an mzLib change — which means a version bump and a repackaging cycle before RNA modern search could work at all.

Instead, `GenerateIndexes` checks `GlobalVariables.AnalyteType != AnalyteType.Oligo` and, for oligos, runs the engine straight into memory without consulting or writing the cache. Nucleic acid databases are small enough that rebuilding each run costs nothing measurable.

Consequences, stated plainly:

- **No mzLib change is needed for this PR.** mzLib stays at 1.0.585, untouched.
- Oligo searches rebuild the index every run. For the databases people actually use, this is not noticeable.
- Protein caching is completely unchanged — same code path, same files, same reuse.
- If someone later wants oligo index caching, that is an mzLib PR adding `[Serializable]` and a parent-relink to `OligoWithSetMods`, and a small follow-up here to drop the check.

## Match type

`ModernSearchEngine` now makes the same choice `ClassicSearchEngine` makes at `ClassicSearchEngine.cs:241`:

```csharp
PeptideSpectralMatches[scanIndex] = GlobalVariables.AnalyteType == AnalyteType.Oligo
    ? new OligoSpectralMatch(...)
    : new PeptideSpectralMatch(...);
```

`AnalyteType` is set inside `MetaMorpheusEngine.Run()` from the engine's own `CommonParameters`, so this is correct for an engine constructed directly in a test as well as for one driven by a task.

## Tests

New file `Test/Transcriptomics/TestRnaModernSearch.cs`:

- `IndexingEngine_IndexesOligos` — the index digests RNA and bins its fragments; entries are `OligoWithSetMods`.
- `OligoIndex_BinsAreSortedByOligoId` — ids ascend within every fragment bin, and the peptide index is ordered by mass. **This one matters**: the search binary-searches a bin *by mass*, which is only valid because id order equals mass order. If that ever stopped holding for oligos, results would go quietly wrong rather than crash. The test also asserts it found multi-entry bins, so it cannot pass vacuously.
- `ModernSearch_FindsSimpleSixmer` — the payoff. Modern search finds the same GUACUG sixmer `TestRnaSearchEngine.FindsSimpleSixmer` finds with classic search, returns it as an `OligoSpectralMatch`, and clears the same score threshold (>22).

Changed: `IndexingEngine_ThrowsOnRNA` → `IndexingEngine_IndexesRNA`, as described above.

## Not covered

Stated so nobody assumes otherwise:

- **Non-specific search on RNA** — refused with a clear message, not implemented.
- **Crosslink and glyco on RNA** — unchanged, proteomics-only.
- **Oligo index caching** — needs the mzLib change described above.
- **No performance claim.** This is about making the path work. Whether modern search is *faster* than classic for realistic nucleic acid databases is unmeasured, and on small databases classic may well win.

## Relationship to #2758

#2758 rewrites `IndexingEngine` and `ModernSearchEngine` heavily (flat CSR fragment index, parallel build). **This PR is deliberately branched off `master`, not off #2758, so it can be reviewed on its own.** The two will conflict — whichever merges second needs a rebase. The conflicts are mechanical (both touch the same declarations, for different reasons) and I am happy to do that rebase in whichever order you prefer.
