### PR TITLE
Write calibrated spectra as mgf (#1673)

### DIFF
--- a/MetaMorpheus/CMD/CMD.csproj
+++ b/MetaMorpheus/CMD/CMD.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.585" />
+    <PackageReference Include="mzLib" Version="1.0.586" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.118" />

--- a/MetaMorpheus/EngineLayer/EngineLayer.csproj
+++ b/MetaMorpheus/EngineLayer/EngineLayer.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.585" />
+    <PackageReference Include="mzLib" Version="1.0.586" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />

--- a/MetaMorpheus/GUI/GUI.csproj
+++ b/MetaMorpheus/GUI/GUI.csproj
@@ -62,7 +62,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.585" />
+    <PackageReference Include="mzLib" Version="1.0.586" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0" />

--- a/MetaMorpheus/GUI/TaskWindows/CalibrateTaskWindow.xaml
+++ b/MetaMorpheus/GUI/TaskWindows/CalibrateTaskWindow.xaml
@@ -375,17 +375,22 @@
                                               ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500">
                                         <ComboBox.ToolTip>
                                             <TextBlock>
-                                                    The container the calibrated spectra are written to. Leave this on mzML unless something downstream needs MGF.
+                                                    The container the calibrated spectra are written to. This file is handed to the next task in the chain, so it decides what
+                                                    a search that follows can see. Leave this on mzML unless something downstream needs MGF.
                                                     <LineBreak/>
                                                     <LineBreak/>
-                                                    MGF carries the title, MS level, precursor m/z and charge, scan number, retention time and the peaks. It has nowhere to put
-                                                    the dissociation type, analyzer type, scan filter, isolation window, precursor scan number or injection time.
+                                                    <Bold>mzML</Bold> — the default. Carries every field a later task reads.
                                                     <LineBreak/>
                                                     <LineBreak/>
-                                                    This file is handed to the next task in the chain, so a search that follows an MGF calibration will not see those fields.
+                                                    <Bold>Mgf</Bold> — MGF including the MS1 scans, so a later task can still deconvolute precursors. On the bundled yeast test
+                                                    file this gives the same 80 PSMs as mzML. The catch is portability: the MGF specification requires a PEPMASS in every block
+                                                    and an MS1 scan has none, so the file is out of spec. ProteoWizard and OpenMS read it anyway, but MSToolkit — and therefore
+                                                    Comet, and other search engines built on it — stops with "Error in MGF file: no PEPMASS found."
                                                     <LineBreak/>
                                                     <LineBreak/>
-                                                    On the bundled yeast test file, a Calibrate then Search chain finds 85 PSMs through mzML and 61 through MGF.
+                                                    <Bold>MgfMs2Only</Bold> — MS2 and above only, so every block has a PEPMASS and every reader accepts the file. Choose this
+                                                    when the MGF is destined for Comet or another MSToolkit-based tool. Without MS1 scans nothing downstream can deconvolute a
+                                                    precursor, which costs roughly a fifth of the identifications: 63 PSMs rather than 80 on the same test file.
                                             </TextBlock>
                                         </ComboBox.ToolTip>
                                     </ComboBox>

--- a/MetaMorpheus/GUI/TaskWindows/CalibrateTaskWindow.xaml
+++ b/MetaMorpheus/GUI/TaskWindows/CalibrateTaskWindow.xaml
@@ -370,6 +370,27 @@
                             </Grid.ColumnDefinitions>
                             <StackPanel Grid.Column="0">
                                 <StackPanel Orientation="Horizontal" Margin="5">
+                                    <Label Content="Output format" VerticalAlignment="Center" />
+                                    <ComboBox x:Name="outputFormatComboBox" MinWidth="90" VerticalAlignment="Center"
+                                              ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500">
+                                        <ComboBox.ToolTip>
+                                            <TextBlock>
+                                                    The container the calibrated spectra are written to. Leave this on mzML unless something downstream needs MGF.
+                                                    <LineBreak/>
+                                                    <LineBreak/>
+                                                    MGF carries the title, MS level, precursor m/z and charge, scan number, retention time and the peaks. It has nowhere to put
+                                                    the dissociation type, analyzer type, scan filter, isolation window, precursor scan number or injection time.
+                                                    <LineBreak/>
+                                                    <LineBreak/>
+                                                    This file is handed to the next task in the chain, so a search that follows an MGF calibration will not see those fields.
+                                                    <LineBreak/>
+                                                    <LineBreak/>
+                                                    On the bundled yeast test file, a Calibrate then Search chain finds 85 PSMs through mzML and 61 through MGF.
+                                            </TextBlock>
+                                        </ComboBox.ToolTip>
+                                    </ComboBox>
+                                </StackPanel>
+                                <StackPanel Orientation="Horizontal" Margin="5">
                                     <CheckBox x:Name="writeIndexMzmlCheckbox" Content="Write indexed .mzML" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500">
                                         <CheckBox.ToolTip>
                                             <TextBlock>

--- a/MetaMorpheus/GUI/TaskWindows/CalibrateTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/CalibrateTaskWindow.xaml.cs
@@ -101,6 +101,8 @@ namespace MetaMorpheusGUI
             PrecursorMassToleranceTextBox.Text = task.CommonParameters.PrecursorMassTolerance.Value.ToString(CultureInfo.InvariantCulture);
             PrecursorMassToleranceComboBox.SelectedIndex = task.CommonParameters.PrecursorMassTolerance is AbsoluteTolerance ? 0 : 1;
             CustomFragmentationWindow = new CustomFragmentationWindow(task.CommonParameters.CustomIons);
+            outputFormatComboBox.ItemsSource = Enum.GetValues(typeof(SpectraFileOutputFormat));
+            outputFormatComboBox.SelectedItem = task.CalibrationParameters.OutputFormat;
             writeIndexMzmlCheckbox.IsChecked = task.CalibrationParameters.WriteIndexedMzml;
             NumberOfDatabaseSearchesTextBox.Text = task.CommonParameters.TotalPartitions.ToString(CultureInfo.InvariantCulture);
 
@@ -389,6 +391,7 @@ namespace MetaMorpheusGUI
                 TheTask.CommonParameters = commonParamsToSave;
             }
 
+            TheTask.CalibrationParameters.OutputFormat = (SpectraFileOutputFormat)outputFormatComboBox.SelectedItem;
             TheTask.CalibrationParameters.WriteIndexedMzml = writeIndexMzmlCheckbox.IsChecked.Value;
             TheTask.CalibrationParameters.WriteIntermediateFiles = writeIntermediateFilesCheckBox.IsChecked.Value;
             if (ModernSearchRadioButton.IsChecked == true)

--- a/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
+++ b/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="itext7" Version="9.7.0" />
     <PackageReference Include="itext7.bouncy-castle-adapter" Version="9.7.0" />
-    <PackageReference Include="mzLib" Version="1.0.585" />
+    <PackageReference Include="mzLib" Version="1.0.586" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.0.0" />
     <PackageReference Include="Svg" Version="3.4.7" />
   </ItemGroup>

--- a/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationParameters.cs
+++ b/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationParameters.cs
@@ -19,8 +19,8 @@
 
         /// <summary>
         /// Container for the calibrated spectra. mzML unless deliberately changed; see
-        /// <see cref="SpectraFileOutputFormat"/> for what MGF cannot carry. WriteIndexedMzml is
-        /// ignored when this is Mgf.
+        /// <see cref="SpectraFileOutputFormat"/> for the trade-off between the two MGF variants.
+        /// WriteIndexedMzml is ignored for either of them.
         /// </summary>
         public SpectraFileOutputFormat OutputFormat { get; set; }
 

--- a/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationParameters.cs
+++ b/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationParameters.cs
@@ -10,11 +10,20 @@
             NumFragmentsNeededForEveryIdentification = 10;
             QValueCutoffForCalibratingPSMs = 0.01;
             WriteIndexedMzml = true;
+            OutputFormat = SpectraFileOutputFormat.MzML;
             SearchType = SearchType.Classic;
         }
 
         public bool WriteIntermediateFiles { get; set; }
         public bool WriteIndexedMzml { get; set; }
+
+        /// <summary>
+        /// Container for the calibrated spectra. mzML unless deliberately changed; see
+        /// <see cref="SpectraFileOutputFormat"/> for what MGF cannot carry. WriteIndexedMzml is
+        /// ignored when this is Mgf.
+        /// </summary>
+        public SpectraFileOutputFormat OutputFormat { get; set; }
+
         public SearchType SearchType { get; set; }
 
         public int MinMS1IsotopicPeaksNeededForConfirmedIdentification { get; set; }

--- a/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationTask.cs
+++ b/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationTask.cs
@@ -49,6 +49,15 @@ namespace TaskLayer
 
         public const string CalibSuffix = "-calib";
 
+        /// <summary>
+        /// Extension for the calibrated file, following <see cref="CalibrationParameters.OutputFormat"/>.
+        /// The next task in the chain is handed this file, so the extension has to match what was written
+        /// or the reader picked for it will not be the one that wrote it.
+        /// </summary>
+        private bool WritingMgf => CalibrationParameters.OutputFormat == SpectraFileOutputFormat.Mgf;
+
+        private string CalibratedFileExtension => WritingMgf ? ".mgf" : ".mzML";
+
 
         private List<string> _unsuccessfullyCalibratedFilePaths;
         private string _taskId;
@@ -85,8 +94,9 @@ namespace TaskLayer
                 string originalUncalibratedFilePath = currentRawFileList[spectraFileIndex];
                 string uncalibratedNewFullFilePath = Path.Combine(outputFolder, Path.GetFileName(currentRawFileList[spectraFileIndex]));
                 string originalUncalibratedFilenameWithoutExtension = Path.GetFileNameWithoutExtension(originalUncalibratedFilePath);
-                string calibratedNewFullFilePath = Path.Combine(OutputFolder, originalUncalibratedFilenameWithoutExtension + CalibSuffix + ".mzML")
-                    .ToSafeOutputPath(CalibSuffix + ".mzML");
+                string calibratedExtension = CalibratedFileExtension;
+                string calibratedNewFullFilePath = Path.Combine(OutputFolder, originalUncalibratedFilenameWithoutExtension + CalibSuffix + calibratedExtension)
+                    .ToSafeOutputPath(CalibSuffix + calibratedExtension);
 
                 // mark the file as in-progress
                 StartingDataFile(originalUncalibratedFilePath, new List<string> { _taskId, "Individual Spectra Files", originalUncalibratedFilePath });
@@ -187,7 +197,7 @@ namespace TaskLayer
             assumedPathToExperDesign = Path.Combine(assumedPathToExperDesign, GlobalVariables.ExperimentalDesignFileName);
             if (File.Exists(assumedPathToExperDesign))
             {
-                WriteNewExperimentalDesignFile(assumedPathToExperDesign, outputFolder, currentRawFileList, _unsuccessfullyCalibratedFilePaths);
+                WriteNewExperimentalDesignFile(assumedPathToExperDesign, outputFolder, currentRawFileList, _unsuccessfullyCalibratedFilePaths, CalibratedFileExtension);
             }
         }
 
@@ -523,7 +533,21 @@ namespace TaskLayer
 
         private void CalibrationOutput(MsDataFile msDataFile, string mzFilePath, FileSpecificParameters fileParams, string tomlName, string taskId, string mzFilenameNoExtension)
         {
-            msDataFile.ExportAsMzML(mzFilePath, CalibrationParameters.WriteIndexedMzml);
+            if (WritingMgf)
+            {
+                // Temporary, and should be deleted once mgf carries these: dissociation type, precursor scan
+                // number and isolation width have no header in the format today, so a task run after this one
+                // sees fewer fields. Measured on the bundled yeast file, a Calibrate -> Search chain finds 85
+                // PSMs through mzML and 61 through mgf.
+                Warn("Writing calibrated spectra as mgf. Dissociation type, precursor scan number and "
+                     + "isolation width are not carried in mgf today, so a task run after this one will "
+                     + "identify fewer spectra than it would from mzML.");
+                msDataFile.ExportAsMgf(mzFilePath);
+            }
+            else
+            {
+                msDataFile.ExportAsMzML(mzFilePath, CalibrationParameters.WriteIndexedMzml);
+            }
             MyTaskResults.NewSpectra.Add(mzFilePath);
             Toml.WriteFile(fileParams, tomlName, tomlConfig);
             FinishedWritingFile(tomlName, new List<string> { taskId, "Individual Spectra Files", mzFilenameNoExtension });
@@ -532,7 +556,7 @@ namespace TaskLayer
         }
 
         private static void WriteNewExperimentalDesignFile(string pathToOldExperDesign, string outputFolder, List<string> originalUncalibratedFileNamesWithExtension,
-            List<string> unsuccessfullyCalibratedFilePaths)
+            List<string> unsuccessfullyCalibratedFilePaths, string calibratedExtension)
         {
             List<SpectraFileInfo> oldExperDesign = ExperimentalDesign.ReadExperimentalDesign(pathToOldExperDesign, originalUncalibratedFileNamesWithExtension, out var errors);
 
@@ -558,7 +582,7 @@ namespace TaskLayer
                 }
                 else
                 {
-                    SpectraFileInfo calibratedSpectraFile = new(Path.Combine(outputFolder, originalFileName + CalibSuffix + ".mzML"),
+                    SpectraFileInfo calibratedSpectraFile = new(Path.Combine(outputFolder, originalFileName + CalibSuffix + calibratedExtension),
                     originalSpectraFile.Condition, originalSpectraFile.BiologicalReplicate, originalSpectraFile.TechnicalReplicate, originalSpectraFile.Fraction);
                     newExperDesign.Add(calibratedSpectraFile);
                 }

--- a/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationTask.cs
+++ b/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationTask.cs
@@ -54,7 +54,8 @@ namespace TaskLayer
         /// The next task in the chain is handed this file, so the extension has to match what was written
         /// or the reader picked for it will not be the one that wrote it.
         /// </summary>
-        private bool WritingMgf => CalibrationParameters.OutputFormat == SpectraFileOutputFormat.Mgf;
+        private bool WritingMgf => CalibrationParameters.OutputFormat is SpectraFileOutputFormat.Mgf
+                                                                       or SpectraFileOutputFormat.MgfMs2Only;
 
         private string CalibratedFileExtension => WritingMgf ? ".mgf" : ".mzML";
 
@@ -535,14 +536,21 @@ namespace TaskLayer
         {
             if (WritingMgf)
             {
-                // Temporary, and should be deleted once mgf carries these: dissociation type, precursor scan
-                // number and isolation width have no header in the format today, so a task run after this one
-                // sees fewer fields. Measured on the bundled yeast file, a Calibrate -> Search chain finds 85
-                // PSMs through mzML and 61 through mgf.
-                Warn("Writing calibrated spectra as mgf. Dissociation type, precursor scan number and "
-                     + "isolation width are not carried in mgf today, so a task run after this one will "
-                     + "identify fewer spectra than it would from mzML.");
-                msDataFile.ExportAsMgf(mzFilePath);
+                bool includeMs1Scans = CalibrationParameters.OutputFormat == SpectraFileOutputFormat.Mgf;
+                if (includeMs1Scans)
+                {
+                    Warn("Writing calibrated spectra as mgf, including MS1 scans. An MS1 block has no "
+                         + "PEPMASS, which the mgf specification requires, so some readers will reject the "
+                         + "file. Use MgfMs2Only if it is destined for one of those.");
+                }
+                else
+                {
+                    Warn("Writing calibrated spectra as mgf without MS1 scans. A task run after this one "
+                         + "cannot deconvolute precursors and will identify fewer spectra than it would "
+                         + "from mzML.");
+                }
+
+                msDataFile.ExportAsMgf(mzFilePath, includeMs1Scans);
             }
             else
             {

--- a/MetaMorpheus/TaskLayer/CalibrationTask/SpectraFileOutputFormat.cs
+++ b/MetaMorpheus/TaskLayer/CalibrationTask/SpectraFileOutputFormat.cs
@@ -4,19 +4,29 @@ namespace TaskLayer
     /// The container a task writes its processed spectra to.
     /// </summary>
     /// <remarks>
-    /// mzML is the default and should stay that way. MGF carries a title, MS level, precursor m/z and
-    /// charge, scan number, retention time and the peak list, and has nowhere to put dissociation type,
-    /// analyzer type, scan filter, isolation window, precursor scan number or injection time. A task's
-    /// output is fed to the next task in the chain, so choosing MGF means the search that follows sees a
-    /// file without those fields.
+    /// mzML is the default and should stay that way. A task's output is fed to the next task in the chain,
+    /// so this choice decides what the search that follows can see.
     ///
-    /// It is offered because "mgf in, mgf out" is a real workflow — smith-chem-wisc/MetaMorpheus#1673 —
-    /// not because it is equivalent. Measured on the bundled yeast test file, a Calibrate then Search chain
-    /// finds 85 PSMs through mzML and 61 through mgf.
+    /// Offered because "mgf in, mgf out" is a real workflow — smith-chem-wisc/MetaMorpheus#1673. Measured on
+    /// the bundled yeast file, a Calibrate then Search chain produces the same 80 PSMs through Mgf as
+    /// through MzML, and 63 through MgfMs2Only.
     /// </remarks>
     public enum SpectraFileOutputFormat
     {
+        /// <summary>Default. Carries every field a later task reads.</summary>
         MzML,
-        Mgf
+
+        /// <summary>
+        /// MGF including MS1 scans, so a later task can still deconvolute precursors. Out of spec: Matrix
+        /// Science requires a PEPMASS in every block and an MS1 has none. ProteoWizard and OpenMS read it,
+        /// MSToolkit — and so Comet — does not. Use <see cref="MgfMs2Only"/> to feed one of those.
+        /// </summary>
+        Mgf,
+
+        /// <summary>
+        /// MGF with MS2 and above only, which every reader accepts. No MS1 means no precursor
+        /// deconvolution downstream, costing roughly a fifth of the identifications.
+        /// </summary>
+        MgfMs2Only
     }
 }

--- a/MetaMorpheus/TaskLayer/CalibrationTask/SpectraFileOutputFormat.cs
+++ b/MetaMorpheus/TaskLayer/CalibrationTask/SpectraFileOutputFormat.cs
@@ -1,0 +1,22 @@
+namespace TaskLayer
+{
+    /// <summary>
+    /// The container a task writes its processed spectra to.
+    /// </summary>
+    /// <remarks>
+    /// mzML is the default and should stay that way. MGF carries a title, MS level, precursor m/z and
+    /// charge, scan number, retention time and the peak list, and has nowhere to put dissociation type,
+    /// analyzer type, scan filter, isolation window, precursor scan number or injection time. A task's
+    /// output is fed to the next task in the chain, so choosing MGF means the search that follows sees a
+    /// file without those fields.
+    ///
+    /// It is offered because "mgf in, mgf out" is a real workflow — smith-chem-wisc/MetaMorpheus#1673 —
+    /// not because it is equivalent. Measured on the bundled yeast test file, a Calibrate then Search chain
+    /// finds 85 PSMs through mzML and 61 through mgf.
+    /// </remarks>
+    public enum SpectraFileOutputFormat
+    {
+        MzML,
+        Mgf
+    }
+}

--- a/MetaMorpheus/TaskLayer/SearchTask/SearchTask.cs
+++ b/MetaMorpheus/TaskLayer/SearchTask/SearchTask.cs
@@ -24,6 +24,9 @@ using System.Linq;
 using System.Threading.Tasks;
 using Chemistry;
 
+
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Test")]
+
 namespace TaskLayer
 {
     public class SearchTask : MetaMorpheusTask
@@ -153,6 +156,30 @@ namespace TaskLayer
                  $"of the old setting. Set MassDiffAcceptorType explicitly to silence this.");
 
             SearchParameters.MassDiffAcceptorType = LegacyMostAbundantEquivalent;
+        }
+
+        /// <summary>
+        /// True only when every MS2 scan names an MS1 scan that is present in the file and has a resolvable
+        /// isolation range. Both are required to deconvolute a precursor: without a precursor scan number
+        /// <see cref="MetaMorpheusTask._GetMs2Scans"/> falls through to the scan header, and a null IsolationRange
+        /// makes GetIsolatedMassesAndCharges return nothing. IsolationRange needs an isolation width as well as a
+        /// centre, and the MGF reader defaults only the centre. A partially annotated file is treated as
+        /// header-only rather than deconvoluted for some scans and not others.
+        /// </summary>
+        internal static bool HasDeconvolutablePrecursorScans(MsDataFile file)
+        {
+            var scans = file.GetAllScansList();
+            var ms1ScanNumbers = scans.Where(s => s.MsnOrder == 1).Select(s => s.OneBasedScanNumber).ToHashSet();
+            if (ms1ScanNumbers.Count == 0)
+            {
+                return false;
+            }
+
+            var ms2Scans = scans.Where(s => s.MsnOrder == 2).ToList();
+            return ms2Scans.Count > 0
+                   && ms2Scans.All(s => s.OneBasedPrecursorScanNumber.HasValue
+                                        && ms1ScanNumbers.Contains(s.OneBasedPrecursorScanNumber.Value)
+                                        && s.IsolationRange != null);
         }
 
         protected override MyTaskResults RunSpecific(string OutputFolder, List<DbForTask> dbFilenameList, List<string> currentRawFileList, string taskId,
@@ -309,7 +336,9 @@ namespace TaskLayer
 
                 // If the file is one which does not have precursor scans, but only precursor information, then we need to set the parameters accordingly
                 // We do this by adjusting the transient combined params so that this can be done on a file by file basis. 
-                if (myMsDataFile is Mgf or Ms2Align)
+                // An MGF written by mzLib carries its MS1 scans and the headers deconvolution needs, so that
+                // case is decided by content. msalign is always header-only.
+                if (myMsDataFile is Ms2Align || (myMsDataFile is Mgf && !HasDeconvolutablePrecursorScans(myMsDataFile)))
                 {
                     combinedParams.DoPrecursorDeconvolution = false;
                     combinedParams.UseProvidedPrecursorInfo = true;

--- a/MetaMorpheus/TaskLayer/TaskLayer.csproj
+++ b/MetaMorpheus/TaskLayer/TaskLayer.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.585" />
+    <PackageReference Include="mzLib" Version="1.0.586" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />

--- a/MetaMorpheus/Test/MgfOutputTests.cs
+++ b/MetaMorpheus/Test/MgfOutputTests.cs
@@ -1,0 +1,114 @@
+using EngineLayer.DatabaseLoading;
+using Nett;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using TaskLayer;
+
+namespace Test
+{
+    /// <summary>
+    /// Writing calibrated spectra as mgf, and choosing between the two mgf variants (MetaMorpheus#1673).
+    /// </summary>
+    [TestFixture]
+    internal static class MgfOutputTests
+    {
+        /// <summary>
+        /// OutputFormat is a plain enum, so Nett round-trips it as a string with no converter -- but only
+        /// as long as nobody registers one for it. Every value, so a new one cannot be added untested.
+        /// </summary>
+        [Test]
+        [TestCase(SpectraFileOutputFormat.MzML)]
+        [TestCase(SpectraFileOutputFormat.Mgf)]
+        [TestCase(SpectraFileOutputFormat.MgfMs2Only)]
+        public static void OutputFormatSurvivesATomlRoundTrip(SpectraFileOutputFormat format)
+        {
+            var task = new CalibrationTask();
+            task.CalibrationParameters.OutputFormat = format;
+
+            string path = Path.Combine(TestContext.CurrentContext.TestDirectory, "outputFormat.toml");
+
+            try
+            {
+                Toml.WriteFile(task, path, MetaMorpheusTask.tomlConfig);
+                Assert.That(File.ReadAllLines(path), Has.Member("OutputFormat = \"" + format + "\""));
+
+                var reread = Toml.ReadFile<CalibrationTask>(path, MetaMorpheusTask.tomlConfig);
+                Assert.That(reread.CalibrationParameters.OutputFormat, Is.EqualTo(format));
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+
+        [Test]
+        public static void OutputFormatDefaultsToMzMLSoNothingChangesUnlessAsked()
+        {
+            Assert.That(new CalibrationTask().CalibrationParameters.OutputFormat,
+                Is.EqualTo(SpectraFileOutputFormat.MzML));
+        }
+
+        /// <summary>
+        /// End to end: the extension, the block contents and the specification-conformance of each variant.
+        /// The next task in the chain is handed this file by extension, so writing mgf under a .mzML name
+        /// would hand it to the wrong reader.
+        /// </summary>
+        [Test]
+        [NonParallelizable]
+        [TestCase(SpectraFileOutputFormat.MzML, ".mzML")]
+        [TestCase(SpectraFileOutputFormat.Mgf, ".mgf")]
+        [TestCase(SpectraFileOutputFormat.MgfMs2Only, ".mgf")]
+        public static void CalibrationWritesTheChosenFormat(SpectraFileOutputFormat format, string expectedExtension)
+        {
+            string unitTestFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, "MgfOutput_" + format);
+            string outputFolder = Path.Combine(unitTestFolder, "TaskOutput");
+            Directory.CreateDirectory(outputFolder);
+
+            try
+            {
+                string spectraPath = Path.Combine(unitTestFolder, "sample.mzML");
+                File.Copy(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "SmallCalibratible_Yeast.mzML"),
+                    spectraPath, true);
+                string database = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "smalldb.fasta");
+
+                var task = new CalibrationTask();
+                task.CalibrationParameters.OutputFormat = format;
+                task.RunTask(outputFolder, new List<DbForTask> { new(database, false) },
+                    new List<string> { spectraPath }, "test");
+
+                string written = Path.Combine(outputFolder, "sample-calib" + expectedExtension);
+                Assert.That(File.Exists(written), Is.True, "calibrated file should be " + expectedExtension);
+
+                if (format == SpectraFileOutputFormat.MzML)
+                {
+                    return;
+                }
+
+                string[] lines = File.ReadAllLines(written);
+                int blocks = lines.Count(l => l == "BEGIN IONS");
+                int ms1Blocks = lines.Count(l => l == "MSLEVEL=1");
+                int pepmasses = lines.Count(l => l.StartsWith("PEPMASS="));
+
+                Assert.That(blocks, Is.GreaterThan(0));
+
+                if (format == SpectraFileOutputFormat.MgfMs2Only)
+                {
+                    Assert.That(ms1Blocks, Is.Zero, "MgfMs2Only must not write MS1 scans");
+                    Assert.That(pepmasses, Is.EqualTo(blocks),
+                        "every block needs the mandatory PEPMASS, or MSToolkit-based readers exit on it");
+                }
+                else
+                {
+                    Assert.That(ms1Blocks, Is.GreaterThan(0), "Mgf must write MS1 scans so precursors survive");
+                    Assert.That(pepmasses, Is.EqualTo(blocks - ms1Blocks));
+                }
+            }
+            finally
+            {
+                Directory.Delete(unitTestFolder, true);
+            }
+        }
+    }
+}

--- a/MetaMorpheus/Test/MgfPrecursorGateTests.cs
+++ b/MetaMorpheus/Test/MgfPrecursorGateTests.cs
@@ -1,0 +1,167 @@
+using MassSpectrometry;
+using MzLibUtil;
+using NUnit.Framework;
+using Readers;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using EngineLayer.DatabaseLoading;
+using TaskLayer;
+
+namespace Test
+{
+    /// <summary>
+    /// Whether a search may deconvolute precursors out of an mgf. Third-party mgf files carry precursor
+    /// information only in the scan header; one mzLib writes carries its MS1 scans too.
+    /// </summary>
+    [TestFixture]
+    internal static class MgfPrecursorGateTests
+    {
+        private static MsDataScan Ms1(int scanNumber) =>
+            new(new MzSpectrum(new[] { 570.0, 571.0, 572.0, 573.0 }, new[] { 100.0, 200.0, 300.0, 400.0 }, false),
+                oneBasedScanNumber: scanNumber, msnOrder: 1, isCentroid: true, polarity: Polarity.Positive,
+                retentionTime: 1.0 + scanNumber, scanWindowRange: new MzRange(500, 600), scanFilter: null,
+                mzAnalyzer: MZAnalyzerType.Orbitrap, totalIonCurrent: 1000.0, injectionTime: null,
+                noiseData: null, nativeId: "scan=" + scanNumber);
+
+        private static MsDataScan Ms2(int scanNumber, int? precursorScanNumber, double? isolationWidth) =>
+            new(new MzSpectrum(new[] { 110.05, 220.11 }, new[] { 500.0, 750.0 }, false),
+                oneBasedScanNumber: scanNumber, msnOrder: 2, isCentroid: true, polarity: Polarity.Positive,
+                retentionTime: 1.0 + scanNumber, scanWindowRange: new MzRange(100, 250), scanFilter: null,
+                mzAnalyzer: MZAnalyzerType.Orbitrap, totalIonCurrent: 1250.0, injectionTime: null,
+                noiseData: null, nativeId: "scan=" + scanNumber, selectedIonMz: 571.8069,
+                selectedIonChargeStateGuess: 2, selectedIonIntensity: 999999.0,
+                isolationMZ: 572.0, isolationWidth: isolationWidth, dissociationType: DissociationType.HCD,
+                oneBasedPrecursorScanNumber: precursorScanNumber, selectedIonMonoisotopicGuessMz: 571.8069);
+
+        private static MsDataFile FileOf(params MsDataScan[] scans) => new GenericMsDataFile(scans, null);
+
+        /// <summary>
+        /// The premise the gate protects: precursor deconvolution needs an MS1 to read and an isolation
+        /// range to read it over. Anything less and the search must fall back to the scan header, which is
+        /// what every third-party mgf has always required.
+        /// </summary>
+        [Test]
+        public static void GateRequiresAnMs1ScanAndAResolvableIsolationRange()
+        {
+            Assert.That(SearchTask.HasDeconvolutablePrecursorScans(FileOf(Ms1(1), Ms2(2, 1, 3.0))), Is.True,
+                "a file with MS1 scans, precursor scan numbers and isolation widths is deconvolutable");
+
+            Assert.That(SearchTask.HasDeconvolutablePrecursorScans(FileOf(Ms2(1, null, 3.0))), Is.False,
+                "no MS1 scans at all -- the ordinary third-party mgf");
+
+            Assert.That(SearchTask.HasDeconvolutablePrecursorScans(FileOf(Ms1(1), Ms2(2, null, 3.0))), Is.False,
+                "MS1 present but nothing points at it");
+
+            Assert.That(SearchTask.HasDeconvolutablePrecursorScans(FileOf(Ms1(1), Ms2(2, 1, null))), Is.False,
+                "no isolation width, so IsolationRange is null and deconvolution would return nothing");
+
+            Assert.That(SearchTask.HasDeconvolutablePrecursorScans(FileOf(Ms1(1), Ms2(2, 99, 3.0))), Is.False,
+                "precursor scan number names a scan that is not in the file");
+
+            Assert.That(SearchTask.HasDeconvolutablePrecursorScans(FileOf(Ms1(1))), Is.False,
+                "no MS2 scans to search");
+        }
+
+        /// <summary>
+        /// One partially annotated scan takes the whole file down the header-only path, rather than leaving
+        /// some scans deconvoluted and others not for no visible reason.
+        /// </summary>
+        [Test]
+        public static void GateIsAllOrNothingAcrossTheFile()
+        {
+            Assert.That(SearchTask.HasDeconvolutablePrecursorScans(
+                    FileOf(Ms1(1), Ms2(2, 1, 3.0), Ms2(3, 1, 3.0))), Is.True);
+
+            Assert.That(SearchTask.HasDeconvolutablePrecursorScans(
+                    FileOf(Ms1(1), Ms2(2, 1, 3.0), Ms2(3, 1, null))), Is.False,
+                "one unannotated scan out of two");
+        }
+
+        /// <summary>
+        /// A round trip through the writer and reader has to satisfy the gate, or the mgf output option
+        /// silently costs the next task its precursors.
+        /// </summary>
+        [Test]
+        public static void AnMgfWrittenByMzLibSatisfiesTheGateAndAnMs2OnlyOneDoesNot()
+        {
+            var file = FileOf(Ms1(1), Ms2(2, 1, 3.0));
+            string withMs1 = Path.Combine(TestContext.CurrentContext.TestDirectory, "gateWithMs1.mgf");
+            string ms2Only = Path.Combine(TestContext.CurrentContext.TestDirectory, "gateMs2Only.mgf");
+
+            try
+            {
+                file.ExportAsMgf(withMs1);
+                file.ExportAsMgf(ms2Only, includeMs1Scans: false);
+
+                var readWithMs1 = MsDataFileReader.GetDataFile(withMs1);
+                readWithMs1.LoadAllStaticData();
+                Assert.That(SearchTask.HasDeconvolutablePrecursorScans(readWithMs1), Is.True);
+
+                var readMs2Only = MsDataFileReader.GetDataFile(ms2Only);
+                readMs2Only.LoadAllStaticData();
+                Assert.That(SearchTask.HasDeconvolutablePrecursorScans(readMs2Only), Is.False);
+            }
+            finally
+            {
+                File.Delete(withMs1);
+                File.Delete(ms2Only);
+            }
+        }
+
+        /// <summary>
+        /// The regression that motivated the content-based gate. SearchTask used to switch precursor
+        /// deconvolution off for anything typed as <see cref="Mgf"/>, on the premise that an mgf has no MS1
+        /// scans to deconvolute. An mgf mzLib wrote does, and the search silently fell back to one
+        /// scan-header precursor per MS2 scan.
+        /// </summary>
+        [Test]
+        [NonParallelizable]
+        public static void SearchDeconvolutesPrecursorsOnlyFromAnMgfThatCarriesMs1Scans()
+        {
+            string unitTestFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, "MgfSearchGate");
+            Directory.CreateDirectory(unitTestFolder);
+
+            try
+            {
+                var source = MsDataFileReader.GetDataFile(
+                    Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "SmallCalibratible_Yeast.mzML"));
+                source.LoadAllStaticData();
+
+                string withMs1 = Path.Combine(unitTestFolder, "withMs1.mgf");
+                string ms2Only = Path.Combine(unitTestFolder, "ms2Only.mgf");
+                source.ExportAsMgf(withMs1);
+                source.ExportAsMgf(ms2Only, includeMs1Scans: false);
+
+                string database = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "smalldb.fasta");
+
+                (int precursors, int ms2Scans) RunSearch(string spectraPath, string name)
+                {
+                    string outputFolder = Path.Combine(unitTestFolder, name);
+                    Directory.CreateDirectory(outputFolder);
+                    new SearchTask().RunTask(outputFolder, new List<DbForTask> { new(database, false) },
+                        new List<string> { spectraPath }, "test");
+
+                    string[] results = File.ReadAllLines(Path.Combine(outputFolder, "results.txt"));
+                    int Read(string label) => int.Parse(
+                        results.First(l => l.StartsWith("All " + label + ": ")).Split(": ")[1]);
+                    return (Read("Precursors"), Read("MS2 Scans"));
+                }
+
+                var deconvoluted = RunSearch(withMs1, "withMs1");
+                var headerOnly = RunSearch(ms2Only, "ms2Only");
+
+                Assert.That(deconvoluted.ms2Scans, Is.EqualTo(headerOnly.ms2Scans),
+                    "both files hold the same MS2 scans");
+                Assert.That(deconvoluted.precursors, Is.GreaterThan(deconvoluted.ms2Scans),
+                    "MS1 scans are present, so deconvolution should find more precursors than there are scans");
+                Assert.That(headerOnly.precursors, Is.EqualTo(headerOnly.ms2Scans),
+                    "no MS1 scans, so the search must fall back to one scan-header precursor per scan");
+            }
+            finally
+            {
+                Directory.Delete(unitTestFolder, true);
+            }
+        }
+    }
+}

--- a/MetaMorpheus/Test/Test.csproj
+++ b/MetaMorpheus/Test/Test.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.585" />
+    <PackageReference Include="mzLib" Version="1.0.586" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />


### PR DESCRIPTION
🤖 Closes #1673. Three commits: the output option, a search fix the option exposed, and a portable mgf variant.

**Blocked on smith-chem-wisc/mzLib#1227 and a release.** The branch pins mzLib 1.0.586 and will not compile until the pin moves to whatever version carries that PR — `ExportAsMgf(path, includeMs1Scans:)` and the extension headers both come from it. I have left the pin wrong rather than guess a version number.

## What you get

`CalibrationParameters.OutputFormat`, defaulting to `MzML` so nothing changes unless asked. Exposed as `OutputFormat = "MzML"` in the task toml and as a dropdown in the Calibrate task window. The calibrated file's extension, the experimental design entry and the write all follow it, so a Calibrate → Search chain hands the next task a file whose extension matches what was written.

| | PSMs | peptides | protein groups | precursors |
|---|---|---|---|---|
| `MzML` | 80 | 55 | 46 | 482 |
| `Mgf` | 80 | 55 | 46 | 482 |
| `MgfMs2Only` | 63 | 44 | 36 | 118 |

`Mgf` and `MzML` agree byte for byte across all 57 columns of `AllPSMs.psmtsv`.

## The search fix, which is the substantive part

`SearchTask` switched precursor deconvolution off for anything typed as `Mgf` or `Ms2Align`. The premise — an mgf has no MS1 scans, only header precursor information — holds for every third-party mgf and not for one mzLib writes. The symptom was **exactly one precursor per MS2 scan**, 118 against mzML's 482, which is what made it findable.

Now gated on whether the file can support deconvolution: every MS2 scan must name an MS1 scan present in the file, and must have a resolvable `IsolationRange`. Both are required — without a precursor scan number `_GetMs2Scans` falls through to the scan header, and a null `IsolationRange` makes `GetIsolatedMassesAndCharges` return nothing. A partially annotated file goes header-only for the whole file rather than deconvoluting some scans and not others.

msalign keeps the unconditional type check; it is pre-deconvoluted by construction.

**This changes search output for mgf files carrying MS1 scans, and only those.** All 17 checked-in mgf fixtures have zero MS1 scans and every one still takes the header-only path. I also checked three synthetic degraded files — our headers stripped, one block missing `PRECURSORSCAN`, one missing `ISOLATIONWIDTH` — and all three fall back.

One case I could not make fall back: dropping only `ISOLATIONMZ` still deconvolutes, because the reader defaults the isolation centre to `PEPMASS` so `IsolationRange` stays non-null. Reaching it needs MS1 blocks *and* `PRECURSORSCAN` *and* `ISOLATIONWIDTH` but no `ISOLATIONMZ` — an mzLib-written mgf someone has edited. I left it rather than add a check that only appears to cover it.

## Why `MgfMs2Only` is a third enum value

The mgf `Mgf` writes includes MS1 scans, which is what preserves the 80 PSMs. Those blocks have no `PEPMASS`, which the spec requires, and MSToolkit — Comet's reader — answers with `Error in MGF file: no PEPMASS found.` then `exit(-12)`. ProteoWizard and OpenMS read it fine. `MgfMs2Only` writes MS2 and above only, so every block carries the mandatory `PEPMASS`.

A third enum value rather than a checkbox because the choice is meaningless when the format is mzML, and a control that does nothing two thirds of the time is worse. The tooltip explains per value which readers need which.

## Tests

11 across `MgfPrecursorGateTests.cs` and `MgfOutputTests.cs`, all passing: six gate cases (three negative), an all-or-nothing case, a write/read round trip, toml round trip of all three enum values, the `MzML` default, an end-to-end calibration per value, and an end-to-end search proving deconvolution happens only with MS1 scans present. That last one was confirmed to fail against the old type check with `Expected: greater than 118, But was: 118`.

`HasDeconvolutablePrecursorScans` is `internal` with `InternalsVisibleTo("Test")`, following `EngineLayer/Util/PrecursorSet.cs`.

Not verified: `Test.csproj` is Windows-targeted, so these ran through a throwaway net10.0 harness. It compiles under `-p:EnableWindowsTargeting=true` and the full solution builds clean under `UbuntuMac`; CI is the check for the rest of the suite.
