### PR TITLE
Bump mzLib to 1.0.587

### DIFF
--- a/MetaMorpheus/CMD/CMD.csproj
+++ b/MetaMorpheus/CMD/CMD.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.585" />
+    <PackageReference Include="mzLib" Version="1.0.587" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.118" />

--- a/MetaMorpheus/EngineLayer/EngineLayer.csproj
+++ b/MetaMorpheus/EngineLayer/EngineLayer.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.585" />
+    <PackageReference Include="mzLib" Version="1.0.587" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />

--- a/MetaMorpheus/GUI/GUI.csproj
+++ b/MetaMorpheus/GUI/GUI.csproj
@@ -62,7 +62,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.585" />
+    <PackageReference Include="mzLib" Version="1.0.587" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0" />

--- a/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
+++ b/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="itext7" Version="9.7.0" />
     <PackageReference Include="itext7.bouncy-castle-adapter" Version="9.7.0" />
-    <PackageReference Include="mzLib" Version="1.0.585" />
+    <PackageReference Include="mzLib" Version="1.0.587" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.0.0" />
     <PackageReference Include="Svg" Version="3.4.7" />
   </ItemGroup>

--- a/MetaMorpheus/MetaMorpheusSetup/Product.wxs
+++ b/MetaMorpheus/MetaMorpheusSetup/Product.wxs
@@ -149,6 +149,12 @@
       <Component Id="src_Newtonsoft.Json.dll" Guid="7001FD86-E768-4C32-9747-0AB44A5A3DE9">
         <File Id="src_Newtonsoft.Json.dll" Name="Newtonsoft.Json.dll" Source="$(var.GUI_TargetDir)Newtonsoft.Json.dll" />
       </Component>
+      <!-- Arrives with mzLib, which declared ZstdSharp.Port in its nuspec from 1.0.586 (mzLib #1179).
+           MetaMorpheus stayed on 1.0.585 until this bump, so this is the first build where the DLL
+           is actually restored into the output and therefore has to be installed. -->
+      <Component Id="src_ZstdSharp.dll" Guid="74BE256C-F581-4DA7-90C8-4D76E2FAA59D">
+        <File Id="src_ZstdSharp.dll" Name="ZstdSharp.dll" Source="$(var.GUI_TargetDir)ZstdSharp.dll" />
+      </Component>
       <Component Id="src_UsefulProteomicsDatabases.dll" Guid="e7f76fbf-d21c-4e57-bed4-33f71822ee18">
         <File Id="src_UsefulProteomicsDatabases.dll" Name="UsefulProteomicsDatabases.dll" Source="$(var.GUI_TargetDir)UsefulProteomicsDatabases.dll" />
       </Component>

--- a/MetaMorpheus/TaskLayer/TaskLayer.csproj
+++ b/MetaMorpheus/TaskLayer/TaskLayer.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.585" />
+    <PackageReference Include="mzLib" Version="1.0.587" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />

--- a/MetaMorpheus/Test/Test.csproj
+++ b/MetaMorpheus/Test/Test.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.585" />
+    <PackageReference Include="mzLib" Version="1.0.587" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />


### PR DESCRIPTION
Nothing but the version, in all six csprojs. Reviewable on its own and merges without waiting on anything else in the quant batch.

Master has been on `1.0.585` across two mzLib releases.

## What 1.0.587 carries that an existing caller would notice

Three things, and MetaMorpheus is exposed to none of them — worth stating explicitly rather than asserting the bump is safe:

- **`QuantifiedPeaks.tsv` gains `Peak FWHM` and `Peak FWHM Status`** ([mzLib #1180](https://github.com/smith-chem-wisc/mzLib/pull/1180)), inserted mid-row. Anything parsing that file *by column index* reads the wrong field. MetaMorpheus writes the file through FlashLFQ and does not parse it back.
- **`QuantificationEngine` now excludes ambiguous spectral matches** ([mzLib #1210](https://github.com/smith-chem-wisc/mzLib/pull/1210)). `PostSearchAnalysisTask` already passes `includeAmbiguous: false` at its own call site, so it was never taking that path.
- **`SumCollapse`, `MeanCollapse` and `SumRollUp.ArrayPool` were removed** ([mzLib #1194](https://github.com/smith-chem-wisc/mzLib/pull/1194), [#1211](https://github.com/smith-chem-wisc/mzLib/pull/1211)). Master references none of them — `grep` for all three comes back empty.

The full release notes are on [mzLib 1.0.587](https://github.com/smith-chem-wisc/mzLib/releases/tag/1.0.587).

## Why separately

Four quant PRs behind this one each needed the same bump, and were each carrying it. Landing it once here means their diffs are about what they actually do, and none of them has to be reviewed with a version change stapled to the front.

## Verification

CI is the verification that counts. A local build proves nothing on this machine — `E:\NugetLocal` is a registered source holding development builds with deliberately high version numbers, so a csproj asking for a version that is not on nuget.org does not fail: NuGet emits `NU1603` and silently floats *up* to the local package. `1.0.587` is confirmed live on nuget.org (`api.nuget.org/v3-flatcontainer/mzlib/1.0.587/mzlib.1.0.587.nupkg` returns 200).