### PR TITLE
Make the protein table rectangular when intensities are omitted, not zeroed

### DIFF
--- a/MetaMorpheus/EngineLayer/ProteinParsimony/ProteinGroup.cs
+++ b/MetaMorpheus/EngineLayer/ProteinParsimony/ProteinGroup.cs
@@ -152,6 +152,30 @@ namespace EngineLayer
         /// </summary>
         public HashSet<string> SearchedSpectraFilePaths { get; set; }
 
+        /// <summary>
+        /// Whether sample intensities were assigned to this group at all. Gates the Intensity_ columns
+        /// in both the header and the row.
+        /// </summary>
+        /// <remarks>
+        /// Deliberately not the per-group SampleGroupResult.HasIntensityData. Whether a column EXISTS
+        /// has to be a property of the group as a whole, or a row cannot line up with a header written
+        /// from a different group -- and AllProteinGroups.tsv writes one header, from
+        /// proteinGroups.First(), then a row per group.
+        ///
+        /// It did line up until now, but by accident: QuantificationAnalysis assigns IntensitiesByFile
+        /// for every protein including unmeasured ones, so the zeros were present and HasIntensityData
+        /// was uniformly true. mzLib's QuantificationEngine omits zero-valued cells instead, leaving an
+        /// assigned-but-empty dictionary, and that is what the isobaric path produces.
+        ///
+        /// Both fields are required: a subset group built for a file none of the samples match gets an
+        /// empty sample list beside an empty dictionary, and gating on the dictionary alone would
+        /// advertise columns nothing can fill. Mirrors BioPolymerGroup.HasAssignedSampleIntensities from
+        /// the mzLib release after 1.0.587; this copy goes away when the pin moves and ProteinGroup
+        /// overrides the header rather than hiding it.
+        /// </remarks>
+        private bool HasAssignedSampleIntensities =>
+            SamplesForQuantification is { Count: > 0 } && IntensitiesBySample is not null;
+
         // Fails open: an unset path list or a group with no file info means we cannot tell, and dropping
         // columns on a guess is worse than keeping them.
         private bool WasSearched(SampleGroupResult group) =>
@@ -261,7 +285,7 @@ namespace EngineLayer
 
                     if (searched)
                         sb.Append($"SpectralCount_{group.Label}\t");
-                    if (group.HasIntensityData)
+                    if (HasAssignedSampleIntensities)
                         sb.Append($"Intensity_{group.Label}\t");
                     if (searched)
                         sb.Append($"CountOccupancy_{group.Label}\t");
@@ -393,9 +417,11 @@ namespace EngineLayer
                         sb.Append("\t");
                     }
 
-                    if (group.HasIntensityData)
+                    if (HasAssignedSampleIntensities)
                     {
-                        if (group.Intensity > 0)
+                        // Empty rather than 0 when this group has nothing: the cell must not
+                        // assert a measurement that was not made.
+                        if (group.HasIntensityData && group.Intensity > 0)
                             sb.Append(group.Intensity);
                         sb.Append("\t");
                     }

--- a/MetaMorpheus/Test/Multiplex_Labeling_TMT_iTRAQ.cs
+++ b/MetaMorpheus/Test/Multiplex_Labeling_TMT_iTRAQ.cs
@@ -986,6 +986,15 @@ namespace Test
         }
 
         [Test]
+        /// <remarks>
+        /// The absence asserted here describes master, where QuantificationAnalysis returns before
+        /// quantifying anything for a multiplex search, so no group is ever assigned intensities. It is
+        /// not a statement that TMT output should have no intensity columns -- when the isobaric path
+        /// starts populating them, this expectation is the one to revisit, and the companion to add is
+        /// the design-file-present case, which nothing covers today.
+        ///
+        /// The AllSame() assertion below is the one that stays true either way.
+        /// </remarks>
         public static void TestTmtProteinGroupsHaveCountColumnsButNoIntensityColumns()
         {
             // Spectral counts and count-based occupancy are per spectra file, so TMT gets them like any

--- a/MetaMorpheus/Test/ProteinGroupTest.cs
+++ b/MetaMorpheus/Test/ProteinGroupTest.cs
@@ -285,6 +285,134 @@ namespace Test
             }
         }
 
+        /// <summary>
+        /// The companion of TestMultipleProteinGroupsHeaderAndRowsHaveSameColumnCount, for the case that
+        /// test cannot reach. It assigns zeros for unmeasured samples, mirroring QuantificationAnalysis,
+        /// so HasIntensityData is true for every group and the columns line up by accident of the
+        /// label-free writer.
+        ///
+        /// mzLib's QuantificationEngine OMITS zero-valued cells instead, so a protein it found nothing
+        /// for gets an assigned-but-empty dictionary. Gating the Intensity_ column on the per-group
+        /// HasIntensityData then emits fewer columns for that protein than for its neighbour, while the
+        /// header is written once from the first group -- so every value after the gap lands under the
+        /// wrong column name. That is the shape the isobaric path produces.
+        /// </summary>
+        [Test]
+        public static void ProteinGroupsWithOmittedIntensitiesStillLineUpWithTheHeader()
+        {
+            Protein protA = new Protein("MEDEEK", "protA");
+            Protein protB = new Protein("MENEEK", "protB");
+            PeptideWithSetModifications pwsmA = new PeptideWithSetModifications(protA, new DigestionParams(), 1, 3, CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0);
+            PeptideWithSetModifications pwsmB = new PeptideWithSetModifications(protB, new DigestionParams(), 1, 3, CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0);
+
+            ProteinGroup pgA = new ProteinGroup(new HashSet<IBioPolymer> { protA },
+                new HashSet<IBioPolymerWithSetMods> { pwsmA }, new HashSet<IBioPolymerWithSetMods> { pwsmA });
+            ProteinGroup pgB = new ProteinGroup(new HashSet<IBioPolymer> { protB },
+                new HashSet<IBioPolymerWithSetMods> { pwsmB }, new HashSet<IBioPolymerWithSetMods> { pwsmB });
+
+            var fileA = new SpectraFileInfo(@"X:akeA.mzML", condition: "", biorep: 0, fraction: 0, techrep: 0);
+            var fileB = new SpectraFileInfo(@"X:akeB.mzML", condition: "", biorep: 1, fraction: 0, techrep: 0);
+            var files = new List<SpectraFileInfo> { fileA, fileB };
+
+            // Both groups were quantified -- both carry the full sample list. pgB simply had nothing
+            // observed, so its dictionary is assigned and empty rather than full of zeros.
+            pgA.FilesForQuantification = files;
+            pgA.IntensitiesByFile = new Dictionary<SpectraFileInfo, double> { { fileA, 100.0 }, { fileB, 200.0 } };
+            pgA.PopulateSampleGroupResults();
+
+            pgB.FilesForQuantification = files;
+            pgB.IntensitiesByFile = new Dictionary<SpectraFileInfo, double>();
+            pgB.PopulateSampleGroupResults();
+
+            var proteinGroups = new List<ProteinGroup> { pgA, pgB };
+
+            int headerColumnCount = proteinGroups.First().GetTabSeparatedHeader().Split('	').Length;
+            foreach (var pg in proteinGroups)
+            {
+                Assert.That(pg.ToString().Split('	').Length, Is.EqualTo(headerColumnCount),
+                    $"Row column count for '{pg.ProteinGroupName}' does not match the header column count.");
+            }
+
+            // And the header must not depend on which group happens to be first: the writer takes it
+            // from proteinGroups.First(), which is not necessarily one that had observations.
+            Assert.That(pgB.GetTabSeparatedHeader(), Is.EqualTo(pgA.GetTabSeparatedHeader()),
+                "A quantified group with no observations must describe the same columns as one with them.");
+        }
+
+        /// <summary>
+        /// The other half of the gate, which the rectangularity test cannot see because it assigns both
+        /// fields on both groups. A group that knows its samples but was never given intensities -- the
+        /// state a quantifier leaves when it does not run -- must describe no intensity columns, because
+        /// nothing could ever fill them. This is what stops the gate from being satisfied by the sample
+        /// list alone.
+        /// </summary>
+        [Test]
+        public static void ProteinGroupWithSamplesButNoAssignedIntensities_HasNoIntensityColumns()
+        {
+            Protein prot = new Protein("MEDEEK", "protA");
+            PeptideWithSetModifications pwsm = new PeptideWithSetModifications(prot, new DigestionParams(), 1, 3, CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0);
+            ProteinGroup pg = new ProteinGroup(new HashSet<IBioPolymer> { prot },
+                new HashSet<IBioPolymerWithSetMods> { pwsm }, new HashSet<IBioPolymerWithSetMods> { pwsm });
+
+            pg.FilesForQuantification = new List<SpectraFileInfo>
+            {
+                new SpectraFileInfo(@"X:akeA.mzML", condition: "", biorep: 0, fraction: 0, techrep: 0)
+            };
+            // IntensitiesByFile deliberately not assigned.
+            pg.PopulateSampleGroupResults();
+
+            string header = pg.GetTabSeparatedHeader();
+            Assert.Multiple(() =>
+            {
+                Assert.That(header, Does.Not.Contain("Intensity_"),
+                    "no intensities were assigned, so nothing could fill an intensity column");
+                Assert.That(header, Does.Contain("SpectralCount_"),
+                    "spectral counts do not depend on quantification");
+                Assert.That(pg.ToString().Split('	').Length, Is.EqualTo(header.Split('	').Length));
+            });
+        }
+
+        /// <summary>
+        /// <summary>
+        /// The third state, and the reason the gate tests a NON-EMPTY sample list rather than merely an
+        /// assigned one. ConstructSubsetProteinGroup, which builds the per-file protein groups, assigns
+        /// an empty sample list beside an empty-but-non-null dictionary whenever no sample matches the
+        /// requested file -- the ordinary case for a protein not seen in that file. With no samples,
+        /// PopulateSampleGroupResults falls back to grouping by spectral-match file path, so the group
+        /// still renders columns; gating on the dictionary alone, or on the list being merely assigned,
+        /// would advertise intensity columns that nothing can ever fill.
+        ///
+        /// The PSM is what makes this observable: without one there are no sample groups at all and the
+        /// row is empty either way.
+        /// </summary>
+        [Test]
+        public static void ProteinGroupWithNoSamplesButPsms_HasNoIntensityColumns()
+        {
+            Protein prot = new Protein("MEDEEK", "protA");
+            PeptideWithSetModifications pwsm = new PeptideWithSetModifications(prot, new DigestionParams(), 1, 3, CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0);
+            ProteinGroup pg = new ProteinGroup(new HashSet<IBioPolymer> { prot },
+                new HashSet<IBioPolymerWithSetMods> { pwsm }, new HashSet<IBioPolymerWithSetMods> { pwsm });
+
+            // A PSM gives PopulateSampleGroupResults something to group by when there is no design.
+            pg.AllPsmsBelowOnePercentFDR.Add(GptmdFilterTests.DummySpectralMatch());
+
+            // Assigned, but empty -- both. This is what a subset for an unmatched file looks like.
+            pg.FilesForQuantification = new List<SpectraFileInfo>();
+            pg.IntensitiesByFile = new Dictionary<SpectraFileInfo, double>();
+            pg.PopulateSampleGroupResults();
+
+            Assert.That(pg.SampleGroupResults, Is.Not.Empty,
+                "the PSM should have produced a sample group, or this test cannot see the difference");
+
+            string header = pg.GetTabSeparatedHeader();
+            Assert.Multiple(() =>
+            {
+                Assert.That(header, Does.Not.Contain("Intensity_"),
+                    "there are no samples, so an intensity column could never be filled");
+                Assert.That(pg.ToString().Split('	').Length, Is.EqualTo(header.Split('	').Length));
+            });
+        }
+
         [Test]
         public static void ProteinGroupMergeTest()
         {


### PR DESCRIPTION
`AllProteinGroups.tsv` writes one header — from `proteinGroups.First()` — then a row per group. The `Intensity_` columns were gated on `SampleGroupResult.HasIntensityData`, which is **per-group**, so a protein the quantifier found nothing for emits two fewer columns than its neighbour and **every value after the gap lands under the wrong column name**. No exception, no warning.

Measured on two groups sharing a sample list where one had nothing observed: **header 28 fields, row 26**.

## It has never fired, and that is an accident about to end

`QuantificationAnalysis` assigns `IntensitiesByFile` for every protein *including unmeasured ones*, so the zeros are present and `HasIntensityData` is uniformly true. `TestMultipleProteinGroupsHeaderAndRowsHaveSameColumnCount` pins exactly that, and its own comment says so:

> mirrors how QuantificationAnalysis always assigns IntensitiesByFile, even for unmeasured proteins

mzLibs `QuantificationEngine` **omits** zero-valued cells instead, leaving an assigned-but-empty dictionary. That is what the isobaric path produces once it starts calling that engine — so this lands before #2755 rather than after it.

## The fix

The gate is now `HasAssignedSampleIntensities` — a non-empty sample list **and** an assigned dictionary. Whether a column *exists* has to be a property of the group as a whole, or a row cannot line up with a header written from a different group.

This is the same reasoning the class already applies elsewhere: `HasPeptideLevelQuantification` is documented as *"assigned uniformly so every group carries the same schema."* That was applied to `IntensityOccupancy_` and not to `Intensity_`.

`WasSearched` is untouched — it answers a different question (whether a sample groups files were searched, which SILAC needs because quantification invents one file per label). The SILAC tests confirm it still behaves.

## Three tests, and two exist because the first cannot see them

Each was verified by mutating the gate and watching the right one fail while the others passed:

| test | kills |
|---|---|
| rectangularity, one group with nothing observed | the original per-group gate (28 vs 26 before the fix) |
| samples assigned, no dictionary | `\|\|` in place of `&&` |
| no samples at all, but PSMs present | the non-empty check weakened to a null check |

The third needs the PSM to be observable: with none there are no sample groups and the row is empty either way. That is the shape a subset group takes when no sample matches the requested file — `ConstructSubsetProteinGroup` assigns an empty sample list beside an empty-but-non-null dictionary, which is the ordinary case for a protein not seen in that file.

Also noted on `TestTmtProteinGroupsHaveCountColumnsButNoIntensityColumns` that the absence it asserts describes **master**, where the multiplex branch returns before quantifying anything — not a claim that TMT output should have no intensity columns. Its `AllSame()` assertion is the half that stays true either way, and the design-file-present case still has no coverage in either repo.

## Counterpart

**mzLib #1240** makes the same correction in `BioPolymerGroup` and exposes the predicate as `protected`. The two are independent — this one fixes MetaMorpheuss own copy and needs no mzLib release. When the pin moves past #1240, this private copy goes away and `ProteinGroup` overrides the header rather than hiding it with `new`, which also closes a latent dispatch hole: `IBioPolymerGroup` declares `GetTabSeparatedHeader`, so an interface-typed call today would pair mzLibs header with MetaMorpheuss row.

133 tests green across the ProteinGroup, multiplex, SILAC and parsimony suites; full suite was green before merging the current master.