### PR TITLE
Name the LoadRnaXML arguments so the thread count stops binding to a variant limit

### DIFF
--- a/MetaMorpheus/EngineLayer/DatabaseLoading/DatabaseLoadingEngine.cs
+++ b/MetaMorpheus/EngineLayer/DatabaseLoading/DatabaseLoadingEngine.cs
@@ -148,7 +148,20 @@ public class DatabaseLoadingEngine(
             GlobalVariables.AddMods(ProteinDbLoader.GetPtmListFromProteinXml(fileName), true, true);
             // TODO: Add in variant params when fixed in MzLib. 
             List<string> modTypesToExclude = GlobalVariables.AllRnaModTypesKnown.Where(b => !localizeableModificationTypes.Contains(b)).ToList();
-            rnaList = RnaDbLoader.LoadRnaXML(fileName, generateTargets, decoyType, isContaminant, GlobalVariables.AllRnaModsKnown, modTypesToExclude, out unknownMods, commonParameters.MaxThreadsToUsePerFile, decoyIdentifier: decoyIdentifier);
+            // Named, not positional. LoadRnaXML orders these as (maxHeterozygousVariants, minAlleleDepth,
+            // maxThreads); LoadProteinXML below orders them as (maxThreads, maxHeterozygousVariants,
+            // minAlleleDepth). Passing the thread count positionally here bound it to
+            // maxHeterozygousVariants, so decoy generation ran at maxThreads = 1 and the variant
+            // combinatorics limit was whatever thread count the run happened to use. Every parameter
+            // involved is a defaulted int, so nothing warned. See #2762.
+            //
+            // maxHeterozygousVariants: 0 matches the protein path below rather than taking mzLib's
+            // default of 4 -- the value has to become something, and 0 is the choice already made here.
+            rnaList = RnaDbLoader.LoadRnaXML(fileName, generateTargets, decoyType, isContaminant,
+                GlobalVariables.AllRnaModsKnown, modTypesToExclude, out unknownMods,
+                maxHeterozygousVariants: 0,
+                maxThreads: commonParameters.MaxThreadsToUsePerFile,
+                decoyIdentifier: decoyIdentifier);
         }
 
         emptyEntriesCount = rnaList.Count(p => p.BaseSequence.Length == 0);


### PR DESCRIPTION
🤖 Closes #2762. One call site, arguments named instead of positional.

## The bug

`DatabaseLoadingEngine.cs:151` passed `commonParameters.MaxThreadsToUsePerFile` as the eighth positional argument to `RnaDbLoader.LoadRnaXML`. Parameter eight is `maxHeterozygousVariants`; `maxThreads` is parameter ten.

```
LoadRnaXML     ... out unknownModifications, maxHeterozygousVariants, minAlleleDepth, maxThreads, ...
LoadProteinXML ... out unknownModifications, maxThreads, maxHeterozygousVariants, minAlleleDepth, ...
```

Same three concepts, opposite order. The protein call five lines below binds correctly; the RNA call was written as though the two matched. Every parameter involved is a defaulted `int`, so nothing warned and nothing failed.

Consequences on master:

- **RNA XML decoy generation ran single-threaded.** `maxThreads` kept its default of `1`, so `RnaDecoyGenerator.GenerateDecoys` never saw the configured thread count.
- **Variant expansion depth was set by the thread count.** The same database and the same task produced different variant RNA on a 4-thread configuration than on a 16-thread one. That is machine-dependent output rather than data-dependent — the same class of problem as smith-chem-wisc/mzLib#1155.

## This changes RNA variant output

Unavoidably. Today's `maxHeterozygousVariants` is whatever `MaxThreadsToUsePerFile` happened to be, so any fix has to replace it with something.

I used `maxHeterozygousVariants: 0`, matching the choice the protein path already makes explicitly on the line below, rather than letting it fall back to mzLib's default of `4`. That is a judgement call and a one-word change in review if you would rather have `4` — but 0 is the value this file has already chosen for the equivalent protein parameter, with the original still visible commented out above it.

Nothing else about RNA loading changes.

## Deliberately not fixed here

The protein path wires `minAlleleDepth` from `commonParameters.MinVariantDepth`; the RNA path takes mzLib's default of `1`. That inconsistency is real and survives this PR. It is a separate decision about what RNA searches should do, not part of the binding bug, so it stays out — and the `// TODO: Add in variant params when fixed in MzLib.` comment above the call is left in place because it is still true.

## Verification

`dotnet build MetaMorpheus.sln -c UbuntuMac -p:EnableWindowsTargeting=true` — 0 errors.

Not verified: the RNA search tests, which are Windows-targeted, so CI is the check. Worth watching whether any RNA variant expectation moves — if one does, that is this fix taking effect rather than breaking something, since the previous value depended on the thread count of whatever machine recorded the expectation.
