### PR TITLE
MetaDraw: draw C-terminal and last-on-screen modifications in the stationary sequence

### DIFF
--- a/MetaMorpheus/GuiFunctions/MetaDraw/DrawnSequence.cs
+++ b/MetaMorpheus/GuiFunctions/MetaDraw/DrawnSequence.cs
@@ -263,16 +263,32 @@ namespace GuiFunctions
         {
             ClearCanvas(stationarySequence.SequenceDrawingCanvas);
             IBioPolymerWithSetMods peptide = sm.ToBioPolymerWithSetMods();
-            string baseSequence = sm.BaseSeq.Substring(MetaDrawSettings.FirstAAonScreenIndex, MetaDrawSettings.NumberOfAAOnScreen);
+            int firstResidueOnScreen = MetaDrawSettings.FirstAAonScreenIndex;
+            int residuesOnScreen = MetaDrawSettings.NumberOfAAOnScreen;
+            string baseSequence = sm.BaseSeq.Substring(firstResidueOnScreen, residuesOnScreen);
             string fullSequence = baseSequence;
 
+            // AllModsOneIsNterminus keys: 1 is the N-terminus, zero-based residue r is r + 2, and the C-terminus is BaseSeq.Length + 2
+            var cTerminalMod = peptide.AllModsOneIsNterminus
+                .Where(p => p.Key == sm.BaseSeq.Length + 2)
+                .Select(p => p.Value)
+                .FirstOrDefault();
+
             // Trim full sequences selectively based upon what is show in scrollable sequence
-            var modDictionary = peptide.AllModsOneIsNterminus.Where(p => p.Key - 1 >= MetaDrawSettings.FirstAAonScreenIndex 
-            && p.Key - 1 < (MetaDrawSettings.FirstAAonScreenIndex + MetaDrawSettings.NumberOfAAOnScreen)).OrderByDescending(p => p.Key);
+            var modDictionary = peptide.AllModsOneIsNterminus.Where(p => p.Key == 1
+                    ? firstResidueOnScreen == 0
+                    : p.Key - 2 >= firstResidueOnScreen && p.Key - 2 < firstResidueOnScreen + residuesOnScreen)
+                .OrderByDescending(p => p.Key);
             foreach (var mod in modDictionary)
             {
                 // if modification is within the visible region
-                fullSequence = fullSequence.Insert(mod.Key - 1 - MetaDrawSettings.FirstAAonScreenIndex, "[" + mod.Value.ModificationType + ":" + mod.Value.IdWithMotif + "]");
+                fullSequence = fullSequence.Insert(mod.Key - 1 - firstResidueOnScreen, "[" + mod.Value.ModificationType + ":" + mod.Value.IdWithMotif + "]");
+            }
+
+            // a C-terminal mod sits past the last residue, so it is appended rather than inserted
+            if (cTerminalMod != null && residuesOnScreen > 0 && firstResidueOnScreen + residuesOnScreen >= sm.BaseSeq.Length)
+            {
+                fullSequence += "-[" + cTerminalMod.ModificationType + ":" + cTerminalMod.IdWithMotif + "]";
             }
 
             List<MatchedFragmentIon> matchedIons = sm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.ResiduePosition > MetaDrawSettings.FirstAAonScreenIndex &&

--- a/MetaMorpheus/Test/MetaDraw/MetaDrawTest.cs
+++ b/MetaMorpheus/Test/MetaDraw/MetaDrawTest.cs
@@ -571,12 +571,25 @@ namespace Test.MetaDraw
                 // Checks to see if the stationary sequence updated with the new positioning
                 string modifiedBaseSeq = psm.BaseSeq.Substring(MetaDrawSettings.FirstAAonScreenIndex, MetaDrawSettings.NumberOfAAOnScreen);
                 string fullSequence = modifiedBaseSeq;
-                var modDictionary = peptide.AllModsOneIsNterminus.Where(p => p.Key - 1 >= MetaDrawSettings.FirstAAonScreenIndex
-                    && p.Key - 1 < (MetaDrawSettings.FirstAAonScreenIndex + MetaDrawSettings.NumberOfAAOnScreen)).OrderByDescending(p => p.Key);
+                var modDictionary = peptide.AllModsOneIsNterminus.Where(p => p.Key == 1
+                        ? MetaDrawSettings.FirstAAonScreenIndex == 0
+                        : p.Key - 2 >= MetaDrawSettings.FirstAAonScreenIndex
+                          && p.Key - 2 < MetaDrawSettings.FirstAAonScreenIndex + MetaDrawSettings.NumberOfAAOnScreen)
+                    .OrderByDescending(p => p.Key);
                 foreach (var mod in modDictionary)
                 {
                     // if modification is within the visible region
                     fullSequence = fullSequence.Insert(mod.Key - 1 - MetaDrawSettings.FirstAAonScreenIndex, "[" + mod.Value.ModificationType + ":" + mod.Value.IdWithMotif + "]");
+                }
+
+                var cTerminalMod = peptide.AllModsOneIsNterminus
+                    .Where(p => p.Key == psm.BaseSeq.Length + 2)
+                    .Select(p => p.Value)
+                    .FirstOrDefault();
+                if (cTerminalMod != null && MetaDrawSettings.NumberOfAAOnScreen > 0
+                    && MetaDrawSettings.FirstAAonScreenIndex + MetaDrawSettings.NumberOfAAOnScreen >= psm.BaseSeq.Length)
+                {
+                    fullSequence += "-[" + cTerminalMod.ModificationType + ":" + cTerminalMod.IdWithMotif + "]";
                 }
 
                 List<MatchedFragmentIon> matchedIons = psm.MatchedIons.Where(p => p.NeutralTheoreticalProduct.ResiduePosition > MetaDrawSettings.FirstAAonScreenIndex &&
@@ -603,6 +616,48 @@ namespace Test.MetaDraw
                 var expected = expectedBaseSequence + expectedIonAnnotations + expectedModCount + expectedNumberCount + expectedNumberLineConnectorCount;
                 Assert.That(metadrawLogic.StationarySequence.SequenceDrawingCanvas.Children.Count, Is.EqualTo(expected));
             }
+        }
+
+        [Test]
+        public static void MetaDraw_StationarySequenceDrawsTerminalAndLastResidueMods()
+        {
+            string psmFile = Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\SequenceCoverageTestPSM.psmtsv");
+            var psm = SpectrumMatchTsvReader.ReadPsmTsv(psmFile, out _).First();
+
+            // "Serine amide on S" is the protein C-terminal sibling of the "Arginine amide on R" of issue 2330
+            var cTerminalMod = GlobalVariables.AllModsKnownDictionary["Serine amide on S"];
+            Assert.That(cTerminalMod.LocationRestriction, Is.EqualTo("C-terminal."));
+            Assert.That(psm.BaseSeq, Does.EndWith("S"));
+            Assert.That(psm.ToBioPolymerWithSetMods().AllModsOneIsNterminus.Keys, Is.EquivalentTo(new[] { 1, 7 }));
+
+            var withCTerminalMod = psm.ReplaceFullSequence(
+                psm.FullSequence + $"-[{cTerminalMod.ModificationType}:{cTerminalMod.IdWithMotif}]", psm.BaseSeq);
+            Assert.That(withCTerminalMod.ToBioPolymerWithSetMods().AllModsOneIsNterminus.Keys,
+                Is.EquivalentTo(new[] { 1, 7, psm.BaseSeq.Length + 2 }));
+
+            // whole peptide on screen: N-terminal, residue and C-terminal mods are all drawn
+            MetaDrawSettings.FirstAAonScreenIndex = 0;
+            MetaDrawSettings.NumberOfAAOnScreen = psm.BaseSeq.Length;
+            var stationary = new DrawnSequence(new Canvas(), withCTerminalMod, true);
+            Assert.That(stationary.SequenceDrawingCanvas.Children.OfType<Ellipse>().Count(), Is.EqualTo(3));
+
+            // scrolled to the end: only the C-terminal mod is on screen
+            MetaDrawSettings.FirstAAonScreenIndex = psm.BaseSeq.Length - 5;
+            MetaDrawSettings.NumberOfAAOnScreen = 5;
+            stationary = new DrawnSequence(new Canvas(), withCTerminalMod, true);
+            Assert.That(stationary.SequenceDrawingCanvas.Children.OfType<Ellipse>().Count(), Is.EqualTo(1));
+
+            // the modified residue is the last one on screen, so its mod is drawn along with the N-terminal mod
+            MetaDrawSettings.FirstAAonScreenIndex = 0;
+            MetaDrawSettings.NumberOfAAOnScreen = 6;
+            stationary = new DrawnSequence(new Canvas(), psm, true);
+            Assert.That(stationary.SequenceDrawingCanvas.Children.OfType<Ellipse>().Count(), Is.EqualTo(2));
+
+            // scrolled one residue past the modified residue, so neither mod is on screen
+            MetaDrawSettings.FirstAAonScreenIndex = 6;
+            MetaDrawSettings.NumberOfAAOnScreen = 20;
+            stationary = new DrawnSequence(new Canvas(), psm, true);
+            Assert.That(stationary.SequenceDrawingCanvas.Children.OfType<Ellipse>(), Is.Empty);
         }
 
         [Test]


### PR DESCRIPTION
🤖 Closes #2330. MetaDraw's stationary sequence — the one drawn over the spectrum in the Child Scan View — never draws a C-terminal modification, and silently drops the modification on the last residue on screen. This is what is left of #2330 now that the sequence-annotation crash reported there is fixed (#2579, released in 1.1.6). Closing the issue on this rather than on #2579: the crash is gone, but the modification the reporter was trying to see is still not drawn, so their scenario only works end to end once this lands.

**This changes where modification circles are drawn, for all modification types, in the stationary sequence only.** Three changes, all in `DrawStationarySequence`:

- a mod on the **last residue on screen** is now drawn (it used to be dropped);
- a mod on the residue **immediately to the left of the window** is no longer drawn (it used to be inserted at index 0 and rendered as an N-terminal circle at x = −12, i.e. attributed to a residue that is off screen);
- a **C-terminal** mod is now drawn one slot past the last residue when the window reaches the end of the peptide (it used to be drawn nowhere).

N-terminal mods and interior mods that are not at either edge of the window are unaffected. The scrollable sequence, the sequence-annotation view and the PTM legend are untouched.

## Cause

`AllModsOneIsNterminus` keys the N-terminus at 1, zero-based residue `r` at `r + 2`, and the C-terminus at `BaseSeq.Length + 2`. The filter used `p.Key - 1` against the on-screen residue window, which is the residue-mod convention off by one, so the window was shifted one residue left at both edges. `BaseSeq.Length + 2` fell outside it for every window, because the window can never extend past the last residue.

A C-terminal mod also cannot be `Insert`ed into the trimmed base sequence — its index is one past the end of the string, which is precisely how the #2330 crash happened in the segment loop of `DrawSequenceAnnotation`. It is appended as `-[type:id]` instead, the same representation `DrawSequenceAnnotation` uses and `IBioPolymerWithSetMods.GetModificationDictionaryFromFullSequence` already understands.

## Tests

`MetaDraw_StationarySequenceDrawsTerminalAndLastResidueMods` drives `DrawnSequence` at four scroll positions over `TestData/SequenceCoverageTestPSM.psmtsv` and counts the drawn circles. The PSM carries an N-terminal acetylation and an oxidation on residue 6; the test appends `Serine amide on S`, the protein-C-terminal sibling of the `Arginine amide on R` from the issue, to its C-terminal S. Three of the four expected counts differ from current behaviour.

`MetaDraw_TestStationarySequencePositioning` mirrors the production filter to compute its expected mod count, so its copy is updated to match; the two filters differ at `FirstAAonScreenIndex` 17 and 37 on that test's data.

## Not verified

The rendered result was not inspected — the WPF views cannot be run on macOS and `Test.csproj` cannot execute there, so the new test compiles but has never been executed and I did not confirm it fails against unfixed code. Its expected counts were derived from a headless harness that ran the old and new trimming side by side against real modification data and mzLib 1.0.587; three of the four differ from the old behaviour, so it should fail, but that is inference. CI is the first real run. The x-coordinates the circles land on were derived from parsed mod keys, not measured from a rendered canvas.

