### PR TITLE
Add the TMT experimental design model and its parser

### DIFF
--- a/MetaMorpheus/EngineLayer/GlobalVariables.cs
+++ b/MetaMorpheus/EngineLayer/GlobalVariables.cs
@@ -69,6 +69,7 @@ namespace EngineLayer
         public static Dictionary<string, DissociationType> AllSupportedDissociationTypes { get; private set; }
         public static List<string> SeparationTypes { get; private set; }
         public static string ExperimentalDesignFileName { get; private set; }
+        public static string TmtExperimentalDesignFileName { get; private set; }
         public static IEnumerable<Crosslinker> Crosslinkers { get { return _KnownCrosslinkers.AsEnumerable(); } }
         public static IEnumerable<char> InvalidAminoAcids { get { return _InvalidAminoAcids.AsEnumerable(); } }
         public static List<string> OGlycanDatabasePaths { get; private set; }
@@ -84,6 +85,7 @@ namespace EngineLayer
             AnalyteType = AnalyteType.Peptide;
             _InvalidAminoAcids = new char[] { 'X', 'B', 'J', 'Z', ':', '|', ';', '[', ']', '{', '}', '(', ')', '+', '-' };
             ExperimentalDesignFileName = "ExperimentalDesign.tsv";
+            TmtExperimentalDesignFileName = "TmtDesign.txt";
             SeparationTypes = new List<string> { { "HPLC" }, { "CZE" } };
 
             SetMetaMorpheusVersion();

--- a/MetaMorpheus/EngineLayer/TmtExperimentalDesign.cs
+++ b/MetaMorpheus/EngineLayer/TmtExperimentalDesign.cs
@@ -127,6 +127,15 @@ namespace EngineLayer
             // How many cells a row needs to carry every required column.
             int minimumCells = new[] { idxFile, idxPlex, idxSample, idxChannel, idxCond, idxBio, idxFrac, idxTech }.Max() + 1;
 
+            // Normalize the provided paths ONCE, the same way the "did not contain the file(s)" check
+            // below normalizes them. The row-level in-this-run test used to compare a resolved path
+            // against these strings raw, so a provided path carrying a '..' segment matched there but
+            // not here: the row was skipped and the file was then reported as missing from a design
+            // that names it. Both file checks now read the same set.
+            var providedFullPaths = new HashSet<string>(
+                fullFilePathsWithExtension.Select(NormalizePath),
+                StringComparer.OrdinalIgnoreCase);
+
             for (int i = 1; i < lines.Length; i++)
             {
                 var line = lines[i];
@@ -162,8 +171,7 @@ namespace EngineLayer
                 string full = ResolveAgainstDesignFile(file, designDirectory);
 
                 // Only consider lines for files actually in this run (mirrors ExperimentalDesign behavior)
-                bool inThisRun = !fullFilePathsWithExtension.Any() ||
-                    fullFilePathsWithExtension.Contains(full, StringComparer.OrdinalIgnoreCase);
+                bool inThisRun = providedFullPaths.Count == 0 || providedFullPaths.Contains(full);
 
                 dataRowsSeen++;
                 if (inThisRun)
@@ -312,15 +320,11 @@ namespace EngineLayer
             if (fullFilePathsWithExtension != null && fullFilePathsWithExtension.Count > 0)
             {
                 // normalize and compare case-insensitively using full paths
-                var provided = new HashSet<string>(
-                    fullFilePathsWithExtension.Select(p => { try { return Path.GetFullPath(p); } catch { return p; } }),
-                    StringComparer.OrdinalIgnoreCase);
-
                 var defined = new HashSet<string>(
-                    fileState.Keys.Select(p => { try { return Path.GetFullPath(p); } catch { return p; } }),
+                    fileState.Keys.Select(NormalizePath),
                     StringComparer.OrdinalIgnoreCase);
 
-                var notDefined = provided.Where(p => !defined.Contains(p)).ToList();
+                var notDefined = providedFullPaths.Where(p => !defined.Contains(p)).ToList();
                 if (notDefined.Any())
                 {
                     errors.Add("Error: The TMT design did not contain the file(s): " + string.Join(", ", notDefined));
@@ -336,6 +340,16 @@ namespace EngineLayer
         /// TmtDesign.txt written alongside its raw files expects to be read from, and only then
         /// against the process working directory.
         /// </summary>
+        /// <summary>
+        /// Full path when the runtime can produce one, the original string when it cannot. Used on both
+        /// sides of every file comparison so the two file checks can never disagree.
+        /// </summary>
+        private static string NormalizePath(string path)
+        {
+            try { return Path.GetFullPath(path); }
+            catch { return path; }
+        }
+
         private static string ResolveAgainstDesignFile(string file, string designDirectory)
         {
             try

--- a/MetaMorpheus/EngineLayer/TmtExperimentalDesign.cs
+++ b/MetaMorpheus/EngineLayer/TmtExperimentalDesign.cs
@@ -29,8 +29,20 @@ namespace EngineLayer
         /// <summary>The column name carrying <see cref="TmtSampleType"/>.</summary>
         public const string SampleTypeColumn = "Sample Type";
 
-        // New validation helper: every (SampleName, BioRep, Fraction, TechRep) must be unique
-        private static string ValidateUniqueSampleBioFracTech(IEnumerable<(string Sample, int Bio, int Fraction, int Tech)> tuples)
+        /// <summary>
+        /// Every (Sample, BioRep, Fraction, TechRep) must be unique WITHIN A PLEX.
+        /// </summary>
+        /// <remarks>
+        /// Per plex rather than per file, because a bridge channel is by definition the same material
+        /// carried in more than one plex under one name -- which is what <see cref="TmtSampleType.Bridge"/>
+        /// exists to describe. Collecting these across the whole file rejected exactly that design, and
+        /// the only way through was to rename the bridges apart, which throws away the fact that they
+        /// are the same material and so defeats the point of having them.
+        ///
+        /// Keyed per plex still catches the case worth catching: one plex describing the same sample
+        /// twice.
+        /// </remarks>
+        private static string ValidateUniqueSampleBioFracTech(IEnumerable<(string Plex, string Sample, int Bio, int Fraction, int Tech)> tuples)
         {
             var duplicates = tuples
                 .GroupBy(t => t)
@@ -42,14 +54,21 @@ namespace EngineLayer
                 return null;
 
             var msgs = duplicates.Select(d =>
-                $"Duplicate combination detected: Sample \"{d.Sample}\" Biorep {d.Bio} Fraction {d.Fraction} Techrep {d.Tech}");
+                $"Duplicate combination detected in plex \"{d.Plex}\": Sample \"{d.Sample}\" " +
+                $"Biorep {d.Bio} Fraction {d.Fraction} Techrep {d.Tech}");
             return string.Join(Environment.NewLine, msgs);
         }
 
         // RETURN: files where each file carries its plex annotations
+        /// <param name="fullFilePathsWithExtension">
+        /// The files this run actually searched, used to ignore design rows naming anything else.
+        /// Null or empty means "do not filter" -- the same meaning the guard in ToMzLibDesign gives it,
+        /// and the reason this no longer throws on null.
+        /// </param>
         public static List<TmtFileInfo> Read(string tmtDesignPath, List<string> fullFilePathsWithExtension, out List<string> errors)
         {
             errors = new List<string>();
+            fullFilePathsWithExtension ??= new List<string>();
             var files = new List<TmtFileInfo>();
 
             // How many data rows the file had, and how many named a file in this run. A design whose
@@ -64,7 +83,7 @@ namespace EngineLayer
             var fileStateConflicts = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
 
             // Collect tuples for uniqueness validation
-            var uniqueTuples = new List<(string Sample, int Bio, int Fraction, int Tech)>();
+            var uniqueTuples = new List<(string Plex, string Sample, int Bio, int Fraction, int Tech)>();
 
             if (!File.Exists(tmtDesignPath))
             {
@@ -127,6 +146,14 @@ namespace EngineLayer
                 var file = cols[idxFile].Trim();
                 if (string.IsNullOrEmpty(file)) continue;
 
+                // A row naming a file and no channel is the placeholder Write emits for a file with no
+                // annotations yet, so that a part-authored design does not lose the file. Read used to
+                // reject it -- the blank Biological Replicate failed int.TryParse, the row was skipped,
+                // and the file was then reported as missing from the design. The placeholder therefore
+                // lost exactly what it existed to preserve, and a part-authored design is the NORMAL
+                // state while someone is filling one in through the GUI.
+                bool channelless = string.IsNullOrWhiteSpace(cols[idxChannel]);
+
                 // Resolve a relative name against the design file's own directory, not the process
                 // working directory. A TmtDesign.txt written with bare file names sits beside the raw
                 // files it names, and Path.GetFullPath alone would only match when the process happened
@@ -142,6 +169,22 @@ namespace EngineLayer
                 if (inThisRun)
                 {
                     dataRowsMatched++;
+
+                    if (channelless)
+                    {
+                        // Register the file with no annotations and move on. Fraction and technical
+                        // replicate still parse when present, so a placeholder carrying them keeps them.
+                        int.TryParse(cols[idxFrac].Trim(), out int placeholderFrac);
+                        int.TryParse(cols[idxTech].Trim(), out int placeholderTech);
+                        if (!fileState.ContainsKey(full))
+                        {
+                            fileState[full] = (cols[idxPlex].Trim(),
+                                placeholderFrac < 1 ? 1 : placeholderFrac,
+                                placeholderTech < 1 ? 1 : placeholderTech);
+                        }
+                        continue;
+                    }
+
                     var plex    = cols[idxPlex].Trim();
                     var sample  = cols[idxSample].Trim();
                     var tag     = cols[idxChannel].Trim();
@@ -155,9 +198,13 @@ namespace EngineLayer
                         continue;
                     }
 
-                    if (!int.TryParse(cols[idxBio].Trim(), out var bio))
+                    // >= 1, matching Fraction and Technical Replicate. A bare TryParse accepted 0 and
+                    // -3 silently, and ToMzLibDesign passes the value straight through to
+                    // ISampleInfo.BiologicalReplicate. If these are ever meant to be 0-based, all three
+                    // columns have to change together rather than one drifting from the other two.
+                    if (!int.TryParse(cols[idxBio].Trim(), out var bio) || bio < 1)
                     {
-                        errors.Add($"Line {i + 1}: invalid Biological Replicate.");
+                        errors.Add($"Line {i + 1}: Biological Replicate must be >= 1.");
                         continue;
                     }
                     if (!int.TryParse(cols[idxFrac].Trim(), out var frac) || frac < 1)
@@ -173,7 +220,7 @@ namespace EngineLayer
 
                     // Record tuple for uniqueness validation (ignore completely blank sample name)
                     if (!string.IsNullOrWhiteSpace(sample))
-                        uniqueTuples.Add((sample, bio, frac, tech));
+                        uniqueTuples.Add((plex, sample, bio, frac, tech));
 
                     // Per-file consistency
                     if (fileState.TryGetValue(full, out var state))
@@ -201,7 +248,7 @@ namespace EngineLayer
                         byTag = new Dictionary<string, TmtPlexAnnotation>(StringComparer.OrdinalIgnoreCase);
                         plexToAnnotations[plex] = byTag;
                     }
-                    if (!byTag.ContainsKey(tag))
+                    if (!byTag.TryGetValue(tag, out var existing))
                     {
                         byTag[tag] = new TmtPlexAnnotation
                         {
@@ -211,6 +258,22 @@ namespace EngineLayer
                             BiologicalReplicate = bio,
                             SampleType = sampleType
                         };
+                    }
+                    // Fractions of one plex legitimately repeat the same channel-to-sample map, which is
+                    // why this is keyed per plex and why a repeat is collapsed rather than refused. But
+                    // collapsing rows that DISAGREE silently discards one of them: two rows naming
+                    // channel 126 as different samples kept the first and said nothing. The uniqueness
+                    // rule above cannot catch it either -- two different sample names are two different
+                    // tuples, so it only fires when the duplicates agree, which is the harmless case.
+                    else if (!string.Equals(existing.SampleName, sample, StringComparison.OrdinalIgnoreCase)
+                             || !string.Equals(existing.Condition, cond, StringComparison.OrdinalIgnoreCase)
+                             || existing.BiologicalReplicate != bio
+                             || existing.SampleType != sampleType)
+                    {
+                        errors.Add(
+                            $"Line {i + 1}: plex \"{plex}\" channel \"{tag}\" is described twice and the " +
+                            $"descriptions disagree — \"{existing.SampleName}\"/\"{existing.Condition}\" " +
+                            $"versus \"{sample}\"/\"{cond}\".");
                     }
                 }
             }

--- a/MetaMorpheus/EngineLayer/TmtExperimentalDesign.cs
+++ b/MetaMorpheus/EngineLayer/TmtExperimentalDesign.cs
@@ -1,0 +1,639 @@
+﻿using FlashLFQ;
+using MassSpectrometry;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace EngineLayer
+{
+    public static class TmtExperimentalDesign
+    {
+        /// <summary>
+        /// The header this class writes. "Sample Type" is the newest column and is OPTIONAL on read
+        /// (see <see cref="RequiredColumns"/>), so a design file written before it existed still loads.
+        /// </summary>
+        public const string Header = "File\tPlex\tSample Name\tTMT Channel\tCondition\tBiological Replicate\tFraction\tTechnical Replicate\tSample Type";
+
+        /// <summary>
+        /// The columns a design file must carry to be readable. "Sample Type" is deliberately absent:
+        /// requiring it would invalidate every TmtDesign.txt written before it was added, and a file
+        /// without it is unambiguous - every channel is a study sample.
+        /// </summary>
+        public static readonly IReadOnlyList<string> RequiredColumns = new[]
+        {
+            "File", "Plex", "Sample Name", "TMT Channel", "Condition",
+            "Biological Replicate", "Fraction", "Technical Replicate"
+        };
+
+        /// <summary>The column name carrying <see cref="TmtSampleType"/>.</summary>
+        public const string SampleTypeColumn = "Sample Type";
+
+        // New validation helper: every (SampleName, BioRep, Fraction, TechRep) must be unique
+        private static string ValidateUniqueSampleBioFracTech(IEnumerable<(string Sample, int Bio, int Fraction, int Tech)> tuples)
+        {
+            var duplicates = tuples
+                .GroupBy(t => t)
+                .Where(g => g.Count() > 1)
+                .Select(g => g.Key)
+                .ToList();
+
+            if (duplicates.Count == 0)
+                return null;
+
+            var msgs = duplicates.Select(d =>
+                $"Duplicate combination detected: Sample \"{d.Sample}\" Biorep {d.Bio} Fraction {d.Fraction} Techrep {d.Tech}");
+            return string.Join(Environment.NewLine, msgs);
+        }
+
+        // RETURN: files where each file carries its plex annotations
+        public static List<TmtFileInfo> Read(string tmtDesignPath, List<string> fullFilePathsWithExtension, out List<string> errors)
+        {
+            errors = new List<string>();
+            var files = new List<TmtFileInfo>();
+
+            // How many data rows the file had, and how many named a file in this run. A design whose
+            // rows all fail to resolve is not an empty design -- it is a design pointed at the wrong
+            // place -- and it used to return no errors at all.
+            int dataRowsSeen = 0;
+            int dataRowsMatched = 0;
+
+            // Collect per-plex annotations (unique by tag) and per-file (plex, frac, tech)
+            var plexToAnnotations = new Dictionary<string, Dictionary<string, TmtPlexAnnotation>>(StringComparer.OrdinalIgnoreCase);
+            var fileState = new Dictionary<string, (string Plex, int Fraction, int TechRep)>(StringComparer.OrdinalIgnoreCase);
+            var fileStateConflicts = new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase);
+
+            // Collect tuples for uniqueness validation
+            var uniqueTuples = new List<(string Sample, int Bio, int Fraction, int Tech)>();
+
+            if (!File.Exists(tmtDesignPath))
+            {
+                errors.Add("TMT design file not found!");
+                return files;
+            }
+
+            string designDirectory;
+            try { designDirectory = Path.GetDirectoryName(Path.GetFullPath(tmtDesignPath)); }
+            catch { designDirectory = null; }
+
+            string[] lines;
+            try
+            {
+                lines = File.ReadAllLines(tmtDesignPath);
+            }
+            catch (Exception ex)
+            {
+                errors.Add("Could not read TMT design file: " + ex.Message);
+                return files;
+            }
+
+            if (lines.Length == 0 || !IsHeaderValid(lines[0]))
+            {
+                errors.Add("TMT design file header is invalid.");
+                return files;
+            }
+
+            var headers = lines[0].Split('\t');
+            int idxFile   = Array.FindIndex(headers, h => string.Equals(h.Trim(), "File", StringComparison.OrdinalIgnoreCase));
+            int idxPlex   = Array.FindIndex(headers, h => string.Equals(h.Trim(), "Plex", StringComparison.OrdinalIgnoreCase));
+            int idxSample = Array.FindIndex(headers, h => string.Equals(h.Trim(), "Sample Name", StringComparison.OrdinalIgnoreCase));
+            int idxChannel= Array.FindIndex(headers, h => string.Equals(h.Trim(), "TMT Channel", StringComparison.OrdinalIgnoreCase));
+            int idxCond   = Array.FindIndex(headers, h => string.Equals(h.Trim(), "Condition", StringComparison.OrdinalIgnoreCase));
+            int idxBio    = Array.FindIndex(headers, h => string.Equals(h.Trim(), "Biological Replicate", StringComparison.OrdinalIgnoreCase));
+            int idxFrac   = Array.FindIndex(headers, h => string.Equals(h.Trim(), "Fraction", StringComparison.OrdinalIgnoreCase));
+            int idxTech   = Array.FindIndex(headers, h => string.Equals(h.Trim(), "Technical Replicate", StringComparison.OrdinalIgnoreCase));
+            // -1 when the file predates the column; every channel then reads as a study sample.
+            int idxType   = Array.FindIndex(headers, h => string.Equals(h.Trim(), SampleTypeColumn, StringComparison.OrdinalIgnoreCase));
+
+            // How many cells a row needs to carry every required column.
+            int minimumCells = new[] { idxFile, idxPlex, idxSample, idxChannel, idxCond, idxBio, idxFrac, idxTech }.Max() + 1;
+
+            for (int i = 1; i < lines.Length; i++)
+            {
+                var line = lines[i];
+                if (string.IsNullOrWhiteSpace(line)) continue;
+
+                var cols = line.Split('\t');
+                // A row must reach every REQUIRED column, not every column in the header. Comparing
+                // against the full header width would reject a row whose only omission is the
+                // optional trailing Sample Type cell — which is exactly what a design file written
+                // before that column existed looks like.
+                if (cols.Length < minimumCells)
+                {
+                    errors.Add($"Line {i + 1} has fewer columns than expected.");
+                    continue;
+                }
+
+                var file = cols[idxFile].Trim();
+                if (string.IsNullOrEmpty(file)) continue;
+
+                // Resolve a relative name against the design file's own directory, not the process
+                // working directory. A TmtDesign.txt written with bare file names sits beside the raw
+                // files it names, and Path.GetFullPath alone would only match when the process happened
+                // to be running in that folder -- so the same design file worked or silently matched
+                // nothing depending on where MetaMorpheus was launched from.
+                string full = ResolveAgainstDesignFile(file, designDirectory);
+
+                // Only consider lines for files actually in this run (mirrors ExperimentalDesign behavior)
+                bool inThisRun = !fullFilePathsWithExtension.Any() ||
+                    fullFilePathsWithExtension.Contains(full, StringComparer.OrdinalIgnoreCase);
+
+                dataRowsSeen++;
+                if (inThisRun)
+                {
+                    dataRowsMatched++;
+                    var plex    = cols[idxPlex].Trim();
+                    var sample  = cols[idxSample].Trim();
+                    var tag     = cols[idxChannel].Trim();
+                    var cond    = cols[idxCond].Trim();
+
+                    var rawType = idxType >= 0 && idxType < cols.Length ? cols[idxType].Trim() : string.Empty;
+                    if (!TryParseSampleType(rawType, out var sampleType))
+                    {
+                        errors.Add($"Line {i + 1}: '{rawType}' is not a recognised Sample Type. " +
+                                   $"Use one of: {string.Join(", ", SampleTypeNames)}.");
+                        continue;
+                    }
+
+                    if (!int.TryParse(cols[idxBio].Trim(), out var bio))
+                    {
+                        errors.Add($"Line {i + 1}: invalid Biological Replicate.");
+                        continue;
+                    }
+                    if (!int.TryParse(cols[idxFrac].Trim(), out var frac) || frac < 1)
+                    {
+                        errors.Add($"Line {i + 1}: Fraction must be >= 1.");
+                        continue;
+                    }
+                    if (!int.TryParse(cols[idxTech].Trim(), out var tech) || tech < 1)
+                    {
+                        errors.Add($"Line {i + 1}: Technical Replicate must be >= 1.");
+                        continue;
+                    }
+
+                    // Record tuple for uniqueness validation (ignore completely blank sample name)
+                    if (!string.IsNullOrWhiteSpace(sample))
+                        uniqueTuples.Add((sample, bio, frac, tech));
+
+                    // Per-file consistency
+                    if (fileState.TryGetValue(full, out var state))
+                    {
+                        if (!string.Equals(state.Plex, plex, StringComparison.OrdinalIgnoreCase) ||
+                            state.Fraction != frac ||
+                            state.TechRep != tech)
+                        {
+                            if (!fileStateConflicts.TryGetValue(full, out var set))
+                            {
+                                set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                                fileStateConflicts[full] = set;
+                            }
+                            set.Add($"{plex}|{frac}|{tech}");
+                        }
+                    }
+                    else
+                    {
+                        fileState[full] = (plex, frac, tech);
+                    }
+
+                    // Plex annotations
+                    if (!plexToAnnotations.TryGetValue(plex, out var byTag))
+                    {
+                        byTag = new Dictionary<string, TmtPlexAnnotation>(StringComparer.OrdinalIgnoreCase);
+                        plexToAnnotations[plex] = byTag;
+                    }
+                    if (!byTag.ContainsKey(tag))
+                    {
+                        byTag[tag] = new TmtPlexAnnotation
+                        {
+                            Tag = tag,
+                            SampleName = sample,
+                            Condition = cond,
+                            BiologicalReplicate = bio,
+                            SampleType = sampleType
+                        };
+                    }
+                }
+            }
+
+            // A design that named files, none of which belong to this run, is a mistake rather than an
+            // empty design -- most often a design written for different data, or one whose relative
+            // paths do not resolve. Reporting nothing here let the command line print success over an
+            // annotation set that was silently empty.
+            if (dataRowsSeen > 0 && dataRowsMatched == 0 && fullFilePathsWithExtension.Any())
+            {
+                errors.Add($"None of the {dataRowsSeen} row(s) in the TMT design name a file in this run. " +
+                           "Check that the File column matches the spectra files being searched.");
+            }
+
+            // Consistency errors
+            foreach (var kvp in fileStateConflicts)
+                errors.Add($"File '{kvp.Key}' has inconsistent Plex/Fraction/TechRep assignments: {string.Join(", ", kvp.Value)}");
+
+            // Uniqueness validation of (Sample,Bio,Fraction,Tech)
+            var uniquenessError = ValidateUniqueSampleBioFracTech(uniqueTuples);
+            if (uniquenessError != null)
+                errors.Add(uniquenessError);
+
+            // Build file list with annotations embedded
+            foreach (var kv in fileState)
+            {
+                var plex = kv.Value.Plex ?? string.Empty;
+                var anns = plexToAnnotations.TryGetValue(plex, out var tags)
+                    ? tags.Values.OrderBy(a => a.Tag, StringComparer.OrdinalIgnoreCase).ToList()
+                    : new List<TmtPlexAnnotation>();
+
+                files.Add(new TmtFileInfo(kv.Key, plex, kv.Value.Fraction, kv.Value.TechRep, anns));
+            }
+
+            // Ensure all provided files are defined in the TMT design (mirrors ExperimentalDesign behavior)
+            if (fullFilePathsWithExtension != null && fullFilePathsWithExtension.Count > 0)
+            {
+                // normalize and compare case-insensitively using full paths
+                var provided = new HashSet<string>(
+                    fullFilePathsWithExtension.Select(p => { try { return Path.GetFullPath(p); } catch { return p; } }),
+                    StringComparer.OrdinalIgnoreCase);
+
+                var defined = new HashSet<string>(
+                    fileState.Keys.Select(p => { try { return Path.GetFullPath(p); } catch { return p; } }),
+                    StringComparer.OrdinalIgnoreCase);
+
+                var notDefined = provided.Where(p => !defined.Contains(p)).ToList();
+                if (notDefined.Any())
+                {
+                    errors.Add("Error: The TMT design did not contain the file(s): " + string.Join(", ", notDefined));
+                }
+            }
+
+            return files;
+        }
+
+        /// <summary>
+        /// Resolves a File cell to a full path. A rooted path is taken as written; a bare or relative
+        /// name is resolved against the design file's own directory first, since that is where a
+        /// TmtDesign.txt written alongside its raw files expects to be read from, and only then
+        /// against the process working directory.
+        /// </summary>
+        private static string ResolveAgainstDesignFile(string file, string designDirectory)
+        {
+            try
+            {
+                if (Path.IsPathRooted(file))
+                {
+                    return Path.GetFullPath(file);
+                }
+
+                if (!string.IsNullOrEmpty(designDirectory))
+                {
+                    string besideDesign = Path.GetFullPath(Path.Combine(designDirectory, file));
+                    if (File.Exists(besideDesign))
+                    {
+                        return besideDesign;
+                    }
+                }
+
+                return Path.GetFullPath(file);
+            }
+            catch
+            {
+                return file;
+            }
+        }
+
+        public static string Write(List<TmtFileInfo> files)
+        {
+            if (files == null || files.Count == 0)
+                throw new InvalidOperationException("No TMT files to write.");
+
+            var dir = Directory.GetParent(files.First().FullFilePathWithExtension)!.FullName;
+            var path = Path.Combine(dir, GlobalVariables.TmtExperimentalDesignFileName);
+
+            using var sw = new StreamWriter(path);
+            sw.WriteLine(Header);
+
+            foreach (var file in files.OrderBy(f => f.Fraction).ThenBy(f => f.TechnicalReplicate))
+            {
+                var plex = file.Plex ?? "";
+                var anns = file.Annotations ?? Array.Empty<TmtPlexAnnotation>();
+
+                if (anns.Count > 0)
+                {
+                    foreach (var a in anns)
+                    {
+                        sw.WriteLine($"{file.FullFilePathWithExtension}\t{plex}\t{a.SampleName}\t{a.Tag}\t{a.Condition}\t{a.BiologicalReplicate}\t{file.Fraction}\t{file.TechnicalReplicate}\t{ToDesignFileValue(a.SampleType)}");
+                    }
+                }
+                else
+                {
+                    sw.WriteLine($"{file.FullFilePathWithExtension}\t{plex}\t\t\t\t\t{file.Fraction}\t{file.TechnicalReplicate}\t");
+                }
+            }
+
+            return path;
+        }
+
+        #region Projection to mzLib
+
+        /// <summary>
+        /// Projects a design onto mzLib's <see cref="IExperimentalDesign"/>, the contract
+        /// <c>QuantificationEngine</c> consumes.
+        ///
+        /// The design file is only a carrier; this is the thing quantification actually runs on, so
+        /// a second carrier (an SDRF-Proteomics file, say) means a second method like this one rather
+        /// than a different engine.
+        /// </summary>
+        /// <param name="files">The parsed design, from <see cref="Read"/>.</param>
+        /// <param name="tag">
+        /// The isobaric tag the search used. It supplies the channel order and the reporter m/z
+        /// values, neither of which the design file states.
+        /// </param>
+        /// <param name="errors">Everything that made the projection impossible or lossy.</param>
+        /// <returns>
+        /// A design keyed by file name WITH extension, matching what
+        /// <c>QuantificationEngine.PivotByFile</c> looks up. Null when <paramref name="errors"/> is
+        /// non-empty, so a caller cannot half-use a broken design.
+        /// </returns>
+        /// <remarks>
+        /// Two contracts are load-bearing here, and getting either wrong mislabels every channel
+        /// silently rather than failing:
+        ///
+        /// 1. ORDER. mzLib requires the ISampleInfo array to line up positionally with
+        ///    <c>ISpectralMatch.Intensities</c>. MetaMorpheus fills that array in
+        ///    <see cref="IsobaricMassTag.GetReporterIonIntensities"/>, which walks
+        ///    <see cref="IsobaricMassTag.ReporterIonMzs"/> — sorted ascending. So the array emitted
+        ///    here is in tag order, NOT the order rows happened to appear in the design file.
+        ///
+        /// 2. LENGTH. That same method returns one intensity per channel the tag defines, whether or
+        ///    not the design annotated it. So every tag channel gets an entry; an unannotated one
+        ///    becomes an <see cref="TmtSampleType.Empty"/> channel rather than being skipped, which
+        ///    would shift every later channel by one.
+        /// </remarks>
+        public static IExperimentalDesign ToMzLibDesign(
+            IEnumerable<TmtFileInfo> files,
+            IsobaricMassTag tag,
+            out List<string> errors)
+        {
+            errors = new List<string>();
+
+            var fileList = files?.ToList();
+            if (fileList == null || fileList.Count == 0)
+            {
+                errors.Add("No TMT design entries to convert.");
+                return null;
+            }
+            if (tag == null)
+            {
+                errors.Add("No isobaric mass tag was supplied, so reporter ion m/z values are unknown. " +
+                           "Check that the search's multiplex label is set.");
+                return null;
+            }
+
+            var channelLabels = IsobaricMassTag.GetReporterIonLabels(tag.TagType);
+            if (channelLabels == null || channelLabels.Count == 0)
+            {
+                errors.Add($"No channel labels are known for isobaric tag {tag.TagType}.");
+                return null;
+            }
+            if (tag.ReporterIonMzs == null || tag.ReporterIonMzs.Length != channelLabels.Count)
+            {
+                errors.Add($"Isobaric tag {tag.TagType} defines {channelLabels.Count} channels but " +
+                           $"{tag.ReporterIonMzs?.Length ?? 0} reporter ion m/z values. The modification " +
+                           "definition and the channel list disagree.");
+                return null;
+            }
+
+            // Plex is a free-text label in the design file but an int on IsobaricQuantSampleInfo.
+            // Assign by sorted order so the same design always yields the same ids.
+            var plexIds = fileList
+                .Select(f => f.Plex ?? string.Empty)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(p => p, StringComparer.OrdinalIgnoreCase)
+                .Select((plex, index) => (plex, id: index + 1))
+                .ToDictionary(x => x.plex, x => x.id, StringComparer.OrdinalIgnoreCase);
+
+            var design = new Dictionary<string, ISampleInfo[]>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var file in fileList)
+            {
+                string fileName = Path.GetFileName(file.FullFilePathWithExtension);
+                if (string.IsNullOrEmpty(fileName))
+                {
+                    errors.Add($"A design entry has no file name: '{file.FullFilePathWithExtension}'.");
+                    continue;
+                }
+                if (design.ContainsKey(fileName))
+                {
+                    errors.Add($"Two design entries share the file name '{fileName}'. " +
+                               "Quantification keys channels by file name, so the names must be distinct.");
+                    continue;
+                }
+
+                var byTag = new Dictionary<string, TmtPlexAnnotation>(StringComparer.OrdinalIgnoreCase);
+                foreach (var annotation in file.Annotations ?? Array.Empty<TmtPlexAnnotation>())
+                {
+                    if (!channelLabels.Contains(annotation.Tag, StringComparer.OrdinalIgnoreCase))
+                    {
+                        errors.Add($"File '{fileName}' annotates channel '{annotation.Tag}', which is not a " +
+                                   $"channel of {tag.TagType}. Expected one of: {string.Join(", ", channelLabels)}.");
+                        continue;
+                    }
+                    byTag[annotation.Tag] = annotation;
+                }
+
+                var samples = new ISampleInfo[channelLabels.Count];
+                for (int i = 0; i < channelLabels.Count; i++)
+                {
+                    string label = channelLabels[i];
+                    byTag.TryGetValue(label, out var annotation);
+
+                    var sampleType = annotation?.SampleType ?? TmtSampleType.Empty;
+
+                    samples[i] = new IsobaricQuantSampleInfo(
+                        fullFilePathWithExtension: file.FullFilePathWithExtension,
+                        condition: annotation?.Condition ?? string.Empty,
+                        biologicalReplicate: annotation?.BiologicalReplicate ?? 0,
+                        technicalReplicate: file.TechnicalReplicate,
+                        fraction: file.Fraction,
+                        plexId: plexIds[file.Plex ?? string.Empty],
+                        channelLabel: label,
+                        reporterIonMz: tag.ReporterIonMzs[i],
+                        isReferenceChannel: IsReferenceChannel(sampleType));
+                }
+
+                design[fileName] = samples;
+            }
+
+            return errors.Count > 0 ? null : new TmtMzLibExperimentalDesign(design);
+        }
+
+        /// <summary>
+        /// The <see cref="IExperimentalDesign"/> returned by <see cref="ToMzLibDesign"/>.
+        /// </summary>
+        private sealed class TmtMzLibExperimentalDesign : IExperimentalDesign
+        {
+            public TmtMzLibExperimentalDesign(Dictionary<string, ISampleInfo[]> design)
+            {
+                FileNameSampleInfoDictionary = design;
+            }
+
+            public Dictionary<string, ISampleInfo[]> FileNameSampleInfoDictionary { get; }
+        }
+
+        #endregion
+
+        #region Sample Type
+
+        /// <summary>
+        /// The accepted spellings, for error messages and for the GUI's drop-down.
+        /// </summary>
+        public static readonly IReadOnlyList<string> SampleTypeNames = new[]
+        {
+            "study sample", "reference", "bridge", "carrier", "empty"
+        };
+
+        /// <summary>
+        /// Reads a Sample Type cell. An empty cell is a study sample, which is what a design file
+        /// written before the column existed means. Comparison is case-insensitive, and the
+        /// SDRF-Proteomics spellings are accepted as-is so the two formats agree.
+        /// </summary>
+        public static bool TryParseSampleType(string value, out TmtSampleType sampleType)
+        {
+            sampleType = TmtSampleType.StudySample;
+
+            if (string.IsNullOrWhiteSpace(value))
+                return true;
+
+            switch (value.Trim().ToLowerInvariant())
+            {
+                case "study sample":
+                case "studysample":
+                case "sample":
+                    sampleType = TmtSampleType.StudySample; return true;
+                case "reference":
+                case "reference channel":
+                case "pooled":
+                    sampleType = TmtSampleType.Reference; return true;
+                case "bridge":
+                case "bridge channel":
+                    sampleType = TmtSampleType.Bridge; return true;
+                case "carrier":
+                case "carrier channel":
+                    sampleType = TmtSampleType.Carrier; return true;
+                case "empty":
+                case "unused":
+                    sampleType = TmtSampleType.Empty; return true;
+                default:
+                    return false;
+            }
+        }
+
+        /// <summary>The spelling written back out, so a read/write round trip is stable.</summary>
+        public static string ToDesignFileValue(TmtSampleType sampleType) => sampleType switch
+        {
+            TmtSampleType.StudySample => "study sample",
+            TmtSampleType.Reference => "reference",
+            TmtSampleType.Bridge => "bridge",
+            TmtSampleType.Carrier => "carrier",
+            TmtSampleType.Empty => "empty",
+            _ => "study sample"
+        };
+
+        /// <summary>
+        /// True when this channel normalizes the others rather than being quantified against them.
+        /// This is the single bit mzLib's <see cref="IsobaricQuantSampleInfo.IsReferenceChannel"/>
+        /// carries, and the only thing <c>ReferenceChannelNormalization</c> asks about.
+        /// </summary>
+        public static bool IsReferenceChannel(TmtSampleType sampleType) =>
+            sampleType is TmtSampleType.Reference or TmtSampleType.Bridge;
+
+        #endregion
+
+        private static bool IsHeaderValid(string headerLine)
+        {
+            if (string.Equals(headerLine, Header, StringComparison.Ordinal))
+                return true;
+
+            var parts = headerLine.Split('\t').Select(s => s.Trim().ToLowerInvariant()).ToHashSet();
+            return RequiredColumns.Select(c => c.ToLowerInvariant()).All(parts.Contains);
+        }
+    }
+
+    public sealed class TmtFileInfo
+    {
+        public TmtFileInfo(string fullFilePathWithExtension, string plex, int fraction, int technicalReplicate, IReadOnlyList<TmtPlexAnnotation> annotations)
+        {
+            FullFilePathWithExtension = fullFilePathWithExtension;
+            Plex = plex ?? string.Empty;
+            Fraction = fraction;
+            TechnicalReplicate = technicalReplicate;
+            Annotations = annotations ?? Array.Empty<TmtPlexAnnotation>();
+        }
+
+        public string FullFilePathWithExtension { get; }
+        public string Plex { get; }
+        public int Fraction { get; }             // 1-based
+        public int TechnicalReplicate { get; }   // 1-based
+        public IReadOnlyList<TmtPlexAnnotation> Annotations { get; } // All tags for this file's plex
+        /// <summary>
+        /// Identity is the file path, compared the way <see cref="TmtExperimentalDesign.Read"/>
+        /// compares it -- case-insensitively, because that is how the design file keys files.
+        /// </summary>
+        public override bool Equals(object obj)
+        {
+            return obj is TmtFileInfo other
+                && string.Equals(FullFilePathWithExtension, other.FullFilePathWithExtension,
+                    StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override int GetHashCode()
+        {
+            return StringComparer.OrdinalIgnoreCase.GetHashCode(FullFilePathWithExtension ?? string.Empty);
+        }
+
+        public override string ToString()
+        {
+            return Path.GetFileName(FullFilePathWithExtension);
+        }
+    }
+
+    public sealed class TmtPlexAnnotation
+    {
+        public string Tag { get; set; } = "";
+        public string SampleName { get; set; } = "";
+        public string Condition { get; set; } = "";
+        public int BiologicalReplicate { get; set; }
+
+        /// <summary>
+        /// What this channel is for. Defaults to <see cref="TmtSampleType.StudySample"/>, which is
+        /// what a design file written before the column existed means.
+        /// </summary>
+        public TmtSampleType SampleType { get; set; } = TmtSampleType.StudySample;
+    }
+
+    /// <summary>
+    /// What a channel is for within its plex.
+    ///
+    /// The names and spellings are taken from SDRF-Proteomics'
+    /// <c>characteristics[sample type]</c> rather than invented here, so that a design read from an
+    /// SDRF file later maps through the same switch as one read from a TmtDesign.txt. That is also
+    /// why this is an enum rather than the single boolean mzLib consumes: mzLib's
+    /// <c>IsobaricQuantSampleInfo.IsReferenceChannel</c> only needs to know whether a channel
+    /// normalizes the others, but the design file is worth keeping more faithful than that.
+    /// </summary>
+    public enum TmtSampleType
+    {
+        /// <summary>An ordinary experimental channel. The default.</summary>
+        StudySample,
+
+        /// <summary>A pooled reference channel, used to normalize the other channels in its plex.</summary>
+        Reference,
+
+        /// <summary>A bridge channel, shared across plexes to make them comparable.</summary>
+        Bridge,
+
+        /// <summary>A carrier channel: high-load material added to boost signal, never quantified.</summary>
+        Carrier,
+
+        /// <summary>An empty channel, present in the plex but carrying no sample.</summary>
+        Empty
+    }
+}

--- a/MetaMorpheus/Test/TmtExperimentalDesignTests.cs
+++ b/MetaMorpheus/Test/TmtExperimentalDesignTests.cs
@@ -642,5 +642,136 @@ namespace Test
             Assert.That(!badFraction.Any(e => e.Contains("Technical Replicate")),
                 "the row was judged past its Fraction, reporting a Technical Replicate as well");
         }
+
+        #region Review findings (#2774)
+
+        private static string WriteDesign(string name, params string[] rows)
+        {
+            string dir = Path.Combine(TestContext.CurrentContext.TestDirectory, "TmtDesignReview", name);
+            Directory.CreateDirectory(dir);
+            string path = Path.Combine(dir, "TmtDesign.txt");
+            var lines = new List<string>
+            {
+                "File\tPlex\tSample Name\tTMT Channel\tCondition\tBiological Replicate\tFraction\tTechnical Replicate\tSample Type"
+            };
+            lines.AddRange(rows);
+            File.WriteAllLines(path, lines);
+            return path;
+        }
+
+        /// <summary>
+        /// Two rows describing one channel differently must be reported, not silently collapsed.
+        ///
+        /// Fractions of a plex legitimately repeat the same channel-to-sample map, which is why a
+        /// repeat is collapsed rather than refused. But collapsing rows that DISAGREE keeps the first
+        /// and discards the second with nothing said -- and the uniqueness rule cannot catch it, since
+        /// two different sample names are two different tuples, so it only fires when the duplicates
+        /// agree, which is the harmless case.
+        /// </summary>
+        [Test]
+        public static void ChannelDescribedTwiceWithDifferentSamplesIsReported()
+        {
+            string path = WriteDesign("disagree",
+                "sample.raw\tPlex1\tTumour\t126\tDisease\t1\t1\t1\tstudy sample",
+                "sample.raw\tPlex1\tNormal\t126\tControl\t2\t1\t1\tstudy sample");
+
+            TmtExperimentalDesign.Read(path, new List<string>(), out var errors);
+
+            Assert.That(errors, Is.Not.Empty, "the second description was discarded silently");
+            Assert.That(string.Join(" ", errors), Does.Contain("126").And.Contain("disagree"));
+        }
+
+        /// <summary>
+        /// A bridge channel is by definition the same material carried in more than one plex under one
+        /// name -- which is what the Sample Type column added by this PR exists to describe. Collecting
+        /// the uniqueness tuples across the whole file rejected exactly that design; the only way
+        /// through was renaming the bridges apart, which throws away the fact that they are the same
+        /// material and so defeats the point of having them.
+        /// </summary>
+        [Test]
+        public static void ABridgeSharedAcrossPlexesIsNotADuplicate()
+        {
+            string path = WriteDesign("bridge",
+                "p1.raw\tPlex1\tTumour\t126\tDisease\t1\t1\t1\tstudy sample",
+                "p1.raw\tPlex1\tBridge\t127N\tBridge\t1\t1\t1\tbridge",
+                "p2.raw\tPlex2\tNormal\t126\tControl\t2\t1\t1\tstudy sample",
+                "p2.raw\tPlex2\tBridge\t127N\tBridge\t1\t1\t1\tbridge");
+
+            var files = TmtExperimentalDesign.Read(path, new List<string>(), out var errors);
+
+            Assert.That(errors, Is.Empty, string.Join(" | ", errors));
+            Assert.That(files, Has.Count.EqualTo(2));
+        }
+
+        /// <summary>
+        /// The same rule still fires within one plex, which is the case worth catching.
+        /// </summary>
+        [Test]
+        public static void TheSameSampleTwiceInOnePlexIsStillADuplicate()
+        {
+            string path = WriteDesign("dupInPlex",
+                "p1.raw\tPlex1\tTumour\t126\tDisease\t1\t1\t1\tstudy sample",
+                "p1.raw\tPlex1\tTumour\t127N\tDisease\t1\t1\t1\tstudy sample");
+
+            TmtExperimentalDesign.Read(path, new List<string>(), out var errors);
+
+            Assert.That(string.Join(" ", errors), Does.Contain("Duplicate combination"));
+        }
+
+        /// <summary>
+        /// Biological Replicate is validated the way Fraction and Technical Replicate are. A bare
+        /// int.TryParse accepted 0 and -3, and ToMzLibDesign passes the value straight through.
+        /// </summary>
+        [TestCase("0")]
+        [TestCase("-3")]
+        public static void BiologicalReplicateBelowOneIsRejected(string bio)
+        {
+            string path = WriteDesign("bio" + bio.Replace("-", "neg"),
+                $"sample.raw\tPlex1\tTumour\t126\tDisease\t{bio}\t1\t1\tstudy sample");
+
+            TmtExperimentalDesign.Read(path, new List<string>(), out var errors);
+
+            Assert.That(string.Join(" ", errors), Does.Contain("Biological Replicate must be >= 1"));
+        }
+
+        /// <summary>
+        /// Null means "do not filter", the same meaning the guard in ToMzLibDesign gives it. It used to
+        /// throw ArgumentNullException, so the two ends of the same parameter disagreed.
+        /// </summary>
+        [Test]
+        public static void ANullFileListMeansDoNotFilterRatherThanThrowing()
+        {
+            string path = WriteDesign("nullFiles",
+                "sample.raw\tPlex1\tTumour\t126\tDisease\t1\t1\t1\tstudy sample");
+
+            List<TmtFileInfo> files = null;
+            Assert.That(() => files = TmtExperimentalDesign.Read(path, null, out _), Throws.Nothing);
+            Assert.That(files, Has.Count.EqualTo(1));
+        }
+
+        /// <summary>
+        /// The placeholder row Write emits for a file with no annotations has to survive being read
+        /// back, since that is the whole reason it is written -- so a design someone is part-way
+        /// through authoring does not lose the file. It did not: the blank Biological Replicate failed
+        /// int.TryParse, the row was skipped, and the file was then reported missing from the design.
+        ///
+        /// This matters most for the GUI PR, where a part-authored design is the normal state rather
+        /// than an edge case.
+        /// </summary>
+        [Test]
+        public static void APlaceholderRowForAnUnannotatedFileSurvivesARoundTrip()
+        {
+            string path = WriteDesign("placeholder",
+                "sample.raw\tPlex1\t\t\t\t\t1\t1\t");
+
+            var files = TmtExperimentalDesign.Read(path, new List<string>(), out var errors);
+
+            Assert.That(errors, Is.Empty, string.Join(" | ", errors));
+            Assert.That(files, Has.Count.EqualTo(1), "the file the placeholder exists to preserve was lost");
+            Assert.That(files[0].Annotations, Is.Empty, "and it carries no annotations, which is the point");
+        }
+
+        #endregion
+
     }
 }

--- a/MetaMorpheus/Test/TmtExperimentalDesignTests.cs
+++ b/MetaMorpheus/Test/TmtExperimentalDesignTests.cs
@@ -247,6 +247,40 @@ namespace Test
         }
 
         /// <summary>
+        /// A provided path that is not already normalized -- here one routed through a '..' segment --
+        /// still matches the design row that names the same file. Both the row-level in-this-run test
+        /// and the "did not contain the file(s)" check normalize their inputs, so they cannot disagree
+        /// and report a file as missing from a design that names it.
+        /// </summary>
+        [Test]
+        public static void AnUnnormalizedProvidedPathStillMatchesItsDesignRow()
+        {
+            string folder = NewFolder("TmtDesignUnnormalizedPath");
+            string rawPath = Path.Combine(folder, "unnormalized.raw");
+            File.WriteAllText(rawPath, string.Empty);
+
+            // Same file, reached through a redundant directory hop.
+            string detoured = Path.Combine(folder, "sub", "..", "unnormalized.raw");
+            Assert.That(detoured, Is.Not.EqualTo(rawPath));
+
+            string designPath = Path.Combine(folder, GlobalVariables.TmtExperimentalDesignFileName);
+            File.WriteAllLines(designPath, new[]
+            {
+                TmtExperimentalDesign.Header,
+                $"{rawPath}	Plex1	S1	126	Control	1	1	1	study sample",
+            });
+
+            var files = TmtExperimentalDesign.Read(designPath, new List<string> { detoured }, out var errors);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(errors, Is.Empty);
+                Assert.That(files.Single().FullFilePathWithExtension, Is.EqualTo(rawPath));
+                Assert.That(files.Single().Annotations, Has.Count.EqualTo(1));
+            });
+        }
+
+        /// <summary>
         /// A row that stops short of the required columns is reported by line number rather than
         /// silently dropped. The count is against the required width, not the full header, so a design
         /// written before the optional Sample Type column existed still loads -- that case is covered
@@ -508,13 +542,10 @@ namespace Test
 
         /// <summary>
         /// A file with no channel annotations still gets a row, so a design the user is part-way
-        /// through authoring does not silently lose the file.
+        /// through authoring does not silently lose the file. Every per-channel cell on that row is
+        /// blank — including the trailing Sample Type cell, hence the tab at the end.
         /// </summary>
         [Test]
-        /// <summary>
-        /// A file with no annotations still gets one row, with every per-channel cell blank —
-        /// including the trailing Sample Type cell, hence the tab at the end.
-        /// </summary>
         public static void WriteEmitsAPlaceholderRowForAFileWithNoAnnotations()
         {
             string folder = NewFolder("TmtDesignNoAnnotations");

--- a/MetaMorpheus/Test/TmtExperimentalDesignTests.cs
+++ b/MetaMorpheus/Test/TmtExperimentalDesignTests.cs
@@ -1,0 +1,646 @@
+﻿using EngineLayer;
+using NUnit.Framework; using Assert = NUnit.Framework.Legacy.ClassicAssert;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Test
+{
+    internal static class TmtExperimentalDesignTests
+    {
+        [Test]
+        public static void WriteTmtExperimentalDesignTest()
+        {
+            string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, "TmtExperimentalDesignTest");
+            Directory.CreateDirectory(outputFolder);
+
+            var file1 = Path.Combine(outputFolder, "file.1.raw");
+            var file2 = Path.Combine(outputFolder, "file.2.raw");
+            var file3 = Path.Combine(outputFolder, "file.3.raw");
+
+            var anns = new List<TmtPlexAnnotation>
+            {
+                new TmtPlexAnnotation { Tag="126", SampleName="S1", Condition="C1", BiologicalReplicate=1 }
+            };
+
+            // define simple per-file state (same plex and channel set for all)
+            var files = new List<TmtFileInfo>
+            {
+                new TmtFileInfo(file1, "PlexA", 1, 1, anns),
+                new TmtFileInfo(file2, "PlexA", 2, 1, anns),
+                new TmtFileInfo(file3, "PlexA", 3, 1, anns)
+            };
+
+            // write and read back
+            _ = TmtExperimentalDesign.Write(files);
+
+            var readFiles = TmtExperimentalDesign.Read(
+                Path.Combine(outputFolder, GlobalVariables.TmtExperimentalDesignFileName),
+                new List<string> { file1, file2, file3 },
+                out var errors);
+
+            Assert.That(!errors.Any(), "No errors expected");
+            Assert.That(readFiles.Count == 3);
+            Assert.That(readFiles.All(f => f.Plex.Equals("PlexA", StringComparison.OrdinalIgnoreCase)));
+            Assert.That(readFiles.All(f => f.Annotations.Count == 1));
+            Assert.That(readFiles.All(f => f.Annotations.First().Tag == "126"));
+
+            Directory.Delete(outputFolder, true);
+        }
+
+        [Test]
+        public static void TestTmtExperimentalDesignErrors()
+        {
+            string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, "TmtExperimentalDesignErrors");
+            Directory.CreateDirectory(outputFolder);
+
+            var file1 = Path.Combine(outputFolder, "file.1.raw");
+            var file2 = Path.Combine(outputFolder, "file.2.raw");
+            var designPath = Path.Combine(outputFolder, GlobalVariables.TmtExperimentalDesignFileName);
+
+            // common annotations
+            var anns = new List<TmtPlexAnnotation>
+            {
+                new TmtPlexAnnotation { Tag="126", SampleName="SampleX", Condition="CondX", BiologicalReplicate=1 }
+            };
+
+            // 1) Duplicate (Sample, Bio, Fraction, Tech) across files -> error
+            {
+                var files = new List<TmtFileInfo>
+                {
+                    new TmtFileInfo(file1, "PlexA", 1, 1, anns),
+                    new TmtFileInfo(file2, "PlexA", 1, 1, anns) // same Sample/Bio/Fraction/Tech
+                };
+
+                _ = TmtExperimentalDesign.Write(files);
+                _ = TmtExperimentalDesign.Read(designPath, new List<string> { file1, file2 }, out var errors);
+                Assert.That(errors.Any(), "Duplicate Sample/Bio/Fraction/Tech should error");
+            }
+
+            // 2) Conflicting per-file assignments -> error (same file appears with different fraction/tech)
+            {
+                // write manually to simulate conflict
+                var lines = new List<string>
+                {
+                    TmtExperimentalDesign.Header,
+                    $"{file1}\tPlexA\tS1\t126\tC1\t1\t1\t1",
+                    $"{file1}\tPlexA\tS1\t127\tC1\t1\t2\t1"
+                };
+                File.WriteAllLines(designPath, lines);
+
+                _ = TmtExperimentalDesign.Read(designPath, new List<string> { file1 }, out var errors);
+                Assert.That(errors.Any(), "Conflicting per-file state should error");
+            }
+
+            // 3) Missing files from design -> error
+            {
+                var files = new List<TmtFileInfo>
+                {
+                    new TmtFileInfo(file1, "PlexA", 1, 1, anns)
+                };
+
+                _ = TmtExperimentalDesign.Write(files);
+
+                _ = TmtExperimentalDesign.Read(designPath, new List<string> { file1, file2 }, out var errors);
+                Assert.That(errors.Any(), "Missing file(s) in design should error");
+            }
+
+            // 4) Non-integer fields -> error (manually write invalid file)
+            {
+                var lines = new List<string>
+                {
+                    TmtExperimentalDesign.Header,
+                    // bad Biological Replicate
+                    $"{file1}\tPlexA\tS1\t126\tC1\ta\t1\t1"
+                };
+                File.WriteAllLines(designPath, lines);
+
+                _ = TmtExperimentalDesign.Read(designPath, new List<string> { file1 }, out var errors1);
+                Assert.That(errors1.Any(), "Non-integer biological replicate should error");
+
+                // bad Fraction
+                lines[1] = $"{file1}\tPlexA\tS1\t126\tC1\t1\ta\t1";
+                File.WriteAllLines(designPath, lines);
+                _ = TmtExperimentalDesign.Read(designPath, new List<string> { file1 }, out var errors2);
+                Assert.That(errors2.Any(), "Non-integer fraction should error");
+
+                // bad Technical Replicate
+                lines[1] = $"{file1}\tPlexA\tS1\t126\tC1\t1\t1\ta";
+                File.WriteAllLines(designPath, lines);
+                _ = TmtExperimentalDesign.Read(designPath, new List<string> { file1 }, out var errors3);
+                Assert.That(errors3.Any(), "Non-integer technical replicate should error");
+            }
+
+            Directory.Delete(outputFolder, true);
+        }
+
+        /// <summary>
+        /// A directory of this test class's own, created fresh so a previous run cannot pollute it.
+        /// </summary>
+        private static string NewFolder(string name)
+        {
+            string folder = Path.Combine(TestContext.CurrentContext.TestDirectory, name);
+            if (Directory.Exists(folder)) Directory.Delete(folder, true);
+            Directory.CreateDirectory(folder);
+            return folder;
+        }
+
+        /// <summary>
+        /// A design whose rows name no file in the run is a design pointed at the wrong data, not an
+        /// empty one. It previously returned no errors and an empty annotation set, so the command line
+        /// reported that it had read the design successfully while quantification had nothing to use.
+        /// </summary>
+        [Test]
+        public static void DesignThatMatchesNoFileInTheRunIsAnError()
+        {
+            string folder = NewFolder("TmtDesignNoMatch");
+            string designPath = Path.Combine(folder, GlobalVariables.TmtExperimentalDesignFileName);
+
+            File.WriteAllLines(designPath, new[]
+            {
+                TmtExperimentalDesign.Header,
+                "someone_elses.raw	Plex1	S1	126	Control	1	1	1	study sample",
+                "someone_elses.raw	Plex1	S2	127N	Treated	1	1	1	study sample",
+            });
+
+            var files = TmtExperimentalDesign.Read(
+                designPath,
+                new List<string> { Path.Combine(folder, "actually_searched.raw") },
+                out var errors);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(files, Is.Empty);
+                Assert.That(errors.Any(e => e.Contains("None of the 2 row(s)")), Is.True,
+                    "a design that resolves to nothing must say so rather than reading as success");
+            });
+        }
+
+        /// <summary>
+        /// A design written with bare file names sits beside the raw files it names. Resolving those
+        /// against the process working directory made the same design file work or match nothing
+        /// depending on where MetaMorpheus was launched from; they resolve against the design file's
+        /// own directory now.
+        /// </summary>
+        [Test]
+        public static void BareFileNamesResolveAgainstTheDesignFileNotTheWorkingDirectory()
+        {
+            string folder = NewFolder("TmtDesignRelativePaths");
+            string rawPath = Path.Combine(folder, "sample.raw");
+            File.WriteAllText(rawPath, string.Empty);   // only its existence matters here
+
+            string designPath = Path.Combine(folder, GlobalVariables.TmtExperimentalDesignFileName);
+            File.WriteAllLines(designPath, new[]
+            {
+                TmtExperimentalDesign.Header,
+                "sample.raw	Plex1	S1	126	Control	1	1	1	study sample",
+                "sample.raw	Plex1	S2	127N	Treated	1	1	1	reference",
+            });
+
+            // Deliberately not the design's directory -- this is the condition that used to break it.
+            string originalWorkingDirectory = Directory.GetCurrentDirectory();
+            Directory.SetCurrentDirectory(TestContext.CurrentContext.TestDirectory);
+            try
+            {
+                var files = TmtExperimentalDesign.Read(designPath, new List<string> { rawPath }, out var errors);
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(errors, Is.Empty);
+                    Assert.That(files, Has.Count.EqualTo(1));
+                    Assert.That(files.Single().FullFilePathWithExtension, Is.EqualTo(rawPath));
+                    Assert.That(files.Single().Annotations, Has.Count.EqualTo(2));
+                });
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(originalWorkingDirectory);
+            }
+        }
+
+        /// <summary>
+        /// A rooted path in the File column is taken as written, so a design that names absolute paths
+        /// keeps working regardless of where it or the process happens to sit.
+        /// </summary>
+        [Test]
+        public static void RootedPathsAreTakenAsWritten()
+        {
+            string folder = NewFolder("TmtDesignRootedPaths");
+            string rawPath = Path.Combine(folder, "rooted.raw");
+            File.WriteAllText(rawPath, string.Empty);
+
+            string designPath = Path.Combine(folder, GlobalVariables.TmtExperimentalDesignFileName);
+            File.WriteAllLines(designPath, new[]
+            {
+                TmtExperimentalDesign.Header,
+                $"{rawPath}	Plex1	S1	126	Control	1	1	1	study sample",
+            });
+
+            var files = TmtExperimentalDesign.Read(designPath, new List<string> { rawPath }, out var errors);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(errors, Is.Empty);
+                Assert.That(files.Single().FullFilePathWithExtension, Is.EqualTo(rawPath));
+            });
+        }
+
+        /// <summary>
+        /// A row that stops short of the required columns is reported by line number rather than
+        /// silently dropped. The count is against the required width, not the full header, so a design
+        /// written before the optional Sample Type column existed still loads -- that case is covered
+        /// separately; this one is a genuinely truncated row.
+        /// </summary>
+        [Test]
+        public static void TruncatedRowIsReportedByLineNumber()
+        {
+            string folder = NewFolder("TmtDesignTruncatedRow");
+            string rawPath = Path.Combine(folder, "sample.raw");
+            File.WriteAllText(rawPath, string.Empty);
+
+            string designPath = Path.Combine(folder, GlobalVariables.TmtExperimentalDesignFileName);
+            File.WriteAllLines(designPath, new[]
+            {
+                TmtExperimentalDesign.Header,
+                "sample.raw	Plex1	S1	126	Control	1	1	1	study sample",
+                "sample.raw	Plex1	S2",                                   // stops after three cells
+            });
+
+            TmtExperimentalDesign.Read(designPath, new List<string> { rawPath }, out var errors);
+
+            Assert.That(errors.Any(e => e.Contains("Line 3") && e.Contains("fewer columns")), Is.True,
+                "the offending line number is the only thing that makes this actionable");
+        }
+
+        /// <summary>
+        /// A non-numeric Biological Replicate is rejected rather than silently becoming zero, which
+        /// would collapse two samples onto one another during roll-up.
+        /// </summary>
+        [Test]
+        public static void NonNumericBiologicalReplicateIsRejected()
+        {
+            string folder = NewFolder("TmtDesignBadBioRep");
+            string rawPath = Path.Combine(folder, "sample.raw");
+            File.WriteAllText(rawPath, string.Empty);
+
+            string designPath = Path.Combine(folder, GlobalVariables.TmtExperimentalDesignFileName);
+            File.WriteAllLines(designPath, new[]
+            {
+                TmtExperimentalDesign.Header,
+                "sample.raw	Plex1	S1	126	Control	first	1	1	study sample",
+            });
+
+            TmtExperimentalDesign.Read(designPath, new List<string> { rawPath }, out var errors);
+
+            Assert.That(errors.Any(e => e.Contains("Biological Replicate")), Is.True);
+        }
+
+        /// <summary>
+        /// One file cannot be in two plexes, or at two fractions, at once. The design is per-file for
+        /// those three fields, so a row that disagrees with an earlier row about them is a mistake that
+        /// would otherwise be resolved by whichever row happened to be read first.
+        /// </summary>
+        [Test]
+        public static void ConflictingPlexOrFractionForOneFileIsReported()
+        {
+            string folder = NewFolder("TmtDesignConflict");
+            string rawPath = Path.Combine(folder, "sample.raw");
+            File.WriteAllText(rawPath, string.Empty);
+
+            string designPath = Path.Combine(folder, GlobalVariables.TmtExperimentalDesignFileName);
+            File.WriteAllLines(designPath, new[]
+            {
+                TmtExperimentalDesign.Header,
+                "sample.raw	Plex1	S1	126	Control	1	1	1	study sample",
+                "sample.raw	Plex2	S2	127N	Treated	1	2	1	study sample",   // different plex AND fraction
+            });
+
+            TmtExperimentalDesign.Read(designPath, new List<string> { rawPath }, out var errors);
+
+            Assert.That(errors.Any(e => e.Contains("inconsistent Plex")), Is.True,
+                "the same file cannot carry two plex or fraction assignments");
+        }
+
+        [Test]
+        public static void MissingDesignFileIsAnError()
+        {
+            var files = TmtExperimentalDesign.Read(
+                Path.Combine(TestContext.CurrentContext.TestDirectory, "no-such-tmt-design.txt"),
+                new List<string>(), out var errors);
+
+            Assert.That(files.Count == 0);
+            Assert.That(errors.Count == 1);
+            Assert.That(errors.Single().Contains("not found"));
+        }
+
+        [Test]
+        public static void EmptyFileAndBadHeaderAreBothRejected()
+        {
+            string folder = NewFolder("TmtDesignHeader");
+            string designPath = Path.Combine(folder, GlobalVariables.TmtExperimentalDesignFileName);
+
+            // An empty file has no header at all.
+            File.WriteAllText(designPath, string.Empty);
+            _ = TmtExperimentalDesign.Read(designPath, new List<string>(), out var emptyErrors);
+            Assert.That(emptyErrors.Any(e => e.Contains("header is invalid")), "Empty file should be rejected");
+
+            // A header missing required columns.
+            File.WriteAllLines(designPath, new[] { "File\tPlex\tSample Name" });
+            _ = TmtExperimentalDesign.Read(designPath, new List<string>(), out var shortErrors);
+            Assert.That(shortErrors.Any(e => e.Contains("header is invalid")), "Incomplete header should be rejected");
+
+            Directory.Delete(folder, true);
+        }
+
+        /// <summary>
+        /// The header is matched by column NAME, not by position, so a design written by hand with its
+        /// columns in a different order still parses. That is what the per-column index lookup buys.
+        /// </summary>
+        [Test]
+        public static void HeaderColumnsMayBeReordered()
+        {
+            string folder = NewFolder("TmtDesignReordered");
+            string designPath = Path.Combine(folder, GlobalVariables.TmtExperimentalDesignFileName);
+            string file1 = Path.Combine(folder, "file.1.raw");
+
+            File.WriteAllLines(designPath, new[]
+            {
+                "Technical Replicate\tFraction\tBiological Replicate\tCondition\tTMT Channel\tSample Name\tPlex\tFile",
+                $"1\t2\t3\tCond\t127N\tSampleA\tPlexB\t{file1}"
+            });
+
+            var files = TmtExperimentalDesign.Read(designPath, new List<string> { file1 }, out var errors);
+
+            Assert.That(!errors.Any(), "A reordered but complete header should parse");
+            Assert.That(files.Count == 1);
+            Assert.That(files[0].Plex == "PlexB");
+            Assert.That(files[0].Fraction == 2);
+            Assert.That(files[0].TechnicalReplicate == 1);
+            Assert.That(files[0].Annotations.Single().Tag == "127N");
+            Assert.That(files[0].Annotations.Single().SampleName == "SampleA");
+            Assert.That(files[0].Annotations.Single().BiologicalReplicate == 3);
+
+            Directory.Delete(folder, true);
+        }
+
+        /// <summary>
+        /// Blank lines are skipped, a row with too few columns is reported by line number, and a row
+        /// naming no file is ignored rather than reported -- the last because a tab-only trailing row
+        /// is what a spreadsheet export produces, and it is not worth stopping a run for.
+        /// </summary>
+        [Test]
+        public static void MalformedRowsAreSkippedOrReportedByLineNumber()
+        {
+            string folder = NewFolder("TmtDesignMalformedRows");
+            string designPath = Path.Combine(folder, GlobalVariables.TmtExperimentalDesignFileName);
+            string file1 = Path.Combine(folder, "file.1.raw");
+
+            File.WriteAllLines(designPath, new[]
+            {
+                TmtExperimentalDesign.Header,
+                $"{file1}\tPlexA\tS1\t126\tC1\t1\t1\t1",
+                "",                                 // blank -> skipped silently
+                $"{file1}\tPlexA\tS1",              // too few columns -> reported
+                "\tPlexA\tS2\t127\tC1\t1\t1\t1"     // names no file -> ignored
+            });
+
+            var files = TmtExperimentalDesign.Read(designPath, new List<string> { file1 }, out var errors);
+
+            Assert.That(files.Count == 1, "Only the one well-formed file should be returned");
+            Assert.That(errors.Count == 1, "Exactly one error: the short row");
+            Assert.That(errors.Single().Contains("Line 4"), "Errors are reported by 1-based line number");
+
+            Directory.Delete(folder, true);
+        }
+
+        /// <summary>
+        /// Fraction and technical replicate are 1-based in the file. A zero is what a caller gets by
+        /// forwarding a 0-based index, so it is rejected rather than accepted as "unset".
+        /// </summary>
+        [Test]
+        public static void FractionAndTechnicalReplicateMustBeOneBased()
+        {
+            string folder = NewFolder("TmtDesignOneBased");
+            string designPath = Path.Combine(folder, GlobalVariables.TmtExperimentalDesignFileName);
+            string file1 = Path.Combine(folder, "file.1.raw");
+
+            File.WriteAllLines(designPath, new[]
+            {
+                TmtExperimentalDesign.Header,
+                $"{file1}\tPlexA\tS1\t126\tC1\t1\t0\t1"
+            });
+            _ = TmtExperimentalDesign.Read(designPath, new List<string>(), out var fractionErrors);
+            Assert.That(fractionErrors.Any(e => e.Contains("Fraction must be >= 1")));
+
+            File.WriteAllLines(designPath, new[]
+            {
+                TmtExperimentalDesign.Header,
+                $"{file1}\tPlexA\tS1\t126\tC1\t1\t1\t0"
+            });
+            _ = TmtExperimentalDesign.Read(designPath, new List<string>(), out var techErrors);
+            Assert.That(techErrors.Any(e => e.Contains("Technical Replicate must be >= 1")));
+
+            Directory.Delete(folder, true);
+        }
+
+        /// <summary>
+        /// An empty spectra-file list means "describe whatever the design names", so every row is kept
+        /// and the file-not-in-design check does not run. This is the path the GUI seeds from.
+        /// </summary>
+        [Test]
+        public static void AnEmptyFileListAcceptsEveryRowInTheDesign()
+        {
+            string folder = NewFolder("TmtDesignNoFileFilter");
+            string designPath = Path.Combine(folder, GlobalVariables.TmtExperimentalDesignFileName);
+            string file1 = Path.Combine(folder, "file.1.raw");
+            string file2 = Path.Combine(folder, "file.2.raw");
+
+            File.WriteAllLines(designPath, new[]
+            {
+                TmtExperimentalDesign.Header,
+                $"{file1}\tPlexA\tS1\t126\tC1\t1\t1\t1",
+                $"{file2}\tPlexA\tS2\t127\tC2\t2\t1\t1"
+            });
+
+            var files = TmtExperimentalDesign.Read(designPath, new List<string>(), out var errors);
+
+            Assert.That(!errors.Any(), "With no file list, nothing can be missing from the design");
+            Assert.That(files.Count == 2);
+            // Both files share a plex, so both carry that plex's whole channel set.
+            Assert.That(files.All(f => f.Annotations.Count == 2));
+
+            Directory.Delete(folder, true);
+        }
+
+        /// <summary>
+        /// The (sample, biorep, fraction, techrep) uniqueness rule applies only to rows that name a
+        /// sample. Two unnamed channels in one plex are not duplicates of each other.
+        /// </summary>
+        [Test]
+        public static void RowsWithNoSampleNameAreExemptFromTheUniquenessRule()
+        {
+            string folder = NewFolder("TmtDesignBlankSample");
+            string designPath = Path.Combine(folder, GlobalVariables.TmtExperimentalDesignFileName);
+            string file1 = Path.Combine(folder, "file.1.raw");
+
+            File.WriteAllLines(designPath, new[]
+            {
+                TmtExperimentalDesign.Header,
+                $"{file1}\tPlexA\t\t126\tC1\t1\t1\t1",
+                $"{file1}\tPlexA\t\t127\tC1\t1\t1\t1"
+            });
+
+            var files = TmtExperimentalDesign.Read(designPath, new List<string> { file1 }, out var errors);
+
+            Assert.That(!errors.Any(), "Blank sample names are not duplicates");
+            Assert.That(files.Single().Annotations.Count == 2);
+
+            Directory.Delete(folder, true);
+        }
+
+        [Test]
+        public static void WriteRefusesAnEmptyDesign()
+        {
+            Assert.Throws<InvalidOperationException>(() => TmtExperimentalDesign.Write(null));
+            Assert.Throws<InvalidOperationException>(() => TmtExperimentalDesign.Write(new List<TmtFileInfo>()));
+        }
+
+        /// <summary>
+        /// A file with no channel annotations still gets a row, so a design the user is part-way
+        /// through authoring does not silently lose the file.
+        /// </summary>
+        [Test]
+        /// <summary>
+        /// A file with no annotations still gets one row, with every per-channel cell blank —
+        /// including the trailing Sample Type cell, hence the tab at the end.
+        /// </summary>
+        public static void WriteEmitsAPlaceholderRowForAFileWithNoAnnotations()
+        {
+            string folder = NewFolder("TmtDesignNoAnnotations");
+            string file1 = Path.Combine(folder, "file.1.raw");
+
+            string written = TmtExperimentalDesign.Write(
+                new List<TmtFileInfo> { new TmtFileInfo(file1, "PlexA", 2, 3, null) });
+
+            var lines = File.ReadAllLines(written);
+            Assert.That(lines.Length == 2);
+            Assert.That(lines[0] == TmtExperimentalDesign.Header);
+            Assert.That(lines[1] == $"{file1}\tPlexA\t\t\t\t\t2\t3\t");
+
+            Directory.Delete(folder, true);
+        }
+
+        /// <summary>
+        /// Rows are written fraction-major, so a design round-trips in a stable order rather than in
+        /// whatever order the GUI grid happened to hold.
+        /// </summary>
+        [Test]
+        public static void WriteOrdersRowsByFractionThenTechnicalReplicate()
+        {
+            string folder = NewFolder("TmtDesignWriteOrder");
+            string file1 = Path.Combine(folder, "file.1.raw");
+            string file2 = Path.Combine(folder, "file.2.raw");
+            string file3 = Path.Combine(folder, "file.3.raw");
+            var anns = new List<TmtPlexAnnotation>
+            {
+                new TmtPlexAnnotation { Tag = "126", SampleName = "S1", Condition = "C1", BiologicalReplicate = 1 }
+            };
+
+            string written = TmtExperimentalDesign.Write(new List<TmtFileInfo>
+            {
+                new TmtFileInfo(file2, "PlexA", 2, 1, anns),
+                new TmtFileInfo(file3, "PlexA", 1, 2, anns),
+                new TmtFileInfo(file1, "PlexA", 1, 1, anns)
+            });
+
+            var rows = File.ReadAllLines(written).Skip(1).Select(l => l.Split('\t')[0]).ToList();
+            Assert.That(rows.SequenceEqual(new[] { file1, file3, file2 }));
+
+            Directory.Delete(folder, true);
+        }
+
+        /// <summary>
+        /// Two TmtFileInfo naming the same file are the same file, whatever the casing -- and their
+        /// hash codes agree, so they collapse in a set rather than both surviving it.
+        /// </summary>
+        [Test]
+        public static void TmtFileInfoIdentityIsTheFilePath()
+        {
+            var a = new TmtFileInfo(@"C:\data\file.1.raw", "PlexA", 1, 1, null);
+            var b = new TmtFileInfo(@"c:\DATA\FILE.1.RAW", "PlexB", 9, 9, null);
+            var c = new TmtFileInfo(@"C:\data\file.2.raw", "PlexA", 1, 1, null);
+
+            Assert.That(a.Equals(b), "Same path, different case -> the same file");
+            Assert.That(a.GetHashCode() == b.GetHashCode(), "Equal instances must hash equally");
+            Assert.That(!a.Equals(c));
+            Assert.That(!a.Equals(null));
+            Assert.That(!a.Equals("not a TmtFileInfo"));
+            Assert.That(new HashSet<TmtFileInfo> { a, b, c }.Count == 2);
+        }
+
+        [Test]
+        public static void TmtFileInfoNormalizesItsOptionalArguments()
+        {
+            var info = new TmtFileInfo(Path.Combine("some", "dir", "file.1.raw"), null, 1, 1, null);
+
+            Assert.That(info.Plex == string.Empty, "A null plex is stored as empty, never null");
+            Assert.That(info.Annotations.Count == 0, "Null annotations become an empty list");
+            Assert.That(info.ToString() == "file.1.raw", "ToString is the bare file name");
+        }
+        /// <summary>
+        /// A row is judged one cell at a time and reported once. Every validation guard in the row
+        /// loop ends in `continue`, so the first bad cell is the only one named -- the row is not
+        /// re-judged on the columns after it.
+        ///
+        /// This is a user-facing contract, not an internal one: Read's error list is what
+        /// ResolveExperimentalDesign prints to the console. Without the skip, one typo in a Sample
+        /// Type cell also reports an invalid Biological Replicate, because TryParse left the out
+        /// parameter at its default -- an error naming a cell the user filled in correctly.
+        ///
+        /// Each case is asserted by what the errors must NOT say, since a count cannot distinguish
+        /// them: the "did not contain the file(s)" error appears either way, because a row skipped
+        /// for being invalid and a row never reached both leave the file undefined.
+        /// </summary>
+        [Test]
+        public static void ARowIsReportedOnceAtItsFirstBadCell()
+        {
+            List<string> ErrorsForRow(string name, string row)
+            {
+                string folder = NewFolder(name);
+                string rawPath = Path.Combine(folder, "sample.raw");
+                File.WriteAllText(rawPath, string.Empty);
+
+                string designPath = Path.Combine(folder, GlobalVariables.TmtExperimentalDesignFileName);
+                File.WriteAllLines(designPath, new[] { TmtExperimentalDesign.Header, row });
+
+                TmtExperimentalDesign.Read(designPath, new List<string> { rawPath }, out var errors);
+                return errors;
+            }
+
+            // Sample Type is unrecognised, and the Biological Replicate after it is also unparseable.
+            var badType = ErrorsForRow("TmtDesignFirstBadCellType",
+                "sample.raw\tPlex1\tS1\t126\tControl\tnot-a-number\t1\t1\tnot-a-sample-type");
+
+            // Biological Replicate is unparseable, and the Fraction after it is below one.
+            var badBio = ErrorsForRow("TmtDesignFirstBadCellBio",
+                "sample.raw\tPlex1\tS1\t126\tControl\tnot-a-number\t0\t1\tstudy sample");
+
+            // Fraction is below one, and the Technical Replicate after it is too.
+            var badFraction = ErrorsForRow("TmtDesignFirstBadCellFraction",
+                "sample.raw\tPlex1\tS1\t126\tControl\t1\t0\t0\tstudy sample");
+
+            Assert.That(badType.Any(e => e.Contains("Sample Type")), "the unrecognised Sample Type is reported");
+            Assert.That(!badType.Any(e => e.Contains("Biological Replicate")),
+                "the row was judged past its Sample Type, reporting a Biological Replicate the guard never parsed");
+
+            Assert.That(badBio.Any(e => e.Contains("Biological Replicate")), "the invalid Biological Replicate is reported");
+            Assert.That(!badBio.Any(e => e.Contains("Fraction")),
+                "the row was judged past its Biological Replicate, reporting a Fraction as well");
+
+            Assert.That(badFraction.Any(e => e.Contains("Fraction")), "the out-of-range Fraction is reported");
+            Assert.That(!badFraction.Any(e => e.Contains("Technical Replicate")),
+                "the row was judged past its Fraction, reporting a Technical Replicate as well");
+        }
+    }
+}

--- a/MetaMorpheus/Test/TmtSampleTypeAndMzLibDesignTests.cs
+++ b/MetaMorpheus/Test/TmtSampleTypeAndMzLibDesignTests.cs
@@ -502,7 +502,7 @@ namespace Test
         {
             var tag = Tmt10();
             var first = FileWith(FixturePath("data") + Path.DirectorySeparatorChar, "PlexA", 1, 1, ("126", "A", 1, TmtSampleType.StudySample));
-            var second = FileWith(@"D:\other\", "PlexA", 1, 1, ("126", "B", 1, TmtSampleType.StudySample));
+            var second = FileWith(FixturePath("other") + Path.DirectorySeparatorChar, "PlexA", 1, 1, ("126", "B", 1, TmtSampleType.StudySample));
 
             var design = TmtExperimentalDesign.ToMzLibDesign(new[] { first, second }, tag, out var errors);
 

--- a/MetaMorpheus/Test/TmtSampleTypeAndMzLibDesignTests.cs
+++ b/MetaMorpheus/Test/TmtSampleTypeAndMzLibDesignTests.cs
@@ -175,6 +175,19 @@ namespace Test
 
         private static IsobaricMassTag Tmt10() => IsobaricMassTag.GetIsobaricMassTag(IsobaricMassTagType.TMT10);
 
+        /// <summary>
+        /// A rooted fixture path ending in <paramref name="name"/>, built for whatever platform the
+        /// tests are running on.
+        /// </summary>
+        /// <remarks>
+        /// The literals here used to be `FixturePath("data", "run1.raw")`, which is not a path off Windows:
+        /// Path.GetFileName keeps the whole string, so the dictionary key is never "run1.raw" and six
+        /// of these tests failed. CI is windows-latest only, so nothing caught it. The production code
+        /// is platform-clean; this was fixture paths alone.
+        /// </remarks>
+        private static string FixturePath(params string[] parts) =>
+            Path.DirectorySeparatorChar + Path.Combine(parts);
+
         private static TmtFileInfo FileWith(string path, string plex, int fraction, int techrep,
             params (string tag, string condition, int bio, TmtSampleType type)[] channels)
         {
@@ -203,7 +216,7 @@ namespace Test
             Assert.IsNotNull(tag, "TMT10 must resolve from the loaded modifications");
 
             // Deliberately scrambled relative to the tag's own channel order.
-            var file = FileWith(@"C:\data\run1.raw", "PlexA", 1, 1,
+            var file = FileWith(FixturePath("data", "run1.raw"), "PlexA", 1, 1,
                 ("129N", "D", 1, TmtSampleType.StudySample),
                 ("126", "A", 1, TmtSampleType.Reference),
                 ("127C", "C", 1, TmtSampleType.StudySample),
@@ -237,7 +250,7 @@ namespace Test
         public static void ToMzLibDesign_CarriesTheAnnotationOntoTheMatchingChannel()
         {
             var tag = Tmt10();
-            var file = FileWith(@"C:\data\run1.raw", "PlexA", 2, 3,
+            var file = FileWith(FixturePath("data", "run1.raw"), "PlexA", 2, 3,
                 ("126", "Reference", 1, TmtSampleType.Reference),
                 ("127N", "Treated", 2, TmtSampleType.StudySample));
 
@@ -268,7 +281,7 @@ namespace Test
         public static void ToMzLibDesign_UnannotatedChannelsBecomeEmptyRatherThanBeingSkipped()
         {
             var tag = Tmt10();
-            var file = FileWith(@"C:\data\run1.raw", "PlexA", 1, 1,
+            var file = FileWith(FixturePath("data", "run1.raw"), "PlexA", 1, 1,
                 ("126", "Reference", 1, TmtSampleType.Reference));
 
             var design = TmtExperimentalDesign.ToMzLibDesign(new[] { file }, tag, out var errors);
@@ -287,7 +300,7 @@ namespace Test
         public static void ToMzLibDesign_ChannelThatIsNotPartOfTheTag_IsAnError()
         {
             var tag = Tmt10();
-            var file = FileWith(@"C:\data\run1.raw", "PlexA", 1, 1,
+            var file = FileWith(FixturePath("data", "run1.raw"), "PlexA", 1, 1,
                 ("135N", "Treated", 1, TmtSampleType.StudySample));   // TMT18 channel, not TMT10
 
             var design = TmtExperimentalDesign.ToMzLibDesign(new[] { file }, tag, out var errors);
@@ -303,9 +316,9 @@ namespace Test
             var tag = Tmt10();
             var files = new[]
             {
-                FileWith(@"C:\data\runB.raw", "PlexB", 1, 1, ("126", "A", 1, TmtSampleType.StudySample)),
-                FileWith(@"C:\data\runA.raw", "PlexA", 1, 1, ("126", "A", 1, TmtSampleType.StudySample)),
-                FileWith(@"C:\data\runA2.raw", "PlexA", 1, 2, ("126", "A", 1, TmtSampleType.StudySample))
+                FileWith(FixturePath("data", "runB.raw"), "PlexB", 1, 1, ("126", "A", 1, TmtSampleType.StudySample)),
+                FileWith(FixturePath("data", "runA.raw"), "PlexA", 1, 1, ("126", "A", 1, TmtSampleType.StudySample)),
+                FileWith(FixturePath("data", "runA2.raw"), "PlexA", 1, 2, ("126", "A", 1, TmtSampleType.StudySample))
             };
 
             var design = TmtExperimentalDesign.ToMzLibDesign(files, tag, out var errors);
@@ -325,7 +338,7 @@ namespace Test
         public static void ToMzLibDesign_KeysByFileNameWithExtension()
         {
             var tag = Tmt10();
-            var file = FileWith(@"C:\some\deep\path\run1.raw", "PlexA", 1, 1,
+            var file = FileWith(FixturePath("some", "deep", "path", "run1.raw"), "PlexA", 1, 1,
                 ("126", "A", 1, TmtSampleType.StudySample));
 
             var design = TmtExperimentalDesign.ToMzLibDesign(new[] { file }, tag, out _);
@@ -337,7 +350,7 @@ namespace Test
         [Test]
         public static void ToMzLibDesign_WithoutATag_IsAnError()
         {
-            var file = FileWith(@"C:\data\run1.raw", "PlexA", 1, 1,
+            var file = FileWith(FixturePath("data", "run1.raw"), "PlexA", 1, 1,
                 ("126", "A", 1, TmtSampleType.StudySample));
 
             var design = TmtExperimentalDesign.ToMzLibDesign(new[] { file }, null, out var errors);
@@ -355,59 +368,7 @@ namespace Test
             Assert.IsNotEmpty(errors);
         }
 
-        /// <summary>
-        /// The window offering the channel drop-down and the tag that validates it must agree, or the
-        /// GUI can write a design that cannot be projected. They were two separate tables until now.
-        /// </summary>
-        [Test]
-        public static void EveryTagsLabelsMatchItsReporterIonCount()
-        {
-            foreach (IsobaricMassTagType type in Enum.GetValues(typeof(IsobaricMassTagType)))
-            {
-                var tag = IsobaricMassTag.GetIsobaricMassTag(type);
-                if (tag == null) continue;   // modification not loaded in this environment
 
-                var labels = IsobaricMassTag.GetReporterIonLabels(type);
-                Assert.IsNotNull(labels, type.ToString());
-                Assert.AreEqual(labels.Count, tag.ReporterIonMzs.Length,
-                    $"{type} has {labels.Count} labels but {tag.ReporterIonMzs.Length} reporter ions");
-            }
-        }
-
-        /// <summary>
-        /// The stronger half of the same invariant, and the one that actually protects the projection:
-        /// ToMzLibDesign pairs channelLabels[i] with ReporterIonMzs[i], so label i has to name the
-        /// channel whose m/z sits at i. A count cannot catch a mislabelled channel -- iTRAQ 8-plex
-        /// carried the name "120" for the 121 reagent for exactly that reason, extracting the right ion
-        /// under a name no kit has.
-        ///
-        /// Every label begins with its nominal mass, so the assertion is available cheaply.
-        /// </summary>
-        [Test]
-        public static void EveryTagsLabelsNameTheChannelAtTheirOwnIndex()
-        {
-            foreach (IsobaricMassTagType type in Enum.GetValues(typeof(IsobaricMassTagType)))
-            {
-                var tag = IsobaricMassTag.GetIsobaricMassTag(type);
-                if (tag == null) continue;   // modification not loaded in this environment
-
-                var labels = IsobaricMassTag.GetReporterIonLabels(type);
-                Assert.IsNotNull(labels, type.ToString());
-
-                for (int i = 0; i < labels.Count; i++)
-                {
-                    string digits = new string(labels[i].TakeWhile(char.IsDigit).ToArray());
-                    Assert.IsNotEmpty(digits, $"{type} label '{labels[i]}' does not begin with a nominal mass");
-
-                    int nominal = int.Parse(digits);
-                    int observed = (int)Math.Round(tag.ReporterIonMzs[i]);
-
-                    Assert.AreEqual(nominal, observed,
-                        $"{type} label '{labels[i]}' at index {i} names channel {nominal}, " +
-                        $"but the reporter ion at that index is {tag.ReporterIonMzs[i]:F4} (channel {observed})");
-                }
-            }
-        }
 
         /// <summary>
         /// ToMzLibDesign pairs channelLabels[i] with ReporterIonMzs[i] positionally. If the two ever
@@ -540,7 +501,7 @@ namespace Test
         public static void TwoEntriesWithNoFileNameAreReportedAsMissingNamesNotACollision()
         {
             var tag = Tmt10();
-            var first = FileWith(@"C:\data\", "PlexA", 1, 1, ("126", "A", 1, TmtSampleType.StudySample));
+            var first = FileWith(FixturePath("data") + Path.DirectorySeparatorChar, "PlexA", 1, 1, ("126", "A", 1, TmtSampleType.StudySample));
             var second = FileWith(@"D:\other\", "PlexA", 1, 1, ("126", "B", 1, TmtSampleType.StudySample));
 
             var design = TmtExperimentalDesign.ToMzLibDesign(new[] { first, second }, tag, out var errors);

--- a/MetaMorpheus/Test/TmtSampleTypeAndMzLibDesignTests.cs
+++ b/MetaMorpheus/Test/TmtSampleTypeAndMzLibDesignTests.cs
@@ -1,0 +1,560 @@
+﻿using EngineLayer;
+using MassSpectrometry;
+using NUnit.Framework;
+using Assert = NUnit.Framework.Legacy.ClassicAssert;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Test
+{
+    /// <summary>
+    /// Covers the Sample Type column of TmtDesign.txt and the projection of a TMT design onto
+    /// mzLib's <see cref="IExperimentalDesign"/>, which is what the quantification engine consumes.
+    /// </summary>
+    [TestFixture]
+    internal static class TmtSampleTypeAndMzLibDesignTests
+    {
+        #region Sample Type parsing
+
+        [TestCase("", TmtSampleType.StudySample)]
+        [TestCase("   ", TmtSampleType.StudySample)]
+        [TestCase("study sample", TmtSampleType.StudySample)]
+        [TestCase("Study Sample", TmtSampleType.StudySample)]
+        [TestCase("reference", TmtSampleType.Reference)]
+        [TestCase("REFERENCE", TmtSampleType.Reference)]
+        [TestCase("pooled", TmtSampleType.Reference)]
+        [TestCase("bridge", TmtSampleType.Bridge)]
+        [TestCase("carrier", TmtSampleType.Carrier)]
+        [TestCase("empty", TmtSampleType.Empty)]
+        public static void TryParseSampleType_AcceptsTheSdrfSpellings(string value, TmtSampleType expected)
+        {
+            Assert.IsTrue(TmtExperimentalDesign.TryParseSampleType(value, out var parsed));
+            Assert.AreEqual(expected, parsed);
+        }
+
+        [TestCase("nonsense")]
+        [TestCase("ref")]
+        public static void TryParseSampleType_RejectsAnythingElse(string value)
+        {
+            Assert.IsFalse(TmtExperimentalDesign.TryParseSampleType(value, out _));
+        }
+
+        [Test]
+        public static void SampleType_RoundTripsThroughItsDesignFileSpelling()
+        {
+            foreach (TmtSampleType type in Enum.GetValues(typeof(TmtSampleType)))
+            {
+                string written = TmtExperimentalDesign.ToDesignFileValue(type);
+                Assert.IsTrue(TmtExperimentalDesign.TryParseSampleType(written, out var readBack), written);
+                Assert.AreEqual(type, readBack);
+                Assert.Contains(written, TmtExperimentalDesign.SampleTypeNames.ToList());
+            }
+        }
+
+        /// <summary>
+        /// Only a reference or a bridge normalizes the other channels, and that is the single bit
+        /// mzLib's IsobaricQuantSampleInfo carries.
+        /// </summary>
+        [TestCase(TmtSampleType.Reference, true)]
+        [TestCase(TmtSampleType.Bridge, true)]
+        [TestCase(TmtSampleType.StudySample, false)]
+        [TestCase(TmtSampleType.Carrier, false)]
+        [TestCase(TmtSampleType.Empty, false)]
+        public static void IsReferenceChannel_IsTrueOnlyForReferenceAndBridge(TmtSampleType type, bool expected)
+        {
+            Assert.AreEqual(expected, TmtExperimentalDesign.IsReferenceChannel(type));
+        }
+
+        #endregion
+
+        #region Sample Type in the design file
+
+        private static string WriteDesign(string folder, string header, params string[] rows)
+        {
+            Directory.CreateDirectory(folder);
+            string path = Path.Combine(folder, GlobalVariables.TmtExperimentalDesignFileName);
+            File.WriteAllLines(path, new[] { header }.Concat(rows));
+            return path;
+        }
+
+        /// <summary>
+        /// A design file written before the Sample Type column existed must still load, with every
+        /// channel reading as a study sample.
+        /// </summary>
+        [Test]
+        public static void Read_DesignWithoutSampleTypeColumn_StillLoads()
+        {
+            string folder = Path.Combine(TestContext.CurrentContext.TestDirectory, "TmtSampleType_Legacy");
+            string file = Path.Combine(folder, "run1.raw");
+
+            string legacyHeader = "File\tPlex\tSample Name\tTMT Channel\tCondition\tBiological Replicate\tFraction\tTechnical Replicate";
+            string path = WriteDesign(folder, legacyHeader,
+                $"{file}\tPlexA\tS1\t126\tControl\t1\t1\t1",
+                $"{file}\tPlexA\tS2\t127N\tTreated\t1\t1\t1");
+
+            var files = TmtExperimentalDesign.Read(path, new List<string> { file }, out var errors);
+
+            Assert.IsEmpty(errors);
+            Assert.AreEqual(1, files.Count);
+            Assert.IsTrue(files[0].Annotations.All(a => a.SampleType == TmtSampleType.StudySample));
+
+            Directory.Delete(folder, true);
+        }
+
+        [Test]
+        public static void Read_ParsesSampleTypeWhenPresent()
+        {
+            string folder = Path.Combine(TestContext.CurrentContext.TestDirectory, "TmtSampleType_Present");
+            string file = Path.Combine(folder, "run1.raw");
+
+            string path = WriteDesign(folder, TmtExperimentalDesign.Header,
+                $"{file}\tPlexA\tPool\t126\tReference\t1\t1\t1\treference",
+                $"{file}\tPlexA\tS1\t127N\tTreated\t1\t1\t1\tstudy sample",
+                $"{file}\tPlexA\t\t127C\t\t1\t1\t1\tempty");
+
+            var files = TmtExperimentalDesign.Read(path, new List<string> { file }, out var errors);
+
+            Assert.IsEmpty(errors);
+            var byTag = files[0].Annotations.ToDictionary(a => a.Tag);
+            Assert.AreEqual(TmtSampleType.Reference, byTag["126"].SampleType);
+            Assert.AreEqual(TmtSampleType.StudySample, byTag["127N"].SampleType);
+            Assert.AreEqual(TmtSampleType.Empty, byTag["127C"].SampleType);
+
+            Directory.Delete(folder, true);
+        }
+
+        [Test]
+        public static void Read_UnrecognisedSampleType_IsReportedAndTheRowIsSkipped()
+        {
+            string folder = Path.Combine(TestContext.CurrentContext.TestDirectory, "TmtSampleType_Bad");
+            string file = Path.Combine(folder, "run1.raw");
+
+            string path = WriteDesign(folder, TmtExperimentalDesign.Header,
+                $"{file}\tPlexA\tS1\t126\tControl\t1\t1\t1\tbanana");
+
+            TmtExperimentalDesign.Read(path, new List<string> { file }, out var errors);
+
+            Assert.IsTrue(errors.Any(e => e.Contains("not a recognised Sample Type")), string.Join(" | ", errors));
+
+            Directory.Delete(folder, true);
+        }
+
+        /// <summary>The header this class writes must be one the same class accepts.</summary>
+        [Test]
+        public static void WrittenHeader_IsAcceptedOnRead()
+        {
+            string folder = Path.Combine(TestContext.CurrentContext.TestDirectory, "TmtSampleType_RoundTrip");
+            string file = Path.Combine(folder, "run1.raw");
+            Directory.CreateDirectory(folder);
+
+            var annotations = new List<TmtPlexAnnotation>
+            {
+                new() { Tag = "126", SampleName = "Pool", Condition = "Reference", BiologicalReplicate = 1, SampleType = TmtSampleType.Reference },
+                new() { Tag = "127N", SampleName = "S1", Condition = "Treated", BiologicalReplicate = 1, SampleType = TmtSampleType.StudySample }
+            };
+
+            TmtExperimentalDesign.Write(new List<TmtFileInfo> { new(file, "PlexA", 1, 1, annotations) });
+
+            var readBack = TmtExperimentalDesign.Read(
+                Path.Combine(folder, GlobalVariables.TmtExperimentalDesignFileName),
+                new List<string> { file }, out var errors);
+
+            Assert.IsEmpty(errors);
+            var byTag = readBack[0].Annotations.ToDictionary(a => a.Tag);
+            Assert.AreEqual(TmtSampleType.Reference, byTag["126"].SampleType);
+            Assert.AreEqual(TmtSampleType.StudySample, byTag["127N"].SampleType);
+
+            Directory.Delete(folder, true);
+        }
+
+        #endregion
+
+        #region Projection onto mzLib
+
+        private static IsobaricMassTag Tmt10() => IsobaricMassTag.GetIsobaricMassTag(IsobaricMassTagType.TMT10);
+
+        private static TmtFileInfo FileWith(string path, string plex, int fraction, int techrep,
+            params (string tag, string condition, int bio, TmtSampleType type)[] channels)
+        {
+            var annotations = channels
+                .Select(c => new TmtPlexAnnotation
+                {
+                    Tag = c.tag,
+                    SampleName = c.condition + "_" + c.bio,
+                    Condition = c.condition,
+                    BiologicalReplicate = c.bio,
+                    SampleType = c.type
+                })
+                .ToList();
+            return new TmtFileInfo(path, plex, fraction, techrep, annotations);
+        }
+
+        /// <summary>
+        /// The load-bearing contract: the ISampleInfo array must be in ascending reporter m/z order,
+        /// because MetaMorpheus fills ISpectralMatch.Intensities in that order and mzLib maps the two
+        /// positionally. A design file listing channels in any other order must not change it.
+        /// </summary>
+        [Test]
+        public static void ToMzLibDesign_OrdersChannelsByReporterMz_NotByDesignFileOrder()
+        {
+            var tag = Tmt10();
+            Assert.IsNotNull(tag, "TMT10 must resolve from the loaded modifications");
+
+            // Deliberately scrambled relative to the tag's own channel order.
+            var file = FileWith(@"C:\data\run1.raw", "PlexA", 1, 1,
+                ("129N", "D", 1, TmtSampleType.StudySample),
+                ("126", "A", 1, TmtSampleType.Reference),
+                ("127C", "C", 1, TmtSampleType.StudySample),
+                ("127N", "B", 1, TmtSampleType.StudySample));
+
+            var design = TmtExperimentalDesign.ToMzLibDesign(new[] { file }, tag, out var errors);
+
+            Assert.IsEmpty(errors);
+            var samples = design.FileNameSampleInfoDictionary["run1.raw"];
+
+            var expectedLabels = IsobaricMassTag.GetReporterIonLabels(IsobaricMassTagType.TMT10);
+            Assert.AreEqual(expectedLabels.Count, samples.Length,
+                "one entry per tag channel, so the array lines up with Intensities");
+
+            for (int i = 0; i < expectedLabels.Count; i++)
+            {
+                var isobaric = (IsobaricQuantSampleInfo)samples[i];
+                Assert.AreEqual(expectedLabels[i], isobaric.ChannelLabel);
+                Assert.AreEqual(tag.ReporterIonMzs[i], isobaric.ReporterIonMz, 1e-6);
+            }
+
+            // Reporter m/z must be strictly increasing, which is what "tag order" means.
+            for (int i = 1; i < samples.Length; i++)
+            {
+                Assert.Less(((IsobaricQuantSampleInfo)samples[i - 1]).ReporterIonMz,
+                            ((IsobaricQuantSampleInfo)samples[i]).ReporterIonMz);
+            }
+        }
+
+        [Test]
+        public static void ToMzLibDesign_CarriesTheAnnotationOntoTheMatchingChannel()
+        {
+            var tag = Tmt10();
+            var file = FileWith(@"C:\data\run1.raw", "PlexA", 2, 3,
+                ("126", "Reference", 1, TmtSampleType.Reference),
+                ("127N", "Treated", 2, TmtSampleType.StudySample));
+
+            var design = TmtExperimentalDesign.ToMzLibDesign(new[] { file }, tag, out var errors);
+            Assert.IsEmpty(errors);
+
+            var samples = design.FileNameSampleInfoDictionary["run1.raw"]
+                .Cast<IsobaricQuantSampleInfo>()
+                .ToDictionary(s => s.ChannelLabel);
+
+            Assert.AreEqual("Reference", samples["126"].Condition);
+            Assert.AreEqual(1, samples["126"].BiologicalReplicate);
+            Assert.IsTrue(samples["126"].IsReferenceChannel);
+
+            Assert.AreEqual("Treated", samples["127N"].Condition);
+            Assert.AreEqual(2, samples["127N"].BiologicalReplicate);
+            Assert.IsFalse(samples["127N"].IsReferenceChannel);
+
+            // Fraction and technical replicate are per-file, not per-channel.
+            Assert.IsTrue(samples.Values.All(s => s.Fraction == 2 && s.TechnicalReplicate == 3));
+        }
+
+        /// <summary>
+        /// A channel the design does not mention still gets an entry, because MetaMorpheus reports an
+        /// intensity for every channel of the tag. Skipping it would shift every later channel by one.
+        /// </summary>
+        [Test]
+        public static void ToMzLibDesign_UnannotatedChannelsBecomeEmptyRatherThanBeingSkipped()
+        {
+            var tag = Tmt10();
+            var file = FileWith(@"C:\data\run1.raw", "PlexA", 1, 1,
+                ("126", "Reference", 1, TmtSampleType.Reference));
+
+            var design = TmtExperimentalDesign.ToMzLibDesign(new[] { file }, tag, out var errors);
+            Assert.IsEmpty(errors);
+
+            var samples = design.FileNameSampleInfoDictionary["run1.raw"];
+            Assert.AreEqual(10, samples.Length);
+
+            var unannotated = samples.Cast<IsobaricQuantSampleInfo>().Where(s => s.ChannelLabel != "126").ToList();
+            Assert.AreEqual(9, unannotated.Count);
+            Assert.IsTrue(unannotated.All(s => s.Condition == string.Empty));
+            Assert.IsTrue(unannotated.All(s => !s.IsReferenceChannel));
+        }
+
+        [Test]
+        public static void ToMzLibDesign_ChannelThatIsNotPartOfTheTag_IsAnError()
+        {
+            var tag = Tmt10();
+            var file = FileWith(@"C:\data\run1.raw", "PlexA", 1, 1,
+                ("135N", "Treated", 1, TmtSampleType.StudySample));   // TMT18 channel, not TMT10
+
+            var design = TmtExperimentalDesign.ToMzLibDesign(new[] { file }, tag, out var errors);
+
+            Assert.IsNull(design, "a design with an impossible channel must not be half-usable");
+            Assert.IsTrue(errors.Any(e => e.Contains("135N")), string.Join(" | ", errors));
+        }
+
+        /// <summary>Plex is free text in the file and an int on the sample info; the mapping must be stable.</summary>
+        [Test]
+        public static void ToMzLibDesign_AssignsStablePlexIds()
+        {
+            var tag = Tmt10();
+            var files = new[]
+            {
+                FileWith(@"C:\data\runB.raw", "PlexB", 1, 1, ("126", "A", 1, TmtSampleType.StudySample)),
+                FileWith(@"C:\data\runA.raw", "PlexA", 1, 1, ("126", "A", 1, TmtSampleType.StudySample)),
+                FileWith(@"C:\data\runA2.raw", "PlexA", 1, 2, ("126", "A", 1, TmtSampleType.StudySample))
+            };
+
+            var design = TmtExperimentalDesign.ToMzLibDesign(files, tag, out var errors);
+            Assert.IsEmpty(errors);
+
+            int PlexOf(string fileName) =>
+                ((IsobaricQuantSampleInfo)design.FileNameSampleInfoDictionary[fileName][0]).PlexId;
+
+            Assert.AreEqual(PlexOf("runA.raw"), PlexOf("runA2.raw"), "same plex, same id");
+            Assert.AreNotEqual(PlexOf("runA.raw"), PlexOf("runB.raw"));
+            Assert.AreEqual(1, PlexOf("runA.raw"), "ids follow the sorted plex names");
+            Assert.AreEqual(2, PlexOf("runB.raw"));
+        }
+
+        /// <summary>The dictionary key must be the file name WITH extension, which is what PivotByFile looks up.</summary>
+        [Test]
+        public static void ToMzLibDesign_KeysByFileNameWithExtension()
+        {
+            var tag = Tmt10();
+            var file = FileWith(@"C:\some\deep\path\run1.raw", "PlexA", 1, 1,
+                ("126", "A", 1, TmtSampleType.StudySample));
+
+            var design = TmtExperimentalDesign.ToMzLibDesign(new[] { file }, tag, out _);
+
+            Assert.IsTrue(design.FileNameSampleInfoDictionary.ContainsKey("run1.raw"));
+            Assert.AreEqual(1, design.FileNameSampleInfoDictionary.Count);
+        }
+
+        [Test]
+        public static void ToMzLibDesign_WithoutATag_IsAnError()
+        {
+            var file = FileWith(@"C:\data\run1.raw", "PlexA", 1, 1,
+                ("126", "A", 1, TmtSampleType.StudySample));
+
+            var design = TmtExperimentalDesign.ToMzLibDesign(new[] { file }, null, out var errors);
+
+            Assert.IsNull(design);
+            Assert.IsTrue(errors.Any(e => e.Contains("isobaric mass tag")), string.Join(" | ", errors));
+        }
+
+        [Test]
+        public static void ToMzLibDesign_WithNoFiles_IsAnError()
+        {
+            var design = TmtExperimentalDesign.ToMzLibDesign(new List<TmtFileInfo>(), Tmt10(), out var errors);
+
+            Assert.IsNull(design);
+            Assert.IsNotEmpty(errors);
+        }
+
+        /// <summary>
+        /// The window offering the channel drop-down and the tag that validates it must agree, or the
+        /// GUI can write a design that cannot be projected. They were two separate tables until now.
+        /// </summary>
+        [Test]
+        public static void EveryTagsLabelsMatchItsReporterIonCount()
+        {
+            foreach (IsobaricMassTagType type in Enum.GetValues(typeof(IsobaricMassTagType)))
+            {
+                var tag = IsobaricMassTag.GetIsobaricMassTag(type);
+                if (tag == null) continue;   // modification not loaded in this environment
+
+                var labels = IsobaricMassTag.GetReporterIonLabels(type);
+                Assert.IsNotNull(labels, type.ToString());
+                Assert.AreEqual(labels.Count, tag.ReporterIonMzs.Length,
+                    $"{type} has {labels.Count} labels but {tag.ReporterIonMzs.Length} reporter ions");
+            }
+        }
+
+        /// <summary>
+        /// The stronger half of the same invariant, and the one that actually protects the projection:
+        /// ToMzLibDesign pairs channelLabels[i] with ReporterIonMzs[i], so label i has to name the
+        /// channel whose m/z sits at i. A count cannot catch a mislabelled channel -- iTRAQ 8-plex
+        /// carried the name "120" for the 121 reagent for exactly that reason, extracting the right ion
+        /// under a name no kit has.
+        ///
+        /// Every label begins with its nominal mass, so the assertion is available cheaply.
+        /// </summary>
+        [Test]
+        public static void EveryTagsLabelsNameTheChannelAtTheirOwnIndex()
+        {
+            foreach (IsobaricMassTagType type in Enum.GetValues(typeof(IsobaricMassTagType)))
+            {
+                var tag = IsobaricMassTag.GetIsobaricMassTag(type);
+                if (tag == null) continue;   // modification not loaded in this environment
+
+                var labels = IsobaricMassTag.GetReporterIonLabels(type);
+                Assert.IsNotNull(labels, type.ToString());
+
+                for (int i = 0; i < labels.Count; i++)
+                {
+                    string digits = new string(labels[i].TakeWhile(char.IsDigit).ToArray());
+                    Assert.IsNotEmpty(digits, $"{type} label '{labels[i]}' does not begin with a nominal mass");
+
+                    int nominal = int.Parse(digits);
+                    int observed = (int)Math.Round(tag.ReporterIonMzs[i]);
+
+                    Assert.AreEqual(nominal, observed,
+                        $"{type} label '{labels[i]}' at index {i} names channel {nominal}, " +
+                        $"but the reporter ion at that index is {tag.ReporterIonMzs[i]:F4} (channel {observed})");
+                }
+            }
+        }
+
+        /// <summary>
+        /// ToMzLibDesign pairs channelLabels[i] with ReporterIonMzs[i] positionally. If the two ever
+        /// differ in length that pairing is meaningless, and the failure is silent: every channel past
+        /// the shorter array would be assigned the wrong reporter ion, producing a design that looks
+        /// complete and reports the wrong sample's abundance. The guard has to refuse rather than
+        /// truncate, and this is what proves it does.
+        ///
+        /// The two lengths come from independent sources -- the DI block in Mods/tmt.txt and the label
+        /// table in IsobaricMassTag -- which is exactly how the iTRAQ 8-plex name drifted. A real tag
+        /// cannot currently reach this state (EveryTagsLabelsMatchItsReporterIonCount asserts as much),
+        /// so the mismatch is constructed by reflection.
+        /// </summary>
+        [Test]
+        public static void MismatchedChannelAndReporterIonCountsAreRefused()
+        {
+            var tag = IsobaricMassTag.GetIsobaricMassTag(IsobaricMassTagType.TMT11);
+            Assert.That(tag, Is.Not.Null, "TMT11 must load, or this test proves nothing");
+
+            int realCount = tag.ReporterIonMzs.Length;
+            typeof(IsobaricMassTag)
+                .GetProperty(nameof(IsobaricMassTag.ReporterIonMzs))!
+                .SetValue(tag, tag.ReporterIonMzs.Take(realCount - 1).ToArray());
+
+            var design = TmtExperimentalDesign.ToMzLibDesign(new[] { OneFile("a.raw", "Plex1", "126") }, tag, out var errors);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(design, Is.Null, "a design must not be produced from a misaligned tag");
+                Assert.That(errors.Any(e => e.Contains("disagree")), Is.True);
+                Assert.That(errors.Any(e => e.Contains($"{realCount} channels")), Is.True,
+                    "the error should name both counts, since the point is which source to fix");
+            });
+        }
+
+        /// <summary>
+        /// The design is keyed by file name, so two entries resolving to the same name would have one
+        /// silently overwrite the other's channels.
+        ///
+        /// The projection is all-or-nothing: any error yields a null design rather than a partial one.
+        /// That is the right call here -- a design missing a file quantifies that file's channels
+        /// against nothing and says so nowhere -- and the per-entry `continue` exists to collect every
+        /// problem in one pass rather than to salvage the rest.
+        /// </summary>
+        [Test]
+        public static void TwoEntriesSharingAFileNameAreRefusedWithoutLosingTheRest()
+        {
+            var tag = IsobaricMassTag.GetIsobaricMassTag(IsobaricMassTagType.TMT11);
+            Assert.That(tag, Is.Not.Null);
+
+            var files = new[]
+            {
+                OneFile(Path.Combine("runA", "sample.raw"), "Plex1", "126"),
+                OneFile(Path.Combine("runB", "sample.raw"), "Plex1", "127N"),   // same name, different folder
+                OneFile("other.raw", "Plex1", "127C"),
+            };
+
+            var design = TmtExperimentalDesign.ToMzLibDesign(files, tag, out var errors);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(errors.Any(e => e.Contains("share the file name")), Is.True);
+                Assert.That(design, Is.Null,
+                    "a colliding key must fail the whole projection, not yield a design missing a file");
+            });
+        }
+
+        /// <summary>
+        /// An entry whose path has no file-name component cannot be keyed at all. Reported, and the
+        /// whole projection refused, rather than producing an entry under an empty key that would
+        /// never match a spectra file.
+        /// </summary>
+        [Test]
+        public static void EntryWithNoFileNameIsReported()
+        {
+            var tag = IsobaricMassTag.GetIsobaricMassTag(IsobaricMassTagType.TMT11);
+            Assert.That(tag, Is.Not.Null);
+
+            var files = new[]
+            {
+                OneFile(Path.Combine("some", "folder") + Path.DirectorySeparatorChar, "Plex1", "126"),
+                OneFile("good.raw", "Plex1", "127N"),
+            };
+
+            var design = TmtExperimentalDesign.ToMzLibDesign(files, tag, out var errors);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(errors.Any(e => e.Contains("no file name")), Is.True);
+                Assert.That(design, Is.Null);
+            });
+        }
+
+        /// <summary>
+        /// Write round-trips a sample type through ToDesignFileValue, so an unrecognised value has to
+        /// produce something Read will accept rather than an empty cell that fails to parse on reload.
+        /// </summary>
+        [Test]
+        public static void UnknownSampleTypeWritesAsStudySample()
+        {
+            string written = TmtExperimentalDesign.ToDesignFileValue((TmtSampleType)999);
+
+            Assert.That(written, Is.EqualTo("study sample"));
+            Assert.That(TmtExperimentalDesign.TryParseSampleType(written, out var parsed), Is.True,
+                "whatever is written must survive a read back");
+            Assert.That(parsed, Is.EqualTo(TmtSampleType.StudySample));
+        }
+
+        /// <summary>A single-file, single-channel design entry, for the checks above.</summary>
+        private static TmtFileInfo OneFile(string path, string plex, string tag) =>
+            new TmtFileInfo(path, plex, 1, 1, new[]
+            {
+                new TmtPlexAnnotation
+                {
+                    Tag = tag,
+                    SampleName = "S1",
+                    Condition = "Control",
+                    BiologicalReplicate = 1,
+                    SampleType = TmtSampleType.StudySample
+                }
+            });
+
+        /// <summary>
+        /// Two entries that both lack a file name are two missing names, not a collision. The skip
+        /// after the first report is what keeps them separate: without it the first is keyed under
+        /// the empty string, and the second is then reported as sharing the file name '' -- naming a
+        /// fault the design does not have, and sending the user looking for a duplicate.
+        /// </summary>
+        [Test]
+        public static void TwoEntriesWithNoFileNameAreReportedAsMissingNamesNotACollision()
+        {
+            var tag = Tmt10();
+            var first = FileWith(@"C:\data\", "PlexA", 1, 1, ("126", "A", 1, TmtSampleType.StudySample));
+            var second = FileWith(@"D:\other\", "PlexA", 1, 1, ("126", "B", 1, TmtSampleType.StudySample));
+
+            var design = TmtExperimentalDesign.ToMzLibDesign(new[] { first, second }, tag, out var errors);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(errors.Count(e => e.Contains("no file name")), Is.EqualTo(2),
+                    "each nameless entry is its own problem");
+                Assert.That(errors.Any(e => e.Contains("share the file name")), Is.False,
+                    "two missing names were reported as a name collision");
+                Assert.That(design, Is.Null);
+            });
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
**First of three PRs splitting #2598.** That PR is 3,300 lines carrying two new WPF windows and has sat at 0/3. #2596 sat 77 days and #2602 sat 233, both smaller — so this split is about getting the work reviewed, not about disagreeing with any of it.

This one is **headless**: `TmtExperimentalDesign`, its parser and writer, and the tests. No CMD wiring, no GUI, nothing that needs a WPF reviewer.

`TmtDesign.txt` describes which data file and reporter channel each sample sits in, so a TMT search can attribute per-channel intensities to conditions. `GlobalVariables` gains the default filename alongside the existing `ExperimentalDesign.tsv`.

**58 tests**: the parser against well-formed and malformed files, sample-type round-tripping, and projection onto mzLib's `IExperimentalDesign` / `IsobaricQuantSampleInfo` — the contract `QuantificationEngine` consumes.

### Two things deliberately not here

- `ResolveExperimentalDesignTests` exercises `CMD.Program.ResolveExperimentalDesign`, so it travels with the CMD wiring. The compiler drew that boundary, not me — it was the one file that would not build without `Program`.
- A comment-only edit to `Multiplex_Labeling_TMT_iTRAQ.cs` that #2771 has since made redundant. It was churn by the time this was split; carrying it would have put a cosmetic diff in front of a reviewer for nothing.

### The other two

| | |
|---|---|
| **CMD wiring** | stacked on this branch |
| **GUI** | stacked on this branch, independently of CMD |

Both show this PR's commits until it merges, then rebase to their own files. **Merge this one first.**
