### PR TITLE
Name iTRAQ 8-plex's eighth channel 121, which is the one that exists

### DIFF
--- a/MetaMorpheus/EngineLayer/Util/IsobaricMassTag.cs
+++ b/MetaMorpheus/EngineLayer/Util/IsobaricMassTag.cs
@@ -194,7 +194,13 @@ namespace EngineLayer
                 IsobaricMassTagType.TMT11 => new List<string> { "126", "127N", "127C", "128N", "128C", "129N", "129C", "130N", "130C", "131N", "131C" },
                 IsobaricMassTagType.TMT18 => new List<string> { "126", "127N", "127C", "128N", "128C", "129N", "129C", "130N", "130C", "131N", "131C", "132N", "132C", "133N", "133C", "134N", "134C", "135N" },
                 IsobaricMassTagType.iTRAQ4 => new List<string> { "114", "115", "116", "117" },
-                IsobaricMassTagType.iTRAQ8 => new List<string> { "113", "114", "115", "116", "117", "118", "119", "120" },
+                // iTRAQ 8-plex has no 120 channel: it is skipped because the phenylalanine immonium
+                // ion sits at 120.081, and the eighth reagent is 121. The m/z extracted here has
+                // always been the right one -- H12 C{13}6 N{15}2 plus a proton is 121.1215 against a
+                // published 121.122 -- so only the NAME was wrong, and it reached users as a column
+                // header in the .psmtsv. The "# 120" comment on that DI line in Mods/tmt.txt is where
+                // it came from.
+                IsobaricMassTagType.iTRAQ8 => new List<string> { "113", "114", "115", "116", "117", "118", "119", "121" },
                 IsobaricMassTagType.diLeu4 => new List<string> { "115", "116", "117", "118" },
                 IsobaricMassTagType.diLeu12 => new List<string> { "115a", "115b", "116a", "116b", "116c", "117a", "117b", "117c", "118a", "118b", "118c", "118d" },
                 _ => null

--- a/MetaMorpheus/Test/Multiplex_Labeling_TMT_iTRAQ.cs
+++ b/MetaMorpheus/Test/Multiplex_Labeling_TMT_iTRAQ.cs
@@ -870,7 +870,10 @@ namespace Test
             Assert.That(itraq4Labels, Is.EqualTo(new List<string> { "114", "115", "116", "117" }));
 
             var itraq8Labels = IsobaricMassTag.GetReporterIonLabels(IsobaricMassTagType.iTRAQ8);
-            Assert.That(itraq8Labels, Is.EqualTo(new List<string> { "113", "114", "115", "116", "117", "118", "119", "120" }));
+            // "121", not "120": 8-plex has no 120 channel. See EveryTagsLabelsNameTheChannelAtTheirOwnIndex,
+            // which checks every label against the reporter ion at its own index rather than against a
+            // hardcoded list -- a hardcoded list can only ever pin whatever was there when it was written.
+            Assert.That(itraq8Labels, Is.EqualTo(new List<string> { "113", "114", "115", "116", "117", "118", "119", "121" }));
 
             var dileu4Labels = IsobaricMassTag.GetReporterIonLabels(IsobaricMassTagType.diLeu4);
             Assert.That(dileu4Labels, Is.EqualTo(new List<string> { "115", "116", "117", "118" }));
@@ -1029,6 +1032,45 @@ namespace Test
             {
                 if (Directory.Exists(outputFolder))
                     Directory.Delete(outputFolder, true);
+            }
+        }
+
+        /// <summary>
+        /// The invariant a hardcoded label list cannot express: GetReporterIonLabels(i) has to name the
+        /// channel whose reporter ion sits at ReporterIonMzs[i], because everything downstream pairs the
+        /// two positionally. A count check cannot catch a mislabelled channel -- iTRAQ 8-plex carried the
+        /// name "120" for the 121 reagent for exactly that reason, extracting the correct ion under a name
+        /// no kit sells.
+        ///
+        /// Every label begins with its nominal mass, so the assertion is available cheaply. This is the
+        /// guard that makes the fix safe rather than merely correct today.
+        /// </summary>
+        [Test]
+        public static void EveryTagsLabelsNameTheChannelAtTheirOwnIndex()
+        {
+            foreach (IsobaricMassTagType type in Enum.GetValues(typeof(IsobaricMassTagType)))
+            {
+                var tag = IsobaricMassTag.GetIsobaricMassTag(type);
+                if (tag == null) continue;   // modification not loaded in this environment
+
+                var labels = IsobaricMassTag.GetReporterIonLabels(type);
+                Assert.That(labels, Is.Not.Null, type.ToString());
+                Assert.That(labels.Count, Is.EqualTo(tag.ReporterIonMzs.Length),
+                    $"{type} has {labels.Count} labels but {tag.ReporterIonMzs.Length} reporter ions");
+
+                for (int i = 0; i < labels.Count; i++)
+                {
+                    string digits = new string(labels[i].TakeWhile(char.IsDigit).ToArray());
+                    Assert.That(digits, Is.Not.Empty,
+                        $"{type} label '{labels[i]}' does not begin with a nominal mass");
+
+                    int nominal = int.Parse(digits);
+                    int observed = (int)Math.Round(tag.ReporterIonMzs[i]);
+
+                    Assert.That(observed, Is.EqualTo(nominal),
+                        $"{type} label '{labels[i]}' at index {i} names channel {nominal}, but the reporter "
+                        + $"ion at that index is {tag.ReporterIonMzs[i]:F4} (channel {observed})");
+                }
             }
         }
     }

--- a/MetaMorpheus/Test/Multiplex_Labeling_TMT_iTRAQ.cs
+++ b/MetaMorpheus/Test/Multiplex_Labeling_TMT_iTRAQ.cs
@@ -1071,6 +1071,23 @@ namespace Test
                         $"{type} label '{labels[i]}' at index {i} names channel {nominal}, but the reporter "
                         + $"ion at that index is {tag.ReporterIonMzs[i]:F4} (channel {observed})");
                 }
+
+                // The nominal mass cannot separate an N channel from a C channel -- 127N and 127C are
+                // both "127" -- so a swapped suffix would pass everything above while pairing each with
+                // the other's ion. They are told apart by mass: at one nominal mass the N form is the
+                // lighter, and ReporterIonMzs is sorted ascending, so N must come first.
+                for (int i = 1; i < labels.Count; i++)
+                {
+                    string prev = labels[i - 1], curr = labels[i];
+                    bool sameNominal = new string(prev.TakeWhile(char.IsDigit).ToArray())
+                                    == new string(curr.TakeWhile(char.IsDigit).ToArray());
+                    if (!sameNominal) continue;
+
+                    if (prev.EndsWith("C") && curr.EndsWith("N"))
+                        Assert.Fail($"{type} orders '{prev}' before '{curr}' at index {i - 1}, but the N form "
+                                    + $"is the lighter of the pair and the reporter ions ascend "
+                                    + $"({tag.ReporterIonMzs[i - 1]:F4} then {tag.ReporterIonMzs[i]:F4})");
+                }
             }
         }
     }


### PR DESCRIPTION
`GetReporterIonLabels` ended iTRAQ 8-plex `"119", "120"`. There is no 120 channel in the 8-plex kit — it is skipped because the phenylalanine immonium ion sits at 120.081 — and the eighth reagent is **121**.

**The m/z was always right.** `H12 C{13}6 N{15}2` plus a proton is 121.1215 against a published 121.122, so MetaMorpheus has been extracting the correct ion and reporting it under a name no kit sells. The `# 120` comment on that DI line in `Mods/tmt.txt` is where it came from.

**This reaches users.** `GetReporterIonLabels` *is* the reporter-ion column header in the `.psmtsv` (`PostSearchAnalysisTask.WritePsmPlusMultiplexIons`), so every iTRAQ 8-plex result file already written names a channel that does not exist. The values under it are correct; only the header is wrong. Anyone joining on that column name is joining on a channel no instrument produced.

Extracted from #2598 to stand alone, because it is wrong data in shipped output and should not wait on a 3,300-line feature review. It is also why #2598 and #2755 had a merge-order constraint — both touch this file and only #2598 carried the fix — so landing it here removes that.

## The test is the point of the PR

A hardcoded label list can only ever pin whatever was there when it was written, which is how this survived. `EveryTagsLabelsNameTheChannelAtTheirOwnIndex` asserts the invariant that actually matters instead: every consumer pairs `channelLabels[i]` with `ReporterIonMzs[i]` **positionally**, so label `i` must name the channel whose reporter ion sits at `i`. Every label begins with its nominal mass, so it is cheap, and it covers all eight tag types rather than the one that was wrong.

Verified it catches the original bug rather than merely passing — against the old label:

```
iTRAQ8 label 120 at index 7 names channel 120,
but the reporter ion at that index is 121.1215 (channel 121)
```

**It also checks the N/C suffix,** which the nominal mass cannot see. `127N` and `127C` are both `"127"`, so a swapped suffix would pass a nominal-mass check while pairing each channel with the others ion — and that is the same family as the `131`/`131N` disagreement between mzLibs two hardcoded label lists. They are separable by mass rather than convention: at one nominal mass the N form is lighter, and `ReporterIonMzs` is sorted ascending, so N must precede C. Verified against a mutant that swaps TMT10s pair:

```
TMT10 orders 127C before 127N at index 1, but the N form is the lighter of the
pair and the reporter ions ascend (127.1248 then 127.1311)
```

The existing `TestGetReporterIonLabelsWithTagType` pinned `"120"`, so it **moved** to `"121"` rather than being loosened, with a pointer to the index test beside it.

97 multiplex, isobaric and TMT tests green.