### PR TITLE
Make IntensitiesByFile drop isobaric samples, as its companion view already does

### DIFF
--- a/MetaMorpheus/EngineLayer/ProteinParsimony/ProteinGroup.cs
+++ b/MetaMorpheus/EngineLayer/ProteinParsimony/ProteinGroup.cs
@@ -113,11 +113,16 @@ namespace EngineLayer
         /// Snapshot view of <see cref="BioPolymerGroup.IntensitiesBySample"/> keyed by SpectraFileInfo.
         /// The getter returns a fresh read-only copy on every call, so mutating the returned value has no
         /// effect on the protein group; assign a new dictionary through the setter to change it.
-        /// SpectraFileInfo only: the getter throws if an isobaric sample is present.
+        /// SpectraFileInfo only: isobaric samples are dropped by the getter, so a round-trip loses them.
+        /// This matches <see cref="FilesForQuantification"/>, which is the companion view over the same
+        /// backing store -- the two describe the same subset and should agree on what happens to a
+        /// sample they cannot represent.
         /// </summary>
         public IReadOnlyDictionary<SpectraFileInfo, double> IntensitiesByFile
         {
-            get => IntensitiesBySample?.ToDictionary(kvp => (SpectraFileInfo)kvp.Key, kvp => kvp.Value);
+            get => IntensitiesBySample?
+                .Where(kvp => kvp.Key is SpectraFileInfo)
+                .ToDictionary(kvp => (SpectraFileInfo)kvp.Key, kvp => kvp.Value);
             set => IntensitiesBySample = value?.ToDictionary(kvp => (ISampleInfo)kvp.Key, kvp => kvp.Value);
         }
 

--- a/MetaMorpheus/Test/ProteinGroupIsobaricViewTests.cs
+++ b/MetaMorpheus/Test/ProteinGroupIsobaricViewTests.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using EngineLayer;
+using MassSpectrometry;
+using NUnit.Framework;
+using Omics;
+using Proteomics;
+
+namespace Test
+{
+    /// <summary>
+    /// ProteinGroup exposes two SpectraFileInfo-shaped views over the base class's sample-keyed
+    /// quantification store: FilesForQuantification and IntensitiesByFile. Isobaric quantification
+    /// puts IsobaricQuantSampleInfo into that store -- one entry per channel rather than per file --
+    /// so both views have to answer for a sample they cannot represent, and they have to answer the
+    /// same way.
+    /// </summary>
+    [TestFixture]
+    [ExcludeFromCodeCoverage]
+    public class ProteinGroupIsobaricViewTests
+    {
+        private const string File = "tmt.raw";
+
+        private static ProteinGroup GroupWith(params ISampleInfo[] samples)
+        {
+            var protein = new Protein("PEPTIDEK", "P1");
+            var group = new ProteinGroup(
+                new HashSet<IBioPolymer> { protein },
+                new HashSet<IBioPolymerWithSetMods>(),
+                new HashSet<IBioPolymerWithSetMods>());
+
+            group.SamplesForQuantification = samples.ToList();
+            group.IntensitiesBySample = samples
+                .Select((s, i) => (s, v: 100.0 * (i + 1)))
+                .ToDictionary(t => t.s, t => t.v);
+
+            return group;
+        }
+
+        private static IsobaricQuantSampleInfo Channel(string label, double mz) =>
+            new IsobaricQuantSampleInfo(File, "Control", 0, 0, 0, 0, label, mz, false);
+
+        [Test]
+        public void IntensitiesByFile_DropsIsobaricChannelsInsteadOfThrowing()
+        {
+            var group = GroupWith(Channel("126", 126.0), Channel("127N", 127.1));
+
+            // Previously a hard cast: reading this after an isobaric search threw
+            // InvalidCastException from inside the ordinary output path.
+            IReadOnlyDictionary<SpectraFileInfo, double> byFile = null;
+            Assert.DoesNotThrow(() => byFile = group.IntensitiesByFile);
+            Assert.That(byFile, Is.Empty);
+        }
+
+        [Test]
+        public void TheTwoFileViewsAgreeOnWhatTheyDrop()
+        {
+            var labelFree = new SpectraFileInfo(File, "Control", 0, 0, 0);
+            var group = GroupWith(labelFree, Channel("126", 126.0), Channel("127N", 127.1));
+
+            // FilesForQuantification has always filtered; IntensitiesByFile now does too, so a caller
+            // reading both sees the same set of files rather than one view succeeding and the other
+            // throwing on identical data.
+            Assert.Multiple(() =>
+            {
+                Assert.That(group.FilesForQuantification, Is.EqualTo(new[] { labelFree }));
+                Assert.That(group.IntensitiesByFile.Keys, Is.EqualTo(new[] { labelFree }));
+                Assert.That(group.IntensitiesByFile[labelFree], Is.EqualTo(100.0));
+            });
+        }
+
+        [Test]
+        public void LabelFreeQuantificationIsUnaffected()
+        {
+            var a = new SpectraFileInfo("a.raw", "Control", 0, 0, 0);
+            var b = new SpectraFileInfo("b.raw", "Treated", 1, 0, 0);
+            var group = GroupWith(a, b);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(group.IntensitiesByFile, Has.Count.EqualTo(2));
+                Assert.That(group.IntensitiesByFile[a], Is.EqualTo(100.0));
+                Assert.That(group.IntensitiesByFile[b], Is.EqualTo(200.0));
+            });
+        }
+    }
+}


### PR DESCRIPTION
`ProteinGroup` exposes two `SpectraFileInfo`-shaped views over the base class's sample-keyed quantification store. They disagree about what to do with a sample they cannot represent:

```csharp
// :108
public IReadOnlyList<SpectraFileInfo> FilesForQuantification
    => SamplesForQuantification?.OfType<SpectraFileInfo>().ToList();

// :120
public IReadOnlyDictionary<SpectraFileInfo, double> IntensitiesByFile
    => IntensitiesBySample?.ToDictionary(kvp => (SpectraFileInfo)kvp.Key, kvp => kvp.Value);
```

The first filters. The second casts, and throws `InvalidCastException` on an `IsobaricQuantSampleInfo`.

**Both behaviours are documented**, twelve lines apart — *"isobaric samples are dropped by the getter"* on one and *"the getter throws if an isobaric sample is present"* on the other. So this was a deliberate choice, not an oversight, and I want to be clear that I am arguing against a decision rather than reporting a slip.

### Why the choice is now the wrong one

It is unreachable on master today, because nothing puts isobaric samples into that store. It becomes reachable the moment mzLib's `QuantificationEngine` writes per-channel intensities onto a protein group — which is what #2755 does.

The failure is not graceful. The read happens on the ordinary output path:

```
System.InvalidCastException : Unable to cast object of type
'MassSpectrometry.IsobaricQuantSampleInfo' to type 'MassSpectrometry.SpectraFileInfo'
   at TaskLayer.PostSearchAnalysisTask.Run()
```

So a TMT search **crashes**, rather than simply not populating a file-keyed view that could never have held channels anyway. "Fail loudly" is a reasonable instinct, but the thing it fails on is a caller doing something correct.

### Why filtering

It makes the pair consistent, which is the part that matters more than either behaviour on its own. A caller reading both views on the same data currently gets one success and one exception; afterwards it gets the same set of files from both.

Dropping is also the honest answer: `IntensitiesByFile` is keyed by `SpectraFileInfo` and one file carries many channels, so there is no correct value to return for them. `IntensitiesBySample` is where that data lives, and it is unaffected.

### Scope

One property getter, one comment. `IntensitiesBySample`, `SamplesForQuantification` and label-free quantification are all untouched.

Three tests: the isobaric-only case that used to throw, a mixed case asserting the two views agree on what they drop, and a label-free case pinning that ordinary quantification is unchanged.

### Why this is its own PR

It was found by #2755's end-to-end TMT tests, and it would have been easy to fix in passing there. But it is a bug in master's own code, on the FlashLFQ output path, and nobody reviewing a quantification-engine PR would look for it. It should be reviewable on its own terms — and #2755 is blocked until it lands.