### PR TITLE
Build calibration test fixture paths with Path.Combine so they run off Windows

### DIFF
--- a/MetaMorpheus/Test/CalibrationTests.cs
+++ b/MetaMorpheus/Test/CalibrationTests.cs
@@ -40,10 +40,10 @@ namespace Test
 
             // set up original spectra file (input to calibration)
             string nonCalibratedFilePath = Path.Combine(unitTestFolder, nonCalibratedFile);
-            File.Copy(Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\SmallCalibratible_Yeast.mzML"), nonCalibratedFilePath, true);
+            File.Copy(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "SmallCalibratible_Yeast.mzML"), nonCalibratedFilePath, true);
 
             // protein db
-            string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\smalldb.fasta");
+            string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "smalldb.fasta");
 
             // set up original experimental design (input to calibration)
             SpectraFileInfo fileInfo = new(nonCalibratedFilePath, "condition", 0, 0, 0);
@@ -107,10 +107,10 @@ namespace Test
 
                 // set up original spectra file (input to calibration)
                 string nonCalibratedFilePath = Path.Combine(unitTestFolder, "filename1.mzML");
-                File.Copy(Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\SmallCalibratible_Yeast.mzML"), nonCalibratedFilePath, true);
+                File.Copy(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "SmallCalibratible_Yeast.mzML"), nonCalibratedFilePath, true);
 
                 // protein db
-                string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\smalldb.fasta");
+                string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "smalldb.fasta");
 
                 // run calibration
                 CalibrationTask calibrationTask = new();
@@ -173,10 +173,10 @@ namespace Test
 
             // set up original spectra file (input to calibration)
             string nonCalibratedFilePath = Path.Combine(unitTestFolder, "filename1.mzML");
-            File.Copy(Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\SmallCalibratible_Yeast.mzML"), nonCalibratedFilePath, true);
+            File.Copy(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "SmallCalibratible_Yeast.mzML"), nonCalibratedFilePath, true);
 
             // protein db for a non-matching organism
-            string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\gapdh.fa");
+            string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "gapdh.fa");
 
             // set up original experimental design (input to calibration)
             SpectraFileInfo fileInfo = new(nonCalibratedFilePath, "condition", 0, 0, 0);
@@ -210,14 +210,14 @@ namespace Test
             Directory.CreateDirectory(outputFolder);
 
             // set up original spectra file (input to calibration)
-            string nonCalibratedFilePath = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\mouseOne.mzML");
+            string nonCalibratedFilePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "mouseOne.mzML");
 
             // set up original experimental design (input to calibration)
             SpectraFileInfo fileInfo = new(nonCalibratedFilePath, "condition", 0, 0, 0);
             _ = ExperimentalDesign.WriteExperimentalDesignToFile(new List<SpectraFileInfo> { fileInfo });
 
             // protein db for a non-matching organism
-            string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\mouseOne.xml");
+            string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "mouseOne.xml");
 
             CalibrationTask calibrationTask = new();
 
@@ -255,8 +255,8 @@ namespace Test
             calibrationTask.CalibrationParameters.SearchType = searchType;
 
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestCalibrationLow");
-            string myFile = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\TaGe_SA_A549_3_snip.mzML");
-            string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\TaGe_SA_A549_3_snip.fasta");
+            string myFile = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "TaGe_SA_A549_3_snip.mzML");
+            string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "TaGe_SA_A549_3_snip.fasta");
             Directory.CreateDirectory(outputFolder);
 
             calibrationTask.RunTask(outputFolder, new List<DbForTask> { new DbForTask(myDatabase, false) }, new List<string> { myFile }, "test");
@@ -282,8 +282,8 @@ namespace Test
                 scoreCutoff: 1);
 
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestCalibrationLow");
-            string myFile = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\SmallCalibratible_Yeast.mzML");
-            string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\smalldb.fasta");
+            string myFile = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "SmallCalibratible_Yeast.mzML");
+            string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "smalldb.fasta");
             Directory.CreateDirectory(outputFolder);
 
             calibrationTask.RunTask(outputFolder, new List<DbForTask> { new DbForTask(myDatabase, false) }, new List<string> { myFile }, "test");
@@ -313,8 +313,8 @@ namespace Test
             calibrationTask.CommonParameters.PrecursorMassMatchMode = PrecursorMassMatchMode.MostAbundant;
 
             string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestCalibrationMostAbundant");
-            string myFile = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\SmallCalibratible_Yeast.mzML");
-            string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\smalldb.fasta");
+            string myFile = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "SmallCalibratible_Yeast.mzML");
+            string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "smalldb.fasta");
             Directory.CreateDirectory(outputFolder);
 
             // The run must complete and produce output; the apex acceptor is constructed during data-point
@@ -340,7 +340,7 @@ namespace Test
 
             // set up original spectra file (input to calibration)
             string nonCalibratedFilePath = Path.Combine(unitTestFolder, nonCalibratedFile);
-            File.Copy(Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\SmallCalibratible_Yeast.mzML"), nonCalibratedFilePath, true);
+            File.Copy(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "SmallCalibratible_Yeast.mzML"), nonCalibratedFilePath, true);
 
             // set up original experimental design (input to calibration)
             SpectraFileInfo fileInfo = new(nonCalibratedFilePath, "condition", 0, 0, 0);
@@ -351,7 +351,7 @@ namespace Test
             SearchTask searchTask = new SearchTask();
 
             // protein db
-            string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\smalldb.fasta");
+            string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "smalldb.fasta");
 
             // run the tasks
             EverythingRunnerEngine a = new EverythingRunnerEngine(
@@ -381,9 +381,9 @@ namespace Test
 
             // set up original spectra file (input to calibration)
             string nonCalibratedFilePathOne = Path.Combine(unitTestFolder, "filename1.mzML");
-            File.Copy(Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\SmallCalibratible_Yeast.mzML"), nonCalibratedFilePathOne, true);
+            File.Copy(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "SmallCalibratible_Yeast.mzML"), nonCalibratedFilePathOne, true);
             string nonCalibratedFilePathTwo = Path.Combine(unitTestFolder, "filename2.mzML");
-            File.Copy(Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\TaGe_SA_A549_3_snip.mzML"), nonCalibratedFilePathTwo, true);
+            File.Copy(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "TaGe_SA_A549_3_snip.mzML"), nonCalibratedFilePathTwo, true);
 
             // set up original experimental design (input to calibration)
             SpectraFileInfo fileInfoOne = new(nonCalibratedFilePathOne, "condition1", 0, 0, 0);
@@ -395,7 +395,7 @@ namespace Test
             SearchTask searchTask = new SearchTask();
 
             // protein db
-            string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\smalldb.fasta");
+            string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "smalldb.fasta");
 
             // run the tasks
             EverythingRunnerEngine a = new EverythingRunnerEngine(
@@ -441,14 +441,14 @@ namespace Test
 
             // set up original spectra file (input to calibration)
             string nonCalibratedFilePath = Path.Combine(unitTestFolder, "filename1.mzML");
-            File.Copy(Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\SmallCalibratible_Yeast.mzML"), nonCalibratedFilePath, true);
+            File.Copy(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "SmallCalibratible_Yeast.mzML"), nonCalibratedFilePath, true);
 
             // set up original BAD experimental design (input to calibration)
             string experimentalDesignPath = Path.Combine(unitTestFolder, "ExperimentalDesign.tsv");
             File.Copy(badExperimentalDesignPath, experimentalDesignPath, true);
 
             // protein db
-            string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\smalldb.fasta");
+            string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "smalldb.fasta");
 
             // run calibration
             CalibrationTask calibrationTask = new CalibrationTask();
@@ -484,10 +484,10 @@ namespace Test
 
             // set up original spectra file (input to calibration)
             string nonCalibratedFilePath = Path.Combine(unitTestFolder, "testfile.mzML");
-            File.Copy(Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\SmallCalibratible_Yeast.mzML"), nonCalibratedFilePath, true);
+            File.Copy(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "SmallCalibratible_Yeast.mzML"), nonCalibratedFilePath, true);
 
             // protein db
-            string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\smalldb.fasta");
+            string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "smalldb.fasta");
 
             // run calibration with Modern Search
             CalibrationTask calibrationTask = new();
@@ -535,11 +535,11 @@ namespace Test
             // set up original spectra files (need separate copies to avoid file locking issues)
             string classicFilePath = Path.Combine(unitTestFolder, "classic_test.mzML");
             string modernFilePath = Path.Combine(unitTestFolder, "modern_test.mzML");
-            File.Copy(Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\SmallCalibratible_Yeast.mzML"), classicFilePath, true);
-            File.Copy(Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\SmallCalibratible_Yeast.mzML"), modernFilePath, true);
+            File.Copy(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "SmallCalibratible_Yeast.mzML"), classicFilePath, true);
+            File.Copy(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "SmallCalibratible_Yeast.mzML"), modernFilePath, true);
 
             // protein db
-            string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\smalldb.fasta");
+            string myDatabase = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "smalldb.fasta");
 
             // run calibration with Classic Search
             CalibrationTask classicCalibrationTask = new();
@@ -719,7 +719,7 @@ namespace Test
             type.GetField("_fixedModifications", BindingFlags.NonPublic | BindingFlags.Instance)
                 .SetValue(calibrationTask, new List<Modification>());
 
-            string dbPath = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\smalldb.fasta");
+            string dbPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "smalldb.fasta");
             type.GetField("_dbFilenameList", BindingFlags.NonPublic | BindingFlags.Instance)
                 .SetValue(calibrationTask, new List<DbForTask> { new DbForTask(dbPath, false) });
 


### PR DESCRIPTION
🤖 Test-only. No production code changes, and no behaviour changes on Windows.

`Test/CalibrationTests.cs` built its fixture paths as `Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\SmallCalibratible_Yeast.mzML")`. That literal is a path only on Windows; on macOS and Linux the backslash is an ordinary filename character, so the file resolves to a single entry named `TestData\SmallCalibratible_Yeast.mzML` that does not exist. This replaces all 27 such literals with separate `Path.Combine` segments.

On Windows the two forms produce the identical string, because `Path.Combine` inserts a `DirectorySeparatorChar` between non-rooted segments and does not rewrite separators inside a segment. CI runs the test project on `windows-latest` only, so this class of bug has never been visible there — the same reason #2721 existed on the production side.

Measured off Windows, in a throwaway net10.0 harness that compiles this file against `EngineLayer` and `TaskLayer`: **15 of the 29 cases failed before, 0 fail after.** Fourteen failed as `FileNotFoundException` naming the backslash path; the fifteenth, `CalibrationRunsInMostAbundantMode`, wraps its run in `Assert.DoesNotThrow` and so failed as `Expected: No Exception to be thrown`. Nothing is left failing for any other reason, and every fixture these tests want is already in the repo.

Only path strings were changed. The 14 regex literals (`@"\d+\.\d*"`) are untouched, as are the single-segment directory and filename literals, which were already correct as `Path.Combine` arguments. No assertion in this file compares a path, and nothing derived from these strings is written into an experimental-design file or a TOML, so there is no string-identity risk on the Windows side.

One deliberate exception: `Path.Combine(experimentalDesignPath, rawFile)` in `TestExperimentalDesignErrors` combines a file path with a filename, producing a nonsense path. That is what the test wants — it only asserts on the resulting error message, and it passes on both platforms. Left alone, and flagged here because a mechanical sweep would be tempted to change it.

This is a slice of a wider pattern rather than the whole of it: roughly 550 more backslash path literals remain across about 45 other files under `Test/`, with `TestOGlyco.cs` (87) and `MetaDraw/MetaDrawTest.cs` (51) the largest. A nastier variant also exists in the same family — hardcoded drive literals like `@"C:\work\out\good_name.mzML"` — which `Path.Combine` cannot rescue. Deliberately not touched here.
