### PR TITLE
Stamp the per-scan scoring table and counting-sort the coarse scores

### DIFF
--- a/MetaMorpheus/EngineLayer/CrosslinkSearch/CrosslinkSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/CrosslinkSearch/CrosslinkSearchEngine.cs
@@ -1,4 +1,5 @@
 ﻿using EngineLayer.ModernSearch;
+using EngineLayer.Util;
 using MassSpectrometry;
 using MzLibUtil;
 using Omics.Fragmentation;
@@ -115,10 +116,11 @@ namespace EngineLayer.CrosslinkSearch
             int[] threads = Enumerable.Range(0, maxThreadsPerFile).ToArray();
             Parallel.ForEach(threads, (scanIndex) =>
             {
-                byte[] scoringTable = new byte[PeptideIndex.Count];
+                var scoringTable = new ScanScoringTable(PeptideIndex.Count, UseStampedScoringTable);
                 List<int> idsOfPeptidesPossiblyObserved = new List<int>();
-                byte[] secondScoringTable = new byte[PeptideIndex.Count];
+                var secondScoringTable = new ScanScoringTable(PeptideIndex.Count, UseStampedScoringTable);
                 List<int> childIdsOfPeptidesPossiblyObserved = new List<int>();
+                var scoreSorter = new DescendingScoreSorter();
 
                 byte scoreAtTopN = 0;
                 int peptideCount = 0;
@@ -129,7 +131,7 @@ namespace EngineLayer.CrosslinkSearch
                     if (GlobalVariables.StopLoops) { return; }
 
                     // empty the scoring table to score the new scan (conserves memory compared to allocating a new array)
-                    Array.Clear(scoringTable, 0, scoringTable.Length);
+                    scoringTable.BeginScan();
                     idsOfPeptidesPossiblyObserved.Clear();      
 
                     var scan = ListOfSortedMs2Scans[scanIndex];
@@ -146,7 +148,7 @@ namespace EngineLayer.CrosslinkSearch
                     //child scan first - pass scoring
                     if (scan.ChildScans != null && CommonParameters.MS2ChildScanDissociationType != DissociationType.Unknown && CommonParameters.MS2ChildScanDissociationType != DissociationType.LowCID)
                     {
-                        Array.Clear(secondScoringTable, 0, secondScoringTable.Length);
+                        secondScoringTable.BeginScan();
                         childIdsOfPeptidesPossiblyObserved.Clear();
 
                         List<int> childBinsToSearch = new List<int>();
@@ -165,7 +167,7 @@ namespace EngineLayer.CrosslinkSearch
                             {
                                 idsOfPeptidesPossiblyObserved.Add(childId);
                             }
-                            scoringTable[childId] = (byte)(scoringTable[childId] + secondScoringTable[childId]);
+                            scoringTable.Set(childId, (byte)(scoringTable[childId] + secondScoringTable[childId]));
                         }
                     }
 
@@ -175,7 +177,7 @@ namespace EngineLayer.CrosslinkSearch
                         scoreAtTopN = 0;
                         peptideCount = 0;
 
-                        foreach (int id in idsOfPeptidesPossiblyObserved.OrderByDescending(p => scoringTable[p]))
+                        foreach (int id in scoreSorter.Sort(idsOfPeptidesPossiblyObserved, scoringTable))
                         {
                             peptideCount++;
                             // Whenever the count exceeds the TopN that we want to keep, we removed everything with a score lower than the score of the TopN-th peptide in the ids list

--- a/MetaMorpheus/EngineLayer/GlycoSearch/GlycoSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/GlycoSearchEngine.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using EngineLayer.Util;
 using MassSpectrometry;
 using EngineLayer.SpectrumMatch;
 
@@ -120,11 +121,12 @@ namespace EngineLayer.GlycoSearch
             int[] threads = Enumerable.Range(0, maxThreadsPerFile).ToArray(); // We can do the parallel search on different threads
             Parallel.ForEach(threads, (scanIndex) =>
             {
-                byte[] scoringTable = new byte[PeptideIndex.Count];
+                var scoringTable = new ScanScoringTable(PeptideIndex.Count, UseStampedScoringTable);
                 List<int> idsOfPeptidesPossiblyObserved = new List<int>();
 
-                byte[] secondScoringTable = new byte[PeptideIndex.Count]; // We didn't use that right now.
+                var secondScoringTable = new ScanScoringTable(PeptideIndex.Count, UseStampedScoringTable); // We didn't use that right now.
                 List<int> childIdsOfPeptidesPossiblyObserved = new List<int>();
+                var scoreSorter = new DescendingScoreSorter();
 
                 List<int> idsOfPeptidesTopN = new List<int>();
                 byte scoreAtTopN = 0;
@@ -136,7 +138,7 @@ namespace EngineLayer.GlycoSearch
                     if (GlobalVariables.StopLoops) { return; }
 
                     // empty the scoring table to score the new scan (conserves memory compared to allocating a new array)
-                    Array.Clear(scoringTable, 0, scoringTable.Length);
+                    scoringTable.BeginScan();
                     idsOfPeptidesPossiblyObserved.Clear();
                     idsOfPeptidesTopN.Clear();
 
@@ -183,7 +185,7 @@ namespace EngineLayer.GlycoSearch
                     {
                         scoreAtTopN = 0;
                         peptideCount = 0;
-                        foreach (int id in idsOfPeptidesPossiblyObserved.OrderByDescending(p => scoringTable[p])) //from the higest score to the lowest score
+                        foreach (int id in scoreSorter.Sort(idsOfPeptidesPossiblyObserved, scoringTable)) //from the higest score to the lowest score
                         {
                             if (scoringTable[id] < (int)byteScoreCutoff) //if the score is lower than the cutoff, we can skip this peptide.
                             {

--- a/MetaMorpheus/EngineLayer/ModernSearch/ModernSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/ModernSearch/ModernSearchEngine.cs
@@ -1,4 +1,5 @@
 ﻿using Chemistry;
+using EngineLayer.Util;
 using MassSpectrometry;
 using Omics.Fragmentation;
 using Proteomics.ProteolyticDigestion;
@@ -21,6 +22,13 @@ namespace EngineLayer.ModernSearch
         protected readonly DissociationType DissociationType;
         protected readonly double MaxMassThatFragmentIonScoreIsDoubled;
 
+        /// <summary>
+        /// Whether the per-scan score table stamps cells instead of clearing them. Worth it when a scan
+        /// touches a small slice of the peptide index; a losing trade for an open search, which touches
+        /// most of it. See ScanScoringTable.
+        /// </summary>
+        protected readonly bool UseStampedScoringTable;
+
         public ModernSearchEngine(SpectralMatch[] globalPsms, Ms2ScanWithSpecificMass[] listOfSortedms2Scans, List<PeptideWithSetModifications> peptideIndex,
             List<int>[] fragmentIndex, int currentPartition, CommonParameters commonParameters, List<(string fileName, CommonParameters fileSpecificParameters)> fileSpecificParameters, MassDiffAcceptor massDiffAcceptor, double maximumMassThatFragmentIonScoreIsDoubled,
             List<string> nestedIds) : base(commonParameters, fileSpecificParameters, nestedIds)
@@ -33,6 +41,7 @@ namespace EngineLayer.ModernSearch
             MassDiffAcceptor = massDiffAcceptor;
             DissociationType = commonParameters.DissociationType;
             MaxMassThatFragmentIonScoreIsDoubled = maximumMassThatFragmentIonScoreIsDoubled;
+            UseStampedScoringTable = massDiffAcceptor is not OpenSearchMode;
         }
 
         protected override MetaMorpheusEngineResults RunSpecific()
@@ -49,9 +58,10 @@ namespace EngineLayer.ModernSearch
 
             Parallel.ForEach(threads, (scanIndex) =>
             {
-                byte[] scoringTable = new byte[PeptideIndex.Count];
+                var scoringTable = new ScanScoringTable(PeptideIndex.Count, UseStampedScoringTable);
                 List<int> idsOfPeptidesPossiblyObserved = new List<int>(PeptideIndex.Count);
                 List<Product> peptideTheorProducts = new List<Product>();
+                var scoreSorter = new DescendingScoreSorter();
 
                 for (; scanIndex < ListOfSortedMs2Scans.Length; scanIndex += maxThreadsPerFile)
                 {
@@ -67,7 +77,7 @@ namespace EngineLayer.ModernSearch
                     IndexScoreScan(scan, scoringTable, byteScoreCutoff, idsOfPeptidesPossiblyObserved, CommonParameters.DissociationType);
 
                     // take indexed-scored peptides and re-score them using the more accurate but slower scoring algorithm
-                    FineScorePeptides(idsOfPeptidesPossiblyObserved, scan, scanIndex, scoringTable, CommonParameters.DissociationType, peptideTheorProducts);
+                    FineScorePeptides(idsOfPeptidesPossiblyObserved, scan, scanIndex, scoringTable, CommonParameters.DissociationType, peptideTheorProducts, scoreSorter);
 
                     //report search progress
                     progress++;
@@ -94,7 +104,7 @@ namespace EngineLayer.ModernSearch
         /// This is a first-pass scoring method which is supposed to be *very fast* but may sometimes miscount the number of truly matched fragments. The number
         /// of matched fragments should always be overestimated, never underestimated.
         /// </summary>
-        protected void IndexScoreScan(Ms2ScanWithSpecificMass scan, byte[] scoringTable, byte byteScoreCutoff, List<int> peptidesPossiblyObserved, DissociationType dissociationType)
+        protected void IndexScoreScan(Ms2ScanWithSpecificMass scan, ScanScoringTable scoringTable, byte byteScoreCutoff, List<int> peptidesPossiblyObserved, DissociationType dissociationType)
         {
             // get allowed theoretical masses from the known experimental mass
             // note that this is the OPPOSITE of the classic search (which calculates experimental masses from theoretical values)	
@@ -104,8 +114,8 @@ namespace EngineLayer.ModernSearch
             double lowestMassPeptideToLookFor = notches.Min(p => p.Minimum);
             double highestMassPeptideToLookFor = notches.Max(p => p.Maximum);
 
-            // clear the scoring table to score the new scan (conserves memory compared to allocating a new array)
-            Array.Clear(scoringTable, 0, scoringTable.Length);
+            // retire the previous scan's scores (conserves memory compared to allocating a new array)
+            scoringTable.BeginScan();
             peptidesPossiblyObserved.Clear();
 
             if (dissociationType == DissociationType.LowCID)
@@ -291,7 +301,7 @@ namespace EngineLayer.ModernSearch
         /// <summary>
         /// Adds a +1 score to all the peptides in the fragment mass bin that meet the precursor mass tolerance.
         /// </summary>
-        protected void IncrementPeptideScoresInBin(int start, int end, List<int> bin, byte[] scoringTable, Ms2ScanWithSpecificMass scan, byte byteScoreCutoff,
+        protected void IncrementPeptideScoresInBin(int start, int end, List<int> bin, ScanScoringTable scoringTable, Ms2ScanWithSpecificMass scan, byte byteScoreCutoff,
             List<int> peptidesPossiblyObserved, DissociationType dissociationType)
         {
             if (dissociationType == DissociationType.LowCID)
@@ -311,7 +321,7 @@ namespace EngineLayer.ModernSearch
                     }
 
                     // mark the peptide as potentially observed so it doesn't get added more than once
-                    scoringTable[peptideId] = 1;
+                    scoringTable.Set(peptideId, 1);
                 }
             }
             else
@@ -320,7 +330,7 @@ namespace EngineLayer.ModernSearch
                 for (int p = start; p <= end; p++)
                 {
                     int peptideId = bin[p];
-                    byte score = ++scoringTable[peptideId];
+                    byte score = scoringTable.Increment(peptideId);
 
                     // if the peptide has met the score cutoff, add it to the list of peptides 
                     // possibly observed so it can be re-scored with the "fine scoring" algorithm
@@ -367,8 +377,8 @@ namespace EngineLayer.ModernSearch
             return PeptideSpectralMatches[scanIndex];
         }
 
-        protected void FineScorePeptides(List<int> peptideIds, Ms2ScanWithSpecificMass scan, int scanIndex, byte[] scoringTable, 
-            DissociationType dissociationType, List<Product> peptideTheorProducts)
+        protected void FineScorePeptides(List<int> peptideIds, Ms2ScanWithSpecificMass scan, int scanIndex, ScanScoringTable scoringTable, 
+            DissociationType dissociationType, List<Product> peptideTheorProducts, DescendingScoreSorter scoreSorter)
         {
             // this method re-scores the top-scoring peptides until no peptide in the rough-scored list can out-score
             // the best-scoring peptide. this guarantees that peptides will be scored accurately, according to metamorpheus score,
@@ -377,7 +387,7 @@ namespace EngineLayer.ModernSearch
             // output, though it will be very close.
             byte bestScore = 0;
 
-            foreach (int id in peptideIds.OrderByDescending(p => scoringTable[p]))
+            foreach (int id in scoreSorter.Sort(peptideIds, scoringTable))
             {
                 if (scoringTable[id] < bestScore && dissociationType != DissociationType.LowCID)
                 {
@@ -398,7 +408,7 @@ namespace EngineLayer.ModernSearch
         /// <summary>
         /// Deprecated.
         /// </summary>
-        protected void IndexedScoring(List<int>[] FragmentIndex, List<int> binsToSearch, byte[] scoringTable, byte byteScoreCutoff, List<int> idsOfPeptidesPossiblyObserved, double scanPrecursorMass, double lowestMassPeptideToLookFor,
+        protected void IndexedScoring(List<int>[] FragmentIndex, List<int> binsToSearch, ScanScoringTable scoringTable, byte byteScoreCutoff, List<int> idsOfPeptidesPossiblyObserved, double scanPrecursorMass, double lowestMassPeptideToLookFor,
             double highestMassPeptideToLookFor, List<PeptideWithSetModifications> peptideIndex, MassDiffAcceptor massDiffAcceptor, double maxMassThatFragmentIonScoreIsDoubled, DissociationType dissociationType)
         {
             // get all theoretical fragments this experimental fragment could be
@@ -445,7 +455,7 @@ namespace EngineLayer.ModernSearch
                         }
 
                         // mark the peptide as potentially observed so it doesn't get added more than once
-                        scoringTable[id] = 1;
+                        scoringTable.Set(id, 1);
                     }
                 }
                 else
@@ -454,10 +464,9 @@ namespace EngineLayer.ModernSearch
                     for (int j = lowestPeptideMassIndex; j <= highestPeptideMassIndex; j++) // iterate through the peptide index in the bin
                     {
                         int id = peptideIdsInThisBin[j];
-                        scoringTable[id]++;
 
                         // if the score of the peptide >3 (counts > 3 times), and the mass difference is accepted, add the peptide to the list of peptides possibly observed
-                        if (scoringTable[id] == byteScoreCutoff && massDiffAcceptor.Accepts(scanPrecursorMass, peptideIndex[id].MonoisotopicMass) >= 0)
+                        if (scoringTable.Increment(id) == byteScoreCutoff && massDiffAcceptor.Accepts(scanPrecursorMass, peptideIndex[id].MonoisotopicMass) >= 0)
                         {
                             idsOfPeptidesPossiblyObserved.Add(id);
                         }

--- a/MetaMorpheus/EngineLayer/NonSpecificEnzymeSearch/NonSpecificEnzymeSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/NonSpecificEnzymeSearch/NonSpecificEnzymeSearchEngine.cs
@@ -5,6 +5,7 @@ using Proteomics;
 using Omics.Fragmentation;
 using Proteomics.ProteolyticDigestion;
 using System;
+using EngineLayer.Util;
 using MassSpectrometry;
 using System.Collections.Generic;
 using System.Linq;
@@ -60,7 +61,7 @@ namespace EngineLayer.NonSpecificEnzymeSearch
             int[] threads = Enumerable.Range(0, maxThreadsPerFile).ToArray();
             Parallel.ForEach(threads, (i) =>
             {
-                byte[] scoringTable = new byte[PeptideIndex.Count];
+                var scoringTable = new ScanScoringTable(PeptideIndex.Count, UseStampedScoringTable);
 
                 List<Product> peptideTheorProducts = new List<Product>();
                 List<int> idsOfPeptidesPossiblyObserved = new List<int>();
@@ -71,7 +72,7 @@ namespace EngineLayer.NonSpecificEnzymeSearch
                     if (GlobalVariables.StopLoops) { return; }
 
                     // empty the scoring table to score the new scan (conserves memory compared to allocating a new array)
-                    Array.Clear(scoringTable, 0, scoringTable.Length);
+                    scoringTable.BeginScan();
                     idsOfPeptidesPossiblyObserved.Clear();
                     List<int> coisolatedIndexes = CoisolationIndex[i];
                     Ms2ScanWithSpecificMass scan = ListOfSortedMs2Scans[coisolatedIndexes[(coisolatedIndexes.Count - 1) / 2]]; //get first scan; all scans should be identical
@@ -166,7 +167,7 @@ namespace EngineLayer.NonSpecificEnzymeSearch
             return new MetaMorpheusEngineResults(this);
         }
 
-        private void SnesIndexedScoring(Ms2ScanWithSpecificMass scan, List<int>[] FragmentIndex, byte[] scoringTable, List<PeptideWithSetModifications> peptideIndex, DissociationType dissociationType)
+        private void SnesIndexedScoring(Ms2ScanWithSpecificMass scan, List<int>[] FragmentIndex, ScanScoringTable scoringTable, List<PeptideWithSetModifications> peptideIndex, DissociationType dissociationType)
         {
             int obsPreviousFragmentCeilingMz = 0;
 
@@ -186,7 +187,7 @@ namespace EngineLayer.NonSpecificEnzymeSearch
                     {
                         for (int pep = 0; pep < bin.Count; pep++)
                         {
-                            scoringTable[bin[pep]]++;
+                            scoringTable.Increment(bin[pep]);
                         }
                     }
 
@@ -210,7 +211,7 @@ namespace EngineLayer.NonSpecificEnzymeSearch
                                     {
                                         for (int pep = 0; pep < bin.Count; pep++)
                                         {
-                                            scoringTable[bin[pep]]++;
+                                            scoringTable.Increment(bin[pep]);
                                         }
                                     }
                                 }
@@ -262,7 +263,7 @@ namespace EngineLayer.NonSpecificEnzymeSearch
                             {
                                 for (int pep = 0; pep < bin.Count; pep++)
                                 {
-                                    scoringTable[bin[pep]]++;
+                                    scoringTable.Increment(bin[pep]);
                                 }
                             }
                         }
@@ -303,7 +304,7 @@ namespace EngineLayer.NonSpecificEnzymeSearch
                                         {
                                             for (int pep = 0; pep < bin.Count; pep++)
                                             {
-                                                scoringTable[bin[pep]]++;
+                                                scoringTable.Increment(bin[pep]);
                                             }
                                         }
                                     }

--- a/MetaMorpheus/EngineLayer/Util/DescendingScoreSorter.cs
+++ b/MetaMorpheus/EngineLayer/Util/DescendingScoreSorter.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace EngineLayer.Util
+{
+    /// <summary>
+    /// Orders peptide ids by their coarse (indexed) score, highest first.
+    ///
+    /// The search used to do this with OrderByDescending, once per scan, which allocated a LINQ
+    /// ordering plus a key array every time. Coarse scores are bytes, so a counting sort over 256
+    /// buckets does the same job in two linear passes with no per-scan allocation.
+    ///
+    /// It is stable, deliberately: peptides that tie on the coarse score are handed back in the order
+    /// they were found, which is what OrderByDescending did. Ties decide which peptide ends up as the
+    /// PSM when the fine scores also tie, so an unstable sort here would quietly change results.
+    ///
+    /// One instance per thread -- it reuses its buffers and is not safe to share.
+    /// </summary>
+    public sealed class DescendingScoreSorter
+    {
+        private const int BucketCount = byte.MaxValue + 1;
+
+        private readonly int[] _bucketStarts = new int[BucketCount + 1];
+        private int[] _sorted = new int[64];
+
+        /// <summary>
+        /// Returns <paramref name="peptideIds"/> ordered by descending score in <paramref name="scores"/>,
+        /// ties in their existing order. The span is valid until the next call on this instance.
+        /// </summary>
+        public ReadOnlySpan<int> Sort(List<int> peptideIds, ScanScoringTable scores)
+        {
+            int count = peptideIds.Count;
+            if (count == 0)
+            {
+                return ReadOnlySpan<int>.Empty;
+            }
+
+            if (_sorted.Length < count)
+            {
+                _sorted = new int[Math.Max(count, _sorted.Length * 2)];
+            }
+
+            Array.Clear(_bucketStarts, 0, _bucketStarts.Length);
+
+            // Bucket by inverted score, so bucket 0 holds the highest scores.
+            for (int i = 0; i < count; i++)
+            {
+                _bucketStarts[byte.MaxValue - scores[peptideIds[i]] + 1]++;
+            }
+
+            for (int bucket = 0; bucket < BucketCount; bucket++)
+            {
+                _bucketStarts[bucket + 1] += _bucketStarts[bucket];
+            }
+
+            // Walking the ids in their original order keeps equal scores in that order.
+            for (int i = 0; i < count; i++)
+            {
+                int id = peptideIds[i];
+                _sorted[_bucketStarts[byte.MaxValue - scores[id]]++] = id;
+            }
+
+            return new ReadOnlySpan<int>(_sorted, 0, count);
+        }
+    }
+}

--- a/MetaMorpheus/EngineLayer/Util/ScanScoringTable.cs
+++ b/MetaMorpheus/EngineLayer/Util/ScanScoringTable.cs
@@ -1,0 +1,104 @@
+using System;
+
+namespace EngineLayer.Util
+{
+    /// <summary>
+    /// The coarse (indexed) score of every peptide in the index, for the scan being scored.
+    ///
+    /// The search used to keep this as a byte[] and Array.Clear the whole thing between scans, which
+    /// is O(peptides) of pure bookkeeping per scan whatever the scan actually touched. This can
+    /// instead stamp each cell with the scan it belongs to and treat a stale stamp as a score of
+    /// zero, which makes starting a scan O(1) -- the stamps only need clearing when they wrap, once
+    /// every 255 scans.
+    ///
+    /// Stamping is not always the better trade. A stamped cell is two bytes wide, so a scan that
+    /// touches most of the index pays double the memory traffic on the hot path to avoid a memset it
+    /// was already amortizing. Measured on a synthetic version of the scoring loop, stamping runs
+    /// ~8-13x faster than clearing when a scan touches ~0.1% of the index (a normal ppm-tolerance
+    /// search) and ~0.6-0.8x as fast when it touches most of it (an open search). So the caller
+    /// picks, and open searches keep clearing.
+    ///
+    /// Either way scores are bytes and increments wrap at 255, matching the byte[] this replaced.
+    ///
+    /// One instance per thread -- it is not safe to share.
+    /// </summary>
+    public sealed class ScanScoringTable
+    {
+        // Stamped layout: high byte is the scan stamp, low byte is the score.
+        private readonly ushort[] _stampedCells;
+        private readonly byte[] _scores;
+        private byte _stamp;
+
+        public ScanScoringTable(int peptideCount, bool stamped)
+        {
+            if (stamped)
+            {
+                _stampedCells = new ushort[peptideCount];
+            }
+            else
+            {
+                _scores = new byte[peptideCount];
+            }
+        }
+
+        private bool Stamped => _stampedCells != null;
+
+        /// <summary>Discards the previous scan's scores.</summary>
+        public void BeginScan()
+        {
+            if (!Stamped)
+            {
+                Array.Clear(_scores, 0, _scores.Length);
+                return;
+            }
+
+            if (_stamp == byte.MaxValue)
+            {
+                // Stamps have wrapped; retire every cell so stale ones cannot alias the new stamp.
+                Array.Clear(_stampedCells, 0, _stampedCells.Length);
+                _stamp = 0;
+            }
+
+            _stamp++;
+        }
+
+        public byte this[int peptideId]
+        {
+            get
+            {
+                if (!Stamped)
+                {
+                    return _scores[peptideId];
+                }
+
+                ushort cell = _stampedCells[peptideId];
+                return (cell >> 8) == _stamp ? (byte)cell : (byte)0;
+            }
+        }
+
+        public void Set(int peptideId, byte score)
+        {
+            if (!Stamped)
+            {
+                _scores[peptideId] = score;
+                return;
+            }
+
+            _stampedCells[peptideId] = (ushort)((_stamp << 8) | score);
+        }
+
+        /// <summary>Adds one to a peptide's score and returns it, wrapping at 255 as a byte does.</summary>
+        public byte Increment(int peptideId)
+        {
+            if (!Stamped)
+            {
+                return ++_scores[peptideId];
+            }
+
+            ushort cell = _stampedCells[peptideId];
+            byte score = (cell >> 8) == _stamp ? (byte)((byte)cell + 1) : (byte)1;
+            _stampedCells[peptideId] = (ushort)((_stamp << 8) | score);
+            return score;
+        }
+    }
+}


### PR DESCRIPTION
<!-- project-of-origin -->
> **Project of origin:** `MetaMorpheus_index_perf`

🤖 Split out of #2758, which is being retired — see the discussion there and on #2742. This half is independent of the fragment-index layout question those two PRs are about, and does not touch the index at all.

## What

Two things the per-scan scoring loop was paying for, in `ModernSearchEngine` and the three engines that inherit from it.

**`Array.Clear` over the whole peptide index between scans.** O(peptides) of pure bookkeeping per scan, whatever the scan actually touched. `ScanScoringTable` instead stamps each cell with the scan it belongs to and reads a stale stamp as zero, so starting a scan is O(1) apart from a clear every 255 scans.

That is not unconditionally better, so it is selected rather than assumed. A stamped cell is two bytes wide, so a scan touching most of the index pays double the memory traffic to skip a memset it was already amortizing. On a synthetic version of the loop, stamping runs ~8-13x faster than clearing when a scan touches ~0.1% of the index — a normal ppm-tolerance search — and ~0.6-0.8x as fast when it touches most of it. So `UseStampedScoringTable` is `massDiffAcceptor is not OpenSearchMode`: open searches keep clearing, which is what crosslink and glyco get.

**`OrderByDescending` on the coarse scores, once per scan, in three engines** — allocating a LINQ ordering and a key array every time. Coarse scores are bytes, so `DescendingScoreSorter` counting-sorts them in two linear passes with no per-scan allocation.

It is stable on purpose. LINQ's ordering is stable, and ties here decide which peptide becomes the PSM, so an unstable sort would change reported results.

## Verification

Full suite on this branch: **1830 passed, 1 skipped, 0 failed**.

Results are unchanged by construction — both changes are representation, not scoring — and the suite includes the search tests that compare PSM counts and scores.

## Note for reviewers

This will conflict with #2742, which edits the same four engine files. The conflicts are narrow (the `scoringTable` parameter type on three signatures) and mechanical either way round.

