### PR TITLE
Give quantified peptides the protein group parsimony resolved them into

### DIFF
--- a/MetaMorpheus/TaskLayer/SearchTask/PostSearchAnalysisTask.cs
+++ b/MetaMorpheus/TaskLayer/SearchTask/PostSearchAnalysisTask.cs
@@ -19,6 +19,7 @@ using System.Text;
 using EngineLayer.DatabaseLoading;
 using MzLibUtil;
 using Omics.Digestion;
+using Omics;
 using Omics.BioPolymer;
 using Omics.Modifications;
 using Omics.SpectrumMatch;
@@ -351,6 +352,9 @@ namespace TaskLayer
 
                 // pass protein group info for each PSM
                 var psmToProteinGroups = new Dictionary<SpectralMatch, List<ProteinGroup>>();
+                // Lets a PSM that parsimony left unassociated be matched back to the group its proteins
+                // ended up in. See ResolveProteinGroupsFromParsimony below.
+                var proteinToFlashLfqGroups = new Dictionary<IBioPolymer, List<ProteinGroup>>();
                 if (ProteinGroups != null && ProteinGroups.Count != 0) //ProteinGroups can be null if parsimony wasn't done, and it can be empty if you're doing the two peptide rule
                 {
                     foreach (var proteinGroup in ProteinGroups)
@@ -360,6 +364,18 @@ namespace TaskLayer
                         var flashLfqProteinGroup = new ProteinGroup(proteinGroup.ProteinGroupName,
                             string.Join("|", proteinsOrderedByAccession.Select(p => p.GeneNames.Select(x => x.Item2).FirstOrDefault())),
                             string.Join("|", proteinsOrderedByAccession.Select(p => p.Organism).Distinct()));
+
+                        foreach (var protein in proteinGroup.Proteins)
+                        {
+                            if (proteinToFlashLfqGroups.TryGetValue(protein, out var groupsForThisProtein))
+                            {
+                                groupsForThisProtein.Add(flashLfqProteinGroup);
+                            }
+                            else
+                            {
+                                proteinToFlashLfqGroups.Add(protein, new List<ProteinGroup> { flashLfqProteinGroup });
+                            }
+                        }
 
                         foreach (var psm in proteinGroup.AllPsmsBelowOnePercentFDR.Cast<SpectralMatch>()
                             .Where(v => v.FullSequence != null))
@@ -557,7 +573,8 @@ namespace TaskLayer
                 {
                     if (!psmToProteinGroups.ContainsKey(psm))
                     {
-                        psmToProteinGroups.Add(psm, new List<ProteinGroup> { undefinedPg });
+                        var resolved = ResolveProteinGroupsFromParsimony(psm, proteinToFlashLfqGroups);
+                        psmToProteinGroups.Add(psm, resolved ?? new List<ProteinGroup> { undefinedPg });
                     }
 
                     proteaseSortedPsms[psm.DigestionParams.DigestionAgent].Add(psm);
@@ -664,6 +681,48 @@ namespace TaskLayer
 
                 EngineCrashed("Quantification", e);
             }
+        }
+
+        /// <summary>
+        /// Finds the protein groups a quantified PSM belongs to when parsimony never associated it with
+        /// one. Returns null when none of the PSM's proteins ended up in a surviving group, which is the
+        /// case <see cref="ProteinGroup"/> "UNDEFINED" is for (e.g. the two-peptide rule dropped them).
+        /// </summary>
+        /// <remarks>
+        /// Parsimony excludes ambiguous PSMs, then narrows every PSM to its parsimonious proteins and
+        /// re-resolves the sequence. A PSM that was ambiguous beforehand can therefore become unambiguous
+        /// afterwards, at which point quantification accepts it but the protein groups were already built
+        /// without it.
+        /// </remarks>
+        private static List<ProteinGroup> ResolveProteinGroupsFromParsimony(SpectralMatch psm,
+            Dictionary<IBioPolymer, List<ProteinGroup>> proteinToFlashLfqGroups)
+        {
+            if (proteinToFlashLfqGroups.Count == 0)
+            {
+                return null;
+            }
+
+            List<ProteinGroup> resolved = null;
+            foreach (var protein in psm.BestMatchingBioPolymersWithSetMods
+                .Select(b => b.SpecificBioPolymer.Parent)
+                .Distinct())
+            {
+                if (protein == null || !proteinToFlashLfqGroups.TryGetValue(protein, out var groups))
+                {
+                    continue;
+                }
+
+                resolved ??= new List<ProteinGroup>();
+                foreach (var group in groups)
+                {
+                    if (!resolved.Contains(group))
+                    {
+                        resolved.Add(group);
+                    }
+                }
+            }
+
+            return resolved;
         }
 
         /// <summary>

--- a/MetaMorpheus/Test/SearchTaskTest.cs
+++ b/MetaMorpheus/Test/SearchTaskTest.cs
@@ -1,4 +1,4 @@
-using EngineLayer;
+﻿using EngineLayer;
 using MassSpectrometry;
 using MzLibUtil;
 using NUnit.Framework; 
@@ -961,6 +961,46 @@ namespace Test
 
             // clean up
             Directory.Delete(folderPath, true);
+        }
+
+        /// <summary>
+        /// A PSM that is ambiguous when parsimony starts is excluded from it, but parsimony's own
+        /// trimming can leave it unambiguous. Quantification then accepts it, so it must still be
+        /// matched to the protein group its proteins landed in rather than reported as UNDEFINED.
+        /// </summary>
+        [Test]
+        public static void QuantifiedPeptideResolvedByParsimonyGetsItsProteinGroup()
+        {
+            string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestIssue2218");
+            string spectraFile = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "TaGe_SA_HeLa_04_subset_longestSeq.mzML");
+            string database = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "hela_snip_for_unitTest.fasta");
+
+            var searchTask = new SearchTask();
+
+            new EverythingRunnerEngine(
+                new List<(string, MetaMorpheusTask)> { ("Task", searchTask) },
+                new List<string> { spectraFile },
+                new List<DbForTask> { new DbForTask(database, false) },
+                outputFolder).Run();
+
+            string[] lines = File.ReadAllLines(Path.Combine(outputFolder, "Task", "AllQuantifiedPeptides.tsv"));
+            int proteinGroupColumn = Array.IndexOf(lines[0].Split('\t'), "Protein Groups");
+            Assert.That(proteinGroupColumn, Is.GreaterThanOrEqualTo(0));
+
+            var undefined = lines.Skip(1)
+                .Select(line => line.Split('\t'))
+                .Where(cells => cells[proteinGroupColumn] == "UNDEFINED")
+                .ToList();
+            Assert.That(undefined, Is.Empty, "quantified peptides with no protein group: "
+                + string.Join(", ", undefined.Select(cells => cells[0])));
+
+            // this is the peptide parsimony disambiguates; it belongs to the beta-tubulin group
+            var tubulin = lines.Skip(1)
+                .Select(line => line.Split('\t'))
+                .Single(cells => cells[1] == "EAESCDCLQGFQLTHSLGGGTGSGMGTLLISK");
+            Assert.That(tubulin[proteinGroupColumn], Does.Contain("P04350"));
+
+            Directory.Delete(outputFolder, true);
         }
     }
 }


### PR DESCRIPTION
🤖 Closes #2218. A quantified peptide could be reported with `UNDEFINED` in the `Protein Groups` column of `AllQuantifiedPeptides.tsv` while its protein group sat in `AllQuantifiedProteinGroups.tsv` in the same output folder.

## Mechanism

`ProteinParsimonyEngine` is built from PSMs filtered with `includeAmbiguous: false`, so a PSM that is ambiguous at that moment contributes no peptides and the protein groups are built without it. Stage 5 then calls `TrimProteinMatches`, which drops non-parsimonious candidates and re-runs `ResolveAllAmbiguities()` — so a PSM ambiguous *before* parsimony can be unambiguous *after* it. `QuantificationAnalysis` re-filters and accepts it, but `psmToProteinGroups` was built from `AllPsmsBelowOnePercentFDR`, which never saw it, so it falls through to the placeholder.

The fix records protein → FlashLFQ-group while building that dictionary, and resolves a leftover PSM from its own post-trim protein assignments. `UNDEFINED` is now used only when none of the PSM's proteins is in a surviving group — which is what the placeholder was for, e.g. when the two-peptide rule removed the group.

## This is not routing around a deliberate conservatism

Worth stating, because `includeAmbiguous: false` looks like exactly that. Splitting the call sites by what the caller does with the result:

| `false` — caller must commit to one sequence to *produce* something | `true` — caller only counts or reports |
|---|---|
| `ProteinParsimonyEngine`, `WritePrunedDatabase` ×2, spectral-library generation/update, `QuantificationAnalysis` ×2 | peptide-level FDR, psmtsv/peptide writers, variant passes |

The parsimony comment — "parsimony will only use non-ambiguous, high-confidence PSMs" — dates from `babdbdb8` (#1406, Sep 2018) and sits beside "KEEP contaminants for use in parsimony!". Contaminants are kept *despite* being low-value, which is the tell: the filter is about needing a definite sequence to attach a protein to, not about trustworthiness.

#2649 states the design in three steps: take all PSMs → **run parsimony on the 1% set** → **disambiguate all PSMs** by removing non-parsimonious proteins. The exclusion is step 2; disambiguation is step 3, an intended product, which #2649 also added reporting for. The guard's reason evaporates once step 3 supplies the sequence. A pipeline that disambiguates and then refuses to use the disambiguation is the defect.

## Why not the opposite fix

The alternative is to stop quantifying such a peptide, on the grounds that it is unambiguous only because the alternatives were discarded. Measured on the reproduction: all five candidates are targets, at identical score, at identical position 123–154, and **the entire ambiguity is one isoleucine/leucine swap** between beta-tubulin paralogues. Four of five carry the same sequence; only TUBB8 differs.

That settles it three ways. I and L are isobaric, so the chromatographic feature, m/z and area are identical under either interpretation — discarding the peak would lose real signal to fix nothing. MetaMorpheus has already committed to this identification everywhere else in the same run (`AllPeptides.psmtsv`, both scans in `AllPSMs.psmtsv`, and the headline "All target peptides with q-value <= 0.01: 23"), so excluding it would mean also deleting it from the peptide output and decrementing that count. And dropping TUBB8 because nothing else requires it is the same inference MetaMorpheus makes for every shared peptide.

## This changes protein-level quantification

FlashLFQ attributes intensity through `Identification.ProteinGroups`, so a peptide leaving `UNDEFINED` now contributes to its real group instead of being discarded into a phantom one. On `TestData/TaGe_SA_HeLa_04_subset_longestSeq.mzML` + `TestData/hela_snip_for_unitTest.fasta` with default settings, that moved one group's intensity from **27,774.34 to 380,500.73**.

Scope, measured across seven fixture configurations: every run producing no `UNDEFINED` rows is **byte-identical** — peptides, protein groups, results.txt. A two-peptide-rule run keeps all 81 of its `UNDEFINED` rows. No peptide is added to or removed from quantified output; row counts are unchanged. This follows from the code, since the new path only runs inside `if (!psmToProteinGroups.ContainsKey(psm))`.

**A reviewer should also see this:** after the fix the peptide maps to a *single* merged group, so FlashLFQ judges it unique-at-group-level and counts it toward protein quant **even when `UseSharedPeptidesForLFQ = false`**. That group-level notion of "shared" is pre-existing FlashLFQ semantics, not introduced here, but it is the mechanism behind the size of that intensity change.

## Prior art

#2259 (trishorts, Feb 2023, `[WIP]`, unmerged) reported this same symptom six weeks after #2218 and called it "messed up protein quantification". It diagnosed a different cause — a PEP-versus-QValue filter-type mismatch from #2161 — and that cause is genuinely gone: both filters now resolve through `FilteredPsms`, whose `QValue` case checks `QValue` and `QValueNotch` together (`FilteredPsms.cs:40`). A second, unrelated cause remained, which is this one.

## Not addressed

The peptide still does not appear in the group's `Number of Peptides` / `Best Sequence` / `Sequence Coverage` columns, because parsimony and protein scoring are untouched. Feeding newly-unambiguous PSMs back into parsimony before `ConstructProteinGroups` would fix that too, but it would change protein group composition, scores, q-values and counts — a separate decision. The same `UNDEFINED` construct in `PostGlycoSearchAnalysisTask.cs:543` is unchanged; I had no glyco reproduction to test it against.

`UNDEFINED` is documented nowhere — no `.xaml`, `.md`, `.txt` or release note in the repo mentions it.

## Test

`SearchTaskTest.QuantifiedPeptideResolvedByParsimonyGetsItsProteinGroup` runs a default search on the HeLa fixture and asserts no quantified peptide is `UNDEFINED`, and that the disambiguated peptide is assigned a group containing `P04350`. Verified to fail against unfixed code, naming the peptide. `Test/Test.csproj` is Windows-targeted so it ran via a throwaway net10.0 harness; CI is the first real run, and no existing test references `UNDEFINED`.
