### PR TITLE
Let the user choose or supply the FASTA header regexes

### DIFF
--- a/MetaMorpheus/EngineLayer/CommonParameters.cs
+++ b/MetaMorpheus/EngineLayer/CommonParameters.cs
@@ -1,4 +1,4 @@
-using MassSpectrometry;
+﻿using MassSpectrometry;
 using MzLibUtil;
 using Omics.Fragmentation;
 using Proteomics.ProteolyticDigestion;
@@ -11,6 +11,7 @@ using Transcriptomics.Digestion;
 using EngineLayer.DIA;
 using Transcriptomics;
 using EngineLayer.FdrAnalysis;
+using EngineLayer.DatabaseLoading;
 
 namespace EngineLayer
 {
@@ -65,7 +66,8 @@ namespace EngineLayer
             DIAparameters diaParameters = null,
             IFragmentationParams fragmentationParams = null,
             PrecursorMassMatchMode precursorMassMatchMode = PrecursorMassMatchMode.Monoisotopic,
-            string rtPredictorName = RTPredictorNames.Chronologer)
+            string rtPredictorName = RTPredictorNames.Chronologer,
+            FastaHeaderParsingParameters fastaHeaderParsing = null)
 
         {
             TaskDescriptor = taskDescriptor;
@@ -136,6 +138,7 @@ namespace EngineLayer
             }
 
             RTPredictorName = rtPredictorName;
+            FastaHeaderParsing = fastaHeaderParsing ?? new FastaHeaderParsingParameters();
 
             CustomIons = digestionParams.ProductsFromDissociationType()[DissociationType.Custom];
 
@@ -220,6 +223,11 @@ namespace EngineLayer
         public IFragmentationParams FragmentationParameters { get; set; }
         public string RTPredictorName { get; private set; }
 
+        /// <summary>
+        /// How protein FASTA deflines are split into accession, name, gene and organism.
+        /// </summary>
+        public FastaHeaderParsingParameters FastaHeaderParsing { get; private set; }
+
         public CommonParameters Clone()
         {
             CommonParameters c = new CommonParameters();
@@ -293,7 +301,8 @@ namespace EngineLayer
                                 DIAparameters,
                                 FragmentationParameters,
                                 PrecursorMassMatchMode,
-                                RTPredictorName);
+                                RTPredictorName,
+                                FastaHeaderParsing);
         }
 
         public void SetCustomProductTypes()

--- a/MetaMorpheus/EngineLayer/DatabaseLoading/DatabaseLoadingEngine.cs
+++ b/MetaMorpheus/EngineLayer/DatabaseLoading/DatabaseLoadingEngine.cs
@@ -168,9 +168,11 @@ public class DatabaseLoadingEngine(
         if (theExtension.Equals(".fasta") || theExtension.Equals(".fa"))
         {
             um = null;
+            var headerRegexes = (commonParameters.FastaHeaderParsing ?? new FastaHeaderParsingParameters()).GetFieldRegexes();
             proteinList = ProteinDbLoader.LoadProteinFasta(fileName, generateTargets, decoyType, isContaminant, out var dbErrors,
-                ProteinDbLoader.UniprotAccessionRegex, ProteinDbLoader.UniprotFullNameRegex, ProteinDbLoader.UniprotFullNameRegex, ProteinDbLoader.UniprotGeneNameRegex,
-                ProteinDbLoader.UniprotOrganismRegex, commonParameters.MaxThreadsToUsePerFile, addTruncations: commonParameters.AddTruncations);
+                headerRegexes.Accession, headerRegexes.FullName, headerRegexes.Name, headerRegexes.GeneName,
+                headerRegexes.Organism, commonParameters.MaxThreadsToUsePerFile, addTruncations: commonParameters.AddTruncations,
+                organismIdRegex: headerRegexes.OrganismId);
         }
         else
         {

--- a/MetaMorpheus/EngineLayer/DatabaseLoading/FastaHeaderParsingParameters.cs
+++ b/MetaMorpheus/EngineLayer/DatabaseLoading/FastaHeaderParsingParameters.cs
@@ -1,0 +1,250 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+using UsefulProteomicsDatabases;
+
+namespace EngineLayer.DatabaseLoading;
+
+/// <summary>
+/// Named FASTA header layouts that MetaMorpheus can parse. <see cref="FastaHeaderFormat.Custom"/>
+/// takes the regexes from <see cref="FastaHeaderParsingParameters"/> instead of a preset.
+/// </summary>
+public enum FastaHeaderFormat
+{
+    UniProt,
+    Ensembl,
+    Gencode,
+    Ncbi,
+    Modomics,
+    Custom
+}
+
+/// <summary>
+/// The six regexes handed to <see cref="ProteinDbLoader.LoadProteinFasta"/>. A null member means the
+/// field is not extracted.
+/// </summary>
+public class FastaHeaderFieldRegexSet
+{
+    public FastaHeaderFieldRegex? Accession { get; init; }
+    public FastaHeaderFieldRegex? FullName { get; init; }
+    public FastaHeaderFieldRegex? Name { get; init; }
+    public FastaHeaderFieldRegex? GeneName { get; init; }
+    public FastaHeaderFieldRegex? Organism { get; init; }
+    public FastaHeaderFieldRegex? OrganismId { get; init; }
+}
+
+/// <summary>
+/// How to pull accession, name, gene and organism out of a protein FASTA defline.
+/// Serialized as a table under [CommonParameters.FastaHeaderParsing]; every member is a string or an
+/// enum so Nett needs no custom converter for the fields themselves.
+/// </summary>
+public class FastaHeaderParsingParameters
+{
+    /// <summary>
+    /// Ceiling on a single validation match. The user supplies these patterns, so a pathological one
+    /// must be rejected at configuration time rather than stalling a load.
+    /// </summary>
+    public static readonly TimeSpan ValidationMatchTimeout = TimeSpan.FromMilliseconds(250);
+
+    /// <summary>
+    /// Deflines the validator matches each pattern against. Only used to smoke out catastrophic
+    /// backtracking; a pattern that matches nothing here is still accepted.
+    /// </summary>
+    internal static readonly string[] ValidationHeaders =
+    [
+        ">sp|P12345|AATM_RABIT Aspartate aminotransferase OS=Oryctolagus cuniculus OX=9986 GN=GOT2 PE=1 SV=2",
+        ">gi|16128008|ref|NP_414555.1| thr operon leader peptide [Escherichia coli str. K-12 substr. MG1655]",
+        ">id:1|Name:tdbR00000010|SOterm:SO:0000254|Type:tRNA|Subtype:Ala|Feature:VGC|Cellular_Localization:prokaryotic cytosol|Species:Escherichia coli"
+    ];
+
+    public FastaHeaderFormat HeaderFormat { get; set; } = FastaHeaderFormat.UniProt;
+
+    public string CustomAccessionRegex { get; set; } = "";
+    public string CustomFullNameRegex { get; set; } = "";
+    public string CustomNameRegex { get; set; } = "";
+    public string CustomGeneNameRegex { get; set; } = "";
+    public string CustomOrganismRegex { get; set; } = "";
+    public string CustomOrganismIdRegex { get; set; } = "";
+
+    public FastaHeaderParsingParameters()
+    {
+    }
+
+    public FastaHeaderParsingParameters(FastaHeaderFormat format,
+        string? accessionRegex = null, string? fullNameRegex = null, string? nameRegex = null,
+        string? geneNameRegex = null, string? organismRegex = null, string? organismIdRegex = null)
+    {
+        HeaderFormat = format;
+        CustomAccessionRegex = accessionRegex ?? "";
+        CustomFullNameRegex = fullNameRegex ?? "";
+        CustomNameRegex = nameRegex ?? "";
+        CustomGeneNameRegex = geneNameRegex ?? "";
+        CustomOrganismRegex = organismRegex ?? "";
+        CustomOrganismIdRegex = organismIdRegex ?? "";
+    }
+
+    public FastaHeaderParsingParameters Clone() => new(HeaderFormat, CustomAccessionRegex,
+        CustomFullNameRegex, CustomNameRegex, CustomGeneNameRegex, CustomOrganismRegex, CustomOrganismIdRegex);
+
+    /// <summary>
+    /// Checks the custom patterns without touching a database. Returns false and fills
+    /// <paramref name="errors"/> with user-facing messages when the configuration cannot be used.
+    /// </summary>
+    public bool Validate(out List<string> errors)
+    {
+        errors = new List<string>();
+        if (HeaderFormat != FastaHeaderFormat.Custom)
+            return true;
+
+        // mzLib falls back to header auto-detection when the accession regex is null, and that
+        // detection throws on a header it does not recognize. Require one instead.
+        if (string.IsNullOrWhiteSpace(CustomAccessionRegex))
+            errors.Add("Custom FASTA header format requires an accession regex. Set 'CustomAccessionRegex' " +
+                       "(the first capture group is used as the accession), or pick a preset FASTA header format.");
+
+        foreach (var (fieldName, pattern) in EnumerateCustomPatterns())
+        {
+            if (string.IsNullOrWhiteSpace(pattern))
+                continue;
+            if (!TryValidatePattern(pattern, out string? reason))
+                errors.Add($"The custom FASTA header regex for {fieldName} is not usable: {reason} Pattern: {pattern}");
+        }
+
+        return errors.Count == 0;
+    }
+
+    /// <summary>
+    /// Builds the regexes to hand to mzLib. Call <see cref="Validate"/> first; this throws on a
+    /// pattern that does not compile, as a backstop for callers that bypass the runner.
+    /// </summary>
+    public FastaHeaderFieldRegexSet GetFieldRegexes()
+    {
+        switch (HeaderFormat)
+        {
+            case FastaHeaderFormat.UniProt:
+                // FullName is deliberately used for both FullName and Name: that is what MetaMorpheus
+                // has always passed, and OrganismId has never been parsed. Changing either moves output.
+                return new FastaHeaderFieldRegexSet
+                {
+                    Accession = ProteinDbLoader.UniprotAccessionRegex,
+                    FullName = ProteinDbLoader.UniprotFullNameRegex,
+                    Name = ProteinDbLoader.UniprotFullNameRegex,
+                    GeneName = ProteinDbLoader.UniprotGeneNameRegex,
+                    Organism = ProteinDbLoader.UniprotOrganismRegex,
+                };
+
+            case FastaHeaderFormat.Ensembl:
+                return new FastaHeaderFieldRegexSet
+                {
+                    Accession = ProteinDbLoader.EnsemblAccessionRegex,
+                    FullName = ProteinDbLoader.EnsemblFullNameRegex,
+                    GeneName = ProteinDbLoader.EnsemblGeneNameRegex,
+                };
+
+            case FastaHeaderFormat.Gencode:
+                return new FastaHeaderFieldRegexSet
+                {
+                    Accession = ProteinDbLoader.GencodeAccessionRegex,
+                    FullName = ProteinDbLoader.GencodeFullNameRegex,
+                    GeneName = ProteinDbLoader.GencodeGeneNameRegex,
+                };
+
+            case FastaHeaderFormat.Ncbi:
+                return new FastaHeaderFieldRegexSet
+                {
+                    Accession = NcbiAccessionRegex,
+                    FullName = NcbiFullNameRegex,
+                    Organism = NcbiOrganismRegex,
+                };
+
+            case FastaHeaderFormat.Modomics:
+                return new FastaHeaderFieldRegexSet
+                {
+                    Accession = ModomicsAccessionRegex,
+                    FullName = ModomicsFullNameRegex,
+                    Name = ModomicsNameRegex,
+                    Organism = ModomicsOrganismRegex,
+                };
+
+            case FastaHeaderFormat.Custom:
+                return new FastaHeaderFieldRegexSet
+                {
+                    Accession = Build("accession", CustomAccessionRegex),
+                    FullName = Build("fullName", CustomFullNameRegex),
+                    Name = Build("name", CustomNameRegex),
+                    GeneName = Build("geneName", CustomGeneNameRegex),
+                    Organism = Build("organism", CustomOrganismRegex),
+                    OrganismId = Build("organismId", CustomOrganismIdRegex),
+                };
+
+            default:
+                throw new MetaMorpheusException($"Unrecognized FASTA header format: {HeaderFormat}");
+        }
+    }
+
+    /// <summary>
+    /// Legacy and modern NCBI deflines: >gi|16128008|ref|NP_414555.1| ... and >ref|NP_414555.1| ...
+    /// The greedy prefix pushes the opening pipe as late as possible, so the capture lands between the
+    /// last two pipes rather than spanning all of them.
+    /// </summary>
+    public static readonly FastaHeaderFieldRegex NcbiAccessionRegex = new("accession", @">.*\|(.*)\|", 0, 1);
+    public static readonly FastaHeaderFieldRegex NcbiFullNameRegex = new("fullName", @">[^ ]*\s(.*?)(\s\[|$)", 0, 1);
+    public static readonly FastaHeaderFieldRegex NcbiOrganismRegex = new("organism", @"\[([^\[\]]+)\]\s*$", 0, 1);
+
+    // Patterns copied verbatim from mzLib RnaDbLoader.ModomicsFieldRegexes; only the mapping onto the
+    // protein fields is ours. Accession uses Name (unique per entry) rather than the repeating SOterm.
+    public static readonly FastaHeaderFieldRegex ModomicsAccessionRegex = new("accession", @"Name:(.+?)\|", 0, 1);
+    public static readonly FastaHeaderFieldRegex ModomicsNameRegex = new("name", @"SOterm:(.+?)\|", 0, 1);
+    public static readonly FastaHeaderFieldRegex ModomicsFullNameRegex = new("fullName", @"Type:(.+?)\|", 0, 1);
+    public static readonly FastaHeaderFieldRegex ModomicsOrganismRegex = new("organism", @"Species:(.+?)$", 0, 1);
+
+    private static FastaHeaderFieldRegex? Build(string fieldName, string pattern) =>
+        string.IsNullOrWhiteSpace(pattern) ? null : new FastaHeaderFieldRegex(fieldName, pattern, 0, 1);
+
+    private IEnumerable<(string FieldName, string Pattern)> EnumerateCustomPatterns()
+    {
+        yield return ("accession", CustomAccessionRegex);
+        yield return ("full name", CustomFullNameRegex);
+        yield return ("name", CustomNameRegex);
+        yield return ("gene name", CustomGeneNameRegex);
+        yield return ("organism", CustomOrganismRegex);
+        yield return ("organism id", CustomOrganismIdRegex);
+    }
+
+    private static bool TryValidatePattern(string pattern, out string? reason)
+    {
+        Regex compiled;
+        try
+        {
+            compiled = new Regex(pattern, RegexOptions.None, ValidationMatchTimeout);
+        }
+        catch (ArgumentException e)
+        {
+            reason = e.Message;
+            return false;
+        }
+
+        if (compiled.GetGroupNumbers().Length < 2)
+        {
+            reason = "it has no capture group, so no field value can be taken from it.";
+            return false;
+        }
+
+        foreach (string header in ValidationHeaders)
+        {
+            try
+            {
+                compiled.Match(header);
+            }
+            catch (RegexMatchTimeoutException)
+            {
+                reason = $"matching it against a sample header took longer than {ValidationMatchTimeout.TotalMilliseconds} ms.";
+                return false;
+            }
+        }
+
+        reason = null;
+        return true;
+    }
+}

--- a/MetaMorpheus/EngineLayer/DatabaseLoading/FastaHeaderParsingParameters.cs
+++ b/MetaMorpheus/EngineLayer/DatabaseLoading/FastaHeaderParsingParameters.cs
@@ -9,7 +9,8 @@ namespace EngineLayer.DatabaseLoading;
 
 /// <summary>
 /// Named FASTA header layouts that MetaMorpheus can parse. <see cref="FastaHeaderFormat.Custom"/>
-/// takes the regexes from <see cref="FastaHeaderParsingParameters"/> instead of a preset.
+/// takes the regexes from <see cref="FastaHeaderParsingParameters"/> instead of a preset;
+/// <see cref="FastaHeaderFormat.Auto"/> passes none and lets mzLib detect the format per file.
 /// </summary>
 public enum FastaHeaderFormat
 {
@@ -17,6 +18,7 @@ public enum FastaHeaderFormat
     Ensembl,
     Gencode,
     Ncbi,
+    Auto,
     Custom
 }
 
@@ -96,6 +98,25 @@ public class FastaHeaderParsingParameters
     public bool Validate(out List<string> errors, IEnumerable<string>? sampleHeaders = null)
     {
         errors = new List<string>();
+
+        if (HeaderFormat == FastaHeaderFormat.Auto)
+        {
+            // mzLib throws on a header it cannot classify, which reaches a GUI user as a crash
+            // report. Refuse it here instead, while there is still a message to give.
+            foreach (string header in sampleHeaders ?? [])
+            {
+                if (ProteinDbLoader.DetectFastaHeaderFormat(header) != FastaHeaderType.Unknown)
+                    continue;
+
+                errors.Add("The FASTA header format could not be detected automatically for this "
+                           + $"header: {header}. Pick a preset FASTA header format, or use Custom "
+                           + "and supply an accession regex.");
+                break;
+            }
+
+            return errors.Count == 0;
+        }
+
         if (HeaderFormat != FastaHeaderFormat.Custom)
             return true;
 
@@ -159,6 +180,11 @@ public class FastaHeaderParsingParameters
                     FullName = NcbiFullNameRegex,
                     Organism = NcbiOrganismRegex,
                 };
+
+            // All null on purpose: LoadProteinFasta only calls DetectFastaHeaderFormat when the
+            // accession regex is null, so an empty set is how detection is requested.
+            case FastaHeaderFormat.Auto:
+                return new FastaHeaderFieldRegexSet();
 
             case FastaHeaderFormat.Custom:
                 return new FastaHeaderFieldRegexSet

--- a/MetaMorpheus/EngineLayer/DatabaseLoading/FastaHeaderParsingParameters.cs
+++ b/MetaMorpheus/EngineLayer/DatabaseLoading/FastaHeaderParsingParameters.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 using UsefulProteomicsDatabases;
 
@@ -16,7 +17,6 @@ public enum FastaHeaderFormat
     Ensembl,
     Gencode,
     Ncbi,
-    Modomics,
     Custom
 }
 
@@ -42,14 +42,17 @@ public class FastaHeaderFieldRegexSet
 public class FastaHeaderParsingParameters
 {
     /// <summary>
-    /// Ceiling on a single validation match. The user supplies these patterns, so a pathological one
-    /// must be rejected at configuration time rather than stalling a load.
+    /// Ceiling on a single validation match. Applies to validation only: mzLib's
+    /// <see cref="FastaHeaderFieldRegex"/> compiles the pattern with no timeout, so a pattern that is
+    /// fast on the headers checked here can still stall a load. Passing real deflines to
+    /// <see cref="Validate"/> is what narrows that gap.
     /// </summary>
     public static readonly TimeSpan ValidationMatchTimeout = TimeSpan.FromMilliseconds(250);
 
     /// <summary>
-    /// Deflines the validator matches each pattern against. Only used to smoke out catastrophic
-    /// backtracking; a pattern that matches nothing here is still accepted.
+    /// Deflines every validation run matches each pattern against, on top of any real ones supplied.
+    /// Only used to smoke out catastrophic backtracking; a pattern that matches nothing here is still
+    /// accepted, since a preset for one database format will not match another.
     /// </summary>
     internal static readonly string[] ValidationHeaders =
     [
@@ -84,14 +87,13 @@ public class FastaHeaderParsingParameters
         CustomOrganismIdRegex = organismIdRegex ?? "";
     }
 
-    public FastaHeaderParsingParameters Clone() => new(HeaderFormat, CustomAccessionRegex,
-        CustomFullNameRegex, CustomNameRegex, CustomGeneNameRegex, CustomOrganismRegex, CustomOrganismIdRegex);
-
     /// <summary>
-    /// Checks the custom patterns without touching a database. Returns false and fills
-    /// <paramref name="errors"/> with user-facing messages when the configuration cannot be used.
+    /// Checks the custom patterns. Returns false and fills <paramref name="errors"/> with user-facing
+    /// messages when the configuration cannot be used. <paramref name="sampleHeaders"/> should be real
+    /// deflines from the databases about to be loaded where the caller can get them: the canned
+    /// headers cannot prove a pattern is fast on the user's own file.
     /// </summary>
-    public bool Validate(out List<string> errors)
+    public bool Validate(out List<string> errors, IEnumerable<string>? sampleHeaders = null)
     {
         errors = new List<string>();
         if (HeaderFormat != FastaHeaderFormat.Custom)
@@ -107,7 +109,7 @@ public class FastaHeaderParsingParameters
         {
             if (string.IsNullOrWhiteSpace(pattern))
                 continue;
-            if (!TryValidatePattern(pattern, out string? reason))
+            if (!TryValidatePattern(pattern, sampleHeaders, out string? reason))
                 errors.Add($"The custom FASTA header regex for {fieldName} is not usable: {reason} Pattern: {pattern}");
         }
 
@@ -158,15 +160,6 @@ public class FastaHeaderParsingParameters
                     Organism = NcbiOrganismRegex,
                 };
 
-            case FastaHeaderFormat.Modomics:
-                return new FastaHeaderFieldRegexSet
-                {
-                    Accession = ModomicsAccessionRegex,
-                    FullName = ModomicsFullNameRegex,
-                    Name = ModomicsNameRegex,
-                    Organism = ModomicsOrganismRegex,
-                };
-
             case FastaHeaderFormat.Custom:
                 return new FastaHeaderFieldRegexSet
                 {
@@ -192,13 +185,6 @@ public class FastaHeaderParsingParameters
     public static readonly FastaHeaderFieldRegex NcbiFullNameRegex = new("fullName", @">[^ ]*\s(.*?)(\s\[|$)", 0, 1);
     public static readonly FastaHeaderFieldRegex NcbiOrganismRegex = new("organism", @"\[([^\[\]]+)\]\s*$", 0, 1);
 
-    // Patterns copied verbatim from mzLib RnaDbLoader.ModomicsFieldRegexes; only the mapping onto the
-    // protein fields is ours. Accession uses Name (unique per entry) rather than the repeating SOterm.
-    public static readonly FastaHeaderFieldRegex ModomicsAccessionRegex = new("accession", @"Name:(.+?)\|", 0, 1);
-    public static readonly FastaHeaderFieldRegex ModomicsNameRegex = new("name", @"SOterm:(.+?)\|", 0, 1);
-    public static readonly FastaHeaderFieldRegex ModomicsFullNameRegex = new("fullName", @"Type:(.+?)\|", 0, 1);
-    public static readonly FastaHeaderFieldRegex ModomicsOrganismRegex = new("organism", @"Species:(.+?)$", 0, 1);
-
     private static FastaHeaderFieldRegex? Build(string fieldName, string pattern) =>
         string.IsNullOrWhiteSpace(pattern) ? null : new FastaHeaderFieldRegex(fieldName, pattern, 0, 1);
 
@@ -212,7 +198,7 @@ public class FastaHeaderParsingParameters
         yield return ("organism id", CustomOrganismIdRegex);
     }
 
-    private static bool TryValidatePattern(string pattern, out string? reason)
+    private static bool TryValidatePattern(string pattern, IEnumerable<string>? sampleHeaders, out string? reason)
     {
         Regex compiled;
         try
@@ -231,7 +217,7 @@ public class FastaHeaderParsingParameters
             return false;
         }
 
-        foreach (string header in ValidationHeaders)
+        foreach (string header in ValidationHeaders.Concat(sampleHeaders ?? []))
         {
             try
             {

--- a/MetaMorpheus/GUI/TaskWindows/CalibrateTaskWindow.xaml
+++ b/MetaMorpheus/GUI/TaskWindows/CalibrateTaskWindow.xaml
@@ -1,4 +1,4 @@
-<Window x:Class="MetaMorpheusGUI.CalibrateTaskWindow"
+﻿<Window x:Class="MetaMorpheusGUI.CalibrateTaskWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -360,6 +360,8 @@
                         </Grid>
                     </StackPanel>
                 </GroupBox>
+
+                <local:FastaHeaderParsingControl x:Name="FastaHeaderParsingSettings" DockPanel.Dock="Top" />
 
                 <GroupBox Header="Output Options" DockPanel.Dock="Top">
                     <StackPanel>

--- a/MetaMorpheus/GUI/TaskWindows/CalibrateTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/CalibrateTaskWindow.xaml.cs
@@ -1,4 +1,4 @@
-using EngineLayer;
+﻿using EngineLayer;
 using GuiFunctions;
 using MassSpectrometry;
 using MzLibUtil;
@@ -70,6 +70,7 @@ namespace MetaMorpheusGUI
 
         private void UpdateFieldsFromTask(CalibrationTask task)
         {
+            FastaHeaderParsingSettings.SetFromParameters(task.CommonParameters.FastaHeaderParsing);
             GlobalVariables.AnalyteType = task.CommonParameters.DetermineAnalyteType();
             DeconHostViewModel = new DeconHostViewModel(TheTask.CommonParameters.PrecursorDeconvolutionParameters,
                 TheTask.CommonParameters.ProductDeconvolutionParameters,
@@ -362,7 +363,8 @@ namespace MetaMorpheusGUI
                     precursorDeconParams: precursorDeconvolutionParameters,
                     productDeconParams: productDeconvolutionParameters,
                     precursorMassMatchMode: UseMostAbundantMassCheckBox.IsChecked.Value ? PrecursorMassMatchMode.MostAbundant : PrecursorMassMatchMode.Monoisotopic,
-                    useProvidedPrecursorInfo: useProvidedPrecursorInfo);
+                    useProvidedPrecursorInfo: useProvidedPrecursorInfo,
+                    fastaHeaderParsing: FastaHeaderParsingSettings.ToParameters());
                 TheTask.CommonParameters = commonParamsToSave;
             }
             else //bottom-up
@@ -385,7 +387,8 @@ namespace MetaMorpheusGUI
                     doPrecursorDeconvolution: doPrecursorDeconvolution,
                     precursorDeconParams: precursorDeconvolutionParameters,
                     productDeconParams: productDeconvolutionParameters,
-                    precursorMassMatchMode: UseMostAbundantMassCheckBox.IsChecked.Value ? PrecursorMassMatchMode.MostAbundant : PrecursorMassMatchMode.Monoisotopic);
+                    precursorMassMatchMode: UseMostAbundantMassCheckBox.IsChecked.Value ? PrecursorMassMatchMode.MostAbundant : PrecursorMassMatchMode.Monoisotopic,
+                    fastaHeaderParsing: FastaHeaderParsingSettings.ToParameters());
                 TheTask.CommonParameters = commonParamsToSave;
             }
 

--- a/MetaMorpheus/GUI/TaskWindows/GPTMDTaskWindow.xaml
+++ b/MetaMorpheus/GUI/TaskWindows/GPTMDTaskWindow.xaml
@@ -1,4 +1,4 @@
-<Window x:Class="MetaMorpheusGUI.GptmdTaskWindow"
+﻿<Window x:Class="MetaMorpheusGUI.GptmdTaskWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -515,6 +515,8 @@
                         </Grid>
                     </Expander>
                 </GroupBox>
+                <local:FastaHeaderParsingControl x:Name="FastaHeaderParsingSettings" DockPanel.Dock="Top" />
+
                 <GroupBox Header="Output Options" DockPanel.Dock="Top" ScrollViewer.CanContentScroll="True">
                     <Expander>
                         <CheckBox x:Name="WriteDecoysCheckBox" Margin="20 0 0 0"

--- a/MetaMorpheus/GUI/TaskWindows/GPTMDTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/GPTMDTaskWindow.xaml.cs
@@ -1,4 +1,4 @@
-using EngineLayer;
+﻿using EngineLayer;
 using MassSpectrometry;
 using MzLibUtil;
 using Nett;
@@ -84,6 +84,7 @@ namespace MetaMorpheusGUI
 
         private void UpdateFieldsFromTask(GptmdTask task)
         {
+            FastaHeaderParsingSettings.SetFromParameters(task.CommonParameters.FastaHeaderParsing);
             GlobalVariables.AnalyteType = task.CommonParameters.DetermineAnalyteType();
             DeconHostViewModel = new DeconHostViewModel(TheTask.CommonParameters.PrecursorDeconvolutionParameters,
                 TheTask.CommonParameters.ProductDeconvolutionParameters,
@@ -579,7 +580,8 @@ namespace MetaMorpheusGUI
                     maxHeterozygousVariants: maxHeterozygousVariants,
                     precursorDeconParams: precursorDeconvolutionParameters,
                     productDeconParams: productDeconvolutionParameters,
-                    precursorMassMatchMode: UseMostAbundantMassCheckBox.IsChecked.Value ? PrecursorMassMatchMode.MostAbundant : PrecursorMassMatchMode.Monoisotopic);
+                    precursorMassMatchMode: UseMostAbundantMassCheckBox.IsChecked.Value ? PrecursorMassMatchMode.MostAbundant : PrecursorMassMatchMode.Monoisotopic,
+                    fastaHeaderParsing: FastaHeaderParsingSettings.ToParameters());
 
             TheTask.GptmdParameters.ListOfModsGptmd = new List<(string, string)>();
             foreach (var heh in GptmdModTypeForTreeViewObservableCollection)

--- a/MetaMorpheus/GUI/TaskWindows/GlycoSearchTaskWindow.xaml
+++ b/MetaMorpheus/GUI/TaskWindows/GlycoSearchTaskWindow.xaml
@@ -589,6 +589,8 @@
                 </GroupBox>
 
                 <!--output options-->
+                <local:FastaHeaderParsingControl x:Name="FastaHeaderParsingSettings" DockPanel.Dock="Top" />
+
                 <GroupBox Header="Output Options" DockPanel.Dock="Top">
                     <StackPanel Orientation="Vertical" Margin="5" Grid.Column="0">
                         <CheckBox x:Name="WriteDecoyCheckBox" Content="Write decoys" />

--- a/MetaMorpheus/GUI/TaskWindows/GlycoSearchTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/GlycoSearchTaskWindow.xaml.cs
@@ -125,6 +125,7 @@ namespace MetaMorpheusGUI
 
         private void UpdateFieldsFromTask(GlycoSearchTask task)
         {
+            FastaHeaderParsingSettings.SetFromParameters(task.CommonParameters.FastaHeaderParsing);
             RbtOGlycoSearch.IsChecked = task._glycoSearchParameters.GlycoSearchType == EngineLayer.GlycoSearch.GlycoSearchType.OGlycanSearch;
             RbtNGlycoSearch.IsChecked = task._glycoSearchParameters.GlycoSearchType == EngineLayer.GlycoSearch.GlycoSearchType.NGlycanSearch;
             Rbt_N_O_GlycoSearch.IsChecked = task._glycoSearchParameters.GlycoSearchType == EngineLayer.GlycoSearch.GlycoSearchType.N_O_GlycanSearch;
@@ -464,7 +465,8 @@ namespace MetaMorpheusGUI
                 assumeOrphanPeaksAreZ1Fragments: protease.Name != "top-down",
                 precursorDeconParams: precursorDeconvolutionParameters,
                 productDeconParams: productDeconvolutionParameters,
-                rtPredictorName: rtPredictorModelName);
+                rtPredictorName: rtPredictorModelName,
+                fastaHeaderParsing: FastaHeaderParsingSettings.ToParameters());
 
             TheTask._glycoSearchParameters.WritePrunedDataBase = WritePrunedDBCheckBox.IsChecked.Value;
             SetModSelectionForPrunedDB();

--- a/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml
+++ b/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml
@@ -1,4 +1,4 @@
-<Window x:Class="MetaMorpheusGUI.SearchTaskWindow"
+﻿<Window x:Class="MetaMorpheusGUI.SearchTaskWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -668,6 +668,8 @@
                     </GroupBox>
 
                     <!-- Output Options -->
+                    <local:FastaHeaderParsingControl x:Name="FastaHeaderParsingSettings" DockPanel.Dock="Top" />
+
                     <GroupBox Header="Output Options" DockPanel.Dock="Top" ScrollViewer.CanContentScroll="True">
 
                         <Grid>

--- a/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/SearchTaskWindow.xaml.cs
@@ -1,4 +1,4 @@
-using EngineLayer;
+﻿using EngineLayer;
 using EngineLayer.FdrAnalysis;
 using GuiFunctions;
 using MassSpectrometry;
@@ -195,6 +195,7 @@ namespace MetaMorpheusGUI
         /// <param name="task"></param>
         private void UpdateFieldsFromTask(SearchTask task)
         {
+            FastaHeaderParsingSettings.SetFromParameters(task.CommonParameters.FastaHeaderParsing);
             GlobalVariables.AnalyteType = task.CommonParameters.DetermineAnalyteType();
             if (task.CommonParameters.DigestionParams is DigestionParams digestionParams)
             {
@@ -673,7 +674,8 @@ namespace MetaMorpheusGUI
                 productDeconParams: productDeconvolutionParameters,
                 precursorMassMatchMode: _massDifferenceAcceptorViewModel.PrecursorMassMatchMode,
                 fragmentationParams: _fragmentationParamsViewModel.ToFragmentationParams(),
-                rtPredictorName: rtPredictorModelName);
+                rtPredictorName: rtPredictorModelName,
+                fastaHeaderParsing: FastaHeaderParsingSettings.ToParameters());
 
             if (ClassicSearchRadioButton.IsChecked.Value)
             {

--- a/MetaMorpheus/GUI/TaskWindows/XLSearchTaskWindow.xaml
+++ b/MetaMorpheus/GUI/TaskWindows/XLSearchTaskWindow.xaml
@@ -368,6 +368,8 @@
                         </StackPanel>
                     </Expander>
                 </GroupBox>
+                <local:FastaHeaderParsingControl x:Name="FastaHeaderParsingSettings" DockPanel.Dock="Top" />
+
                 <GroupBox Header="Output Options" DockPanel.Dock="Top">
                     <Expander x:Name="OutputExpander">
                         <StackPanel Orientation="Vertical">

--- a/MetaMorpheus/GUI/TaskWindows/XLSearchTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/XLSearchTaskWindow.xaml.cs
@@ -121,6 +121,7 @@ namespace MetaMorpheusGUI
 
         private void UpdateFieldsFromTask(XLSearchTask task)
         {
+            FastaHeaderParsingSettings.SetFromParameters(task.CommonParameters.FastaHeaderParsing);
             cbCrosslinkers.SelectedItem = task.XlSearchParameters.Crosslinker;
             txtXLTopNum.Text = task.XlSearchParameters.CrosslinkSearchTopNum.ToString(CultureInfo.InvariantCulture);
             ckbAddCompIon.IsChecked = task.CommonParameters.AddCompIons;
@@ -352,7 +353,8 @@ namespace MetaMorpheusGUI
                 listOfModsFixed: listOfModsFixed,
                 assumeOrphanPeaksAreZ1Fragments: protease.Name != "top-down",
                 precursorDeconParams: precursorDeconvolutionParameters,
-                productDeconParams: productDeconvolutionParameters);
+                productDeconParams: productDeconvolutionParameters,
+                fastaHeaderParsing: FastaHeaderParsingSettings.ToParameters());
 
             TheTask.CommonParameters = commonParamsToSave;
 

--- a/MetaMorpheus/GUI/Views/FastaHeaderParsingControl.xaml
+++ b/MetaMorpheus/GUI/Views/FastaHeaderParsingControl.xaml
@@ -22,6 +22,10 @@
                             <LineBreak />
                             Choose Custom to enter your own regular expressions below.
                             <LineBreak />
+                            Auto lets the library detect UniProt, Ensembl or Gencode per file. It also
+                            changes Name to the short form (ADH1_YEAST rather than the description) and
+                            fills in the NCBI taxonomy id, so its output differs from UniProt.
+                            <LineBreak />
                             Applies to .fasta databases only; a UniProt XML carries its own fields.
                         </TextBlock>
                     </ComboBox.ToolTip>

--- a/MetaMorpheus/GUI/Views/FastaHeaderParsingControl.xaml
+++ b/MetaMorpheus/GUI/Views/FastaHeaderParsingControl.xaml
@@ -1,0 +1,111 @@
+<UserControl x:Class="MetaMorpheusGUI.FastaHeaderParsingControl"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:MetaMorpheusGUI"
+             mc:Ignorable="d"
+             d:DesignHeight="260" d:DesignWidth="650">
+
+    <GroupBox Header="FASTA Header Parsing" DockPanel.Dock="Top">
+        <StackPanel Margin="5">
+            <StackPanel Orientation="Horizontal" Margin="5 2 0 2">
+                <Label Content="Header format:" Width="120" />
+                <ComboBox x:Name="FastaHeaderFormatComboBox" Width="130" HorizontalAlignment="Left"
+                          SelectionChanged="FastaHeaderFormatComboBox_SelectionChanged"
+                          ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500">
+                    <ComboBox.ToolTip>
+                        <TextBlock>
+                            How each FASTA defline is split into accession, name, gene and organism.
+                            <LineBreak />
+                            UniProt is the default and is what every previous version used.
+                            <LineBreak />
+                            Choose Custom to enter your own regular expressions below.
+                            <LineBreak />
+                            Applies to .fasta databases only; a UniProt XML carries its own fields.
+                        </TextBlock>
+                    </ComboBox.ToolTip>
+                </ComboBox>
+                <TextBlock x:Name="PresetSummaryTextBlock" Margin="15 4 0 0" Foreground="Gray"
+                           FontStyle="Italic" FontSize="10" TextWrapping="Wrap" MaxWidth="380" />
+            </StackPanel>
+
+            <TextBlock Margin="5 6 5 2" TextWrapping="Wrap" Foreground="Gray" FontStyle="Italic" FontSize="10">
+                The first capture group of each expression becomes that field. Leave a box empty to skip
+                the field. An accession expression is required. A malformed expression is reported as a
+                warning before the run starts, not as a crash.
+            </TextBlock>
+
+            <Grid x:Name="CustomRegexGrid" Margin="5 2 5 2" IsEnabled="False">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="Auto" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <Label Grid.Row="0" Grid.Column="0" Content="Accession:" Width="120" />
+                <TextBox Grid.Row="0" Grid.Column="1" x:Name="CustomAccessionRegexTextBox" Margin="0 2 0 2"
+                         ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500">
+                    <TextBox.ToolTip>
+                        <TextBlock>
+                            The identifier MetaMorpheus joins every output file on. Required.
+                            <LineBreak />
+                            Example, taking the RefSeq accession out of &gt;gi|16128008|ref|NP_414555.1| :
+                            &gt;.*\|(.*)\|
+                            <LineBreak />
+                            An accession containing a | breaks the multi-value columns in .psmtsv, so
+                            capture a field rather than a span of fields.
+                        </TextBlock>
+                    </TextBox.ToolTip>
+                </TextBox>
+
+                <Label Grid.Row="1" Grid.Column="0" Content="Full name:" Width="120" />
+                <TextBox Grid.Row="1" Grid.Column="1" x:Name="CustomFullNameRegexTextBox" Margin="0 2 0 2"
+                         ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500">
+                    <TextBox.ToolTip>
+                        <TextBlock>The descriptive name, written as the protein full name.</TextBlock>
+                    </TextBox.ToolTip>
+                </TextBox>
+
+                <Label Grid.Row="2" Grid.Column="0" Content="Name:" Width="120" />
+                <TextBox Grid.Row="2" Grid.Column="1" x:Name="CustomNameRegexTextBox" Margin="0 2 0 2"
+                         ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500">
+                    <TextBox.ToolTip>
+                        <TextBlock>The short entry name, e.g. AATM_RABIT in a UniProt defline.</TextBlock>
+                    </TextBox.ToolTip>
+                </TextBox>
+
+                <Label Grid.Row="3" Grid.Column="0" Content="Gene name:" Width="120" />
+                <TextBox Grid.Row="3" Grid.Column="1" x:Name="CustomGeneNameRegexTextBox" Margin="0 2 0 2"
+                         ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500">
+                    <TextBox.ToolTip>
+                        <TextBlock>The gene, written to the Gene Name column.</TextBlock>
+                    </TextBox.ToolTip>
+                </TextBox>
+
+                <Label Grid.Row="4" Grid.Column="0" Content="Organism:" Width="120" />
+                <TextBox Grid.Row="4" Grid.Column="1" x:Name="CustomOrganismRegexTextBox" Margin="0 2 0 2"
+                         ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500">
+                    <TextBox.ToolTip>
+                        <TextBlock>The species, written to the Organism column.</TextBlock>
+                    </TextBox.ToolTip>
+                </TextBox>
+
+                <Label Grid.Row="5" Grid.Column="0" Content="Organism ID:" Width="120" />
+                <TextBox Grid.Row="5" Grid.Column="1" x:Name="CustomOrganismIdRegexTextBox" Margin="0 2 0 2"
+                         ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500">
+                    <TextBox.ToolTip>
+                        <TextBlock>The NCBI taxonomy id, e.g. the 9986 in OX=9986.</TextBlock>
+                    </TextBox.ToolTip>
+                </TextBox>
+            </Grid>
+        </StackPanel>
+    </GroupBox>
+</UserControl>

--- a/MetaMorpheus/GUI/Views/FastaHeaderParsingControl.xaml.cs
+++ b/MetaMorpheus/GUI/Views/FastaHeaderParsingControl.xaml.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Windows.Controls;
+using EngineLayer.DatabaseLoading;
+
+namespace MetaMorpheusGUI
+{
+    /// <summary>
+    /// Interaction logic for FastaHeaderParsingControl.xaml
+    /// </summary>
+    public partial class FastaHeaderParsingControl : UserControl
+    {
+        public FastaHeaderParsingControl()
+        {
+            InitializeComponent();
+
+            foreach (FastaHeaderFormat format in Enum.GetValues<FastaHeaderFormat>())
+                FastaHeaderFormatComboBox.Items.Add(format);
+
+            SetFromParameters(new FastaHeaderParsingParameters());
+        }
+
+        public void SetFromParameters(FastaHeaderParsingParameters parameters)
+        {
+            parameters ??= new FastaHeaderParsingParameters();
+
+            FastaHeaderFormatComboBox.SelectedItem = parameters.HeaderFormat;
+            CustomAccessionRegexTextBox.Text = parameters.CustomAccessionRegex;
+            CustomFullNameRegexTextBox.Text = parameters.CustomFullNameRegex;
+            CustomNameRegexTextBox.Text = parameters.CustomNameRegex;
+            CustomGeneNameRegexTextBox.Text = parameters.CustomGeneNameRegex;
+            CustomOrganismRegexTextBox.Text = parameters.CustomOrganismRegex;
+            CustomOrganismIdRegexTextBox.Text = parameters.CustomOrganismIdRegex;
+
+            UpdateCustomEnabledState();
+        }
+
+        public FastaHeaderParsingParameters ToParameters()
+        {
+            var format = FastaHeaderFormatComboBox.SelectedItem is FastaHeaderFormat selected
+                ? selected
+                : FastaHeaderFormat.UniProt;
+
+            return new FastaHeaderParsingParameters(format,
+                CustomAccessionRegexTextBox.Text,
+                CustomFullNameRegexTextBox.Text,
+                CustomNameRegexTextBox.Text,
+                CustomGeneNameRegexTextBox.Text,
+                CustomOrganismRegexTextBox.Text,
+                CustomOrganismIdRegexTextBox.Text);
+        }
+
+        private void FastaHeaderFormatComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            UpdateCustomEnabledState();
+        }
+
+        private void UpdateCustomEnabledState()
+        {
+            if (CustomRegexGrid == null || PresetSummaryTextBlock == null)
+                return;
+
+            bool isCustom = FastaHeaderFormatComboBox.SelectedItem is FastaHeaderFormat.Custom;
+            CustomRegexGrid.IsEnabled = isCustom;
+            PresetSummaryTextBlock.Text = isCustom
+                ? ""
+                : DescribePreset(FastaHeaderFormatComboBox.SelectedItem as FastaHeaderFormat?);
+        }
+
+        private static string DescribePreset(FastaHeaderFormat? format) => format switch
+        {
+            FastaHeaderFormat.UniProt => "sp|P12345|AATM_RABIT ... OS= GN=",
+            FastaHeaderFormat.Ensembl => "ENSP00000001 pep:... gene:ENSG00000001",
+            FastaHeaderFormat.Gencode => "ENSP0000001.1|ENST...|...|gene symbol|...",
+            FastaHeaderFormat.Ncbi => "gi|16128008|ref|NP_414555.1| description [organism]",
+            FastaHeaderFormat.Modomics => "id:1|Name:tdbR00000010|SOterm:...|Species:...",
+            _ => ""
+        };
+    }
+}

--- a/MetaMorpheus/GUI/Views/FastaHeaderParsingControl.xaml.cs
+++ b/MetaMorpheus/GUI/Views/FastaHeaderParsingControl.xaml.cs
@@ -72,7 +72,6 @@ namespace MetaMorpheusGUI
             FastaHeaderFormat.Ensembl => "ENSP00000001 pep:... gene:ENSG00000001",
             FastaHeaderFormat.Gencode => "ENSP0000001.1|ENST...|...|gene symbol|...",
             FastaHeaderFormat.Ncbi => "gi|16128008|ref|NP_414555.1| description [organism]",
-            FastaHeaderFormat.Modomics => "id:1|Name:tdbR00000010|SOterm:...|Species:...",
             _ => ""
         };
     }

--- a/MetaMorpheus/GUI/Views/FastaHeaderParsingControl.xaml.cs
+++ b/MetaMorpheus/GUI/Views/FastaHeaderParsingControl.xaml.cs
@@ -72,6 +72,7 @@ namespace MetaMorpheusGUI
             FastaHeaderFormat.Ensembl => "ENSP00000001 pep:... gene:ENSG00000001",
             FastaHeaderFormat.Gencode => "ENSP0000001.1|ENST...|...|gene symbol|...",
             FastaHeaderFormat.Ncbi => "gi|16128008|ref|NP_414555.1| description [organism]",
+            FastaHeaderFormat.Auto => "detected per file; changes Name and taxonomy id - see tooltip",
             _ => ""
         };
     }

--- a/MetaMorpheus/TaskLayer/EverythingRunnerEngine.cs
+++ b/MetaMorpheus/TaskLayer/EverythingRunnerEngine.cs
@@ -88,8 +88,10 @@ namespace TaskLayer
                 var ok = TaskList[i];
 
                 // A malformed user-supplied header regex is a configuration mistake, not a crash.
+                // Real deflines are passed in because mzLib compiles the pattern without a match
+                // timeout, so only the user's own headers can show it is fast enough on them.
                 if (ok.Item2.CommonParameters?.FastaHeaderParsing is { } headerParsing
-                    && !headerParsing.Validate(out var headerRegexErrors))
+                    && !headerParsing.Validate(out var headerRegexErrors, SampleFastaHeaders(CurrentXmlDbFilenameList)))
                 {
                     foreach (string headerRegexError in headerRegexErrors)
                         Warn($"Cannot proceed. {ok.Item1}: {headerRegexError}");
@@ -150,6 +152,44 @@ namespace TaskLayer
             }
             FinishedWritingAllResultsFileHandler?.Invoke(this, new StringEventArgs(resultsFileName, null));
             FinishedAllTasks(OutputFolder);
+        }
+
+        /// <summary>
+        /// The first few deflines of each FASTA in the run, for validating a user-supplied regex
+        /// against the headers it will actually meet. Unreadable files are skipped: this is
+        /// validation input, and the loader reports a bad path itself.
+        /// </summary>
+        private static List<string> SampleFastaHeaders(List<DbForTask> databases, int perFile = 5)
+        {
+            var headers = new List<string>();
+            foreach (var db in databases ?? new List<DbForTask>())
+            {
+                if (db.IsSpectralLibrary)
+                    continue;
+
+                string extension = Path.GetExtension(db.FilePath).ToLowerInvariant();
+                if (extension != ".fasta" && extension != ".fa")
+                    continue;
+
+                try
+                {
+                    int taken = 0;
+                    foreach (string line in File.ReadLines(db.FilePath))
+                    {
+                        if (!line.StartsWith('>'))
+                            continue;
+                        headers.Add(line);
+                        if (++taken == perFile)
+                            break;
+                    }
+                }
+                catch (Exception)
+                {
+                    // Not this gate's job to report.
+                }
+            }
+
+            return headers;
         }
 
         private void Warn(string v)

--- a/MetaMorpheus/TaskLayer/EverythingRunnerEngine.cs
+++ b/MetaMorpheus/TaskLayer/EverythingRunnerEngine.cs
@@ -1,4 +1,4 @@
-using EngineLayer;
+﻿using EngineLayer;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -86,6 +86,16 @@ namespace TaskLayer
                 }
                
                 var ok = TaskList[i];
+
+                // A malformed user-supplied header regex is a configuration mistake, not a crash.
+                if (ok.Item2.CommonParameters?.FastaHeaderParsing is { } headerParsing
+                    && !headerParsing.Validate(out var headerRegexErrors))
+                {
+                    foreach (string headerRegexError in headerRegexErrors)
+                        Warn($"Cannot proceed. {ok.Item1}: {headerRegexError}");
+                    FinishedAllTasks(OutputFolder);
+                    return;
+                }
 
                 // reset product types for custom fragmentation
                 ok.Item2.CommonParameters.SetCustomProductTypes();

--- a/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
+++ b/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
@@ -46,6 +46,20 @@ namespace TaskLayer
 
     public abstract class MetaMorpheusTask
     {
+        /// <summary>
+        /// Nett hands a bare ArgumentException to the caller on an unrecognized enum name, which does
+        /// not say what the legal values are.
+        /// </summary>
+        private static FastaHeaderFormat ParseFastaHeaderFormat(string value)
+        {
+            if (Enum.TryParse<FastaHeaderFormat>(value, true, out var parsed))
+                return parsed;
+
+            throw new MetaMorpheusException(
+                $"Unrecognized FASTA header format '{value}'. Valid values are: "
+                + string.Join(", ", Enum.GetNames<FastaHeaderFormat>()) + ".");
+        }
+
         public static readonly TomlSettings tomlConfig = TomlSettings.Create(cfg => cfg
             .ConfigureType<Tolerance>(type => type
                 .WithConversionFor<TomlString>(convert => convert
@@ -180,7 +194,7 @@ namespace TaskLayer
             .ConfigureType<FastaHeaderFormat>(type => type
                 .WithConversionFor<TomlString>(convert => convert
                     .ToToml(custom => custom.ToString())
-                    .FromToml(tmlString => Enum.Parse<FastaHeaderFormat>(tmlString.Value, true))))
+                    .FromToml(tmlString => ParseFastaHeaderFormat(tmlString.Value))))
         );
        
 

--- a/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
+++ b/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
@@ -1,4 +1,4 @@
-using Chemistry;
+﻿using Chemistry;
 using EngineLayer;
 using EngineLayer.Indexing;
 using MassSpectrometry;
@@ -175,6 +175,12 @@ namespace TaskLayer
                 .CreateInstance(() => RnaFragmentationParams.Default))
             .ConfigureType<FragmentationParams>(type => type
                 .CreateInstance(() => new()))
+            .ConfigureType<FastaHeaderParsingParameters>(type => type
+                .CreateInstance(() => new FastaHeaderParsingParameters()))
+            .ConfigureType<FastaHeaderFormat>(type => type
+                .WithConversionFor<TomlString>(convert => convert
+                    .ToToml(custom => custom.ToString())
+                    .FromToml(tmlString => Enum.Parse<FastaHeaderFormat>(tmlString.Value, true))))
         );
        
 
@@ -621,7 +627,8 @@ namespace TaskLayer
                 useMostAbundantPrecursorIntensity: commonParams.UseMostAbundantPrecursorIntensity,
                 fragmentationParams: commonParams.FragmentationParameters,
                 precursorMassMatchMode: commonParams.PrecursorMassMatchMode,
-                rtPredictorName: commonParams.RTPredictorName);
+                rtPredictorName: commonParams.RTPredictorName,
+                fastaHeaderParsing: commonParams.FastaHeaderParsing);
 
             return returnParams;
         }

--- a/MetaMorpheus/Test/FastaHeaderParsingTest.cs
+++ b/MetaMorpheus/Test/FastaHeaderParsingTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using EngineLayer;
 using EngineLayer.DatabaseLoading;
 using Nett;
@@ -93,19 +94,6 @@ namespace Test
             Assert.That(protein.Accession, Is.EqualTo("NP_414555.1"));
             Assert.That(protein.FullName, Is.EqualTo("thr operon leader peptide"));
             Assert.That(protein.Organism, Is.EqualTo("Escherichia coli str. K-12 substr. MG1655"));
-        }
-
-        [Test]
-        public static void ModomicsPresetParsesAModomicsDefline()
-        {
-            string path = WriteFasta(Path.Combine("FastaHeaderParsing", "modomicsPreset.fasta"), ModomicsHeader, "PEPTIDEK");
-            var protein = Load(path, new FastaHeaderParsingParameters(FastaHeaderFormat.Modomics)).Single();
-
-            // Name, not SOterm: SOterm repeats across entries, so it collides as an accession.
-            Assert.That(protein.Accession, Is.EqualTo("tdbR00000010"));
-            Assert.That(protein.Name, Is.EqualTo("SO:0000254"));
-            Assert.That(protein.FullName, Is.EqualTo("tRNA"));
-            Assert.That(protein.Organism, Is.EqualTo("Escherichia coli"));
         }
 
         [Test]
@@ -258,6 +246,45 @@ namespace Test
             Assert.That(engine.Warnings, Is.Not.Empty);
             Assert.That(engine.Warnings.Single(), Does.StartWith("Cannot proceed. Task1-SearchTask:")
                 .And.Contain("not usable"));
+        }
+
+        [Test]
+        public static void ARegexIsCheckedAgainstTheSuppliedHeadersNotOnlyTheCannedOnes()
+        {
+            // Fails at the second character of every canned defline, so it is fast on those, and
+            // backtracks catastrophically on the header supplied below.
+            var parameters = new FastaHeaderParsingParameters(FastaHeaderFormat.Custom,
+                accessionRegex: @"^>(a+)+X$");
+
+            Assert.That(parameters.Validate(out _), Is.True,
+                "the canned headers alone cannot show this pattern is slow");
+
+            string ownHeader = ">" + new string('a', 40);
+            Assert.That(parameters.Validate(out var errors, new[] { ownHeader }), Is.False);
+            Assert.That(errors.Single(), Does.Contain("longer than"));
+        }
+
+        [Test]
+        public static void AnUnrecognizedHeaderFormatNamesTheValidValues()
+        {
+            string tomlPath = Path.Combine(TestContext.CurrentContext.TestDirectory,
+                "FastaHeaderParsing", "badFormatName.toml");
+            Directory.CreateDirectory(Path.GetDirectoryName(tomlPath));
+            Toml.WriteFile(new SearchTask(), tomlPath, MetaMorpheusTask.tomlConfig);
+
+            string original = File.ReadAllText(tomlPath);
+            string corrupted = Regex.Replace(original, @"HeaderFormat\s*=\s*""[^""]*""",
+                "HeaderFormat = \"Uniprot2\"");
+            Assert.That(corrupted, Is.Not.EqualTo(original), "the written toml must carry a HeaderFormat to corrupt");
+            File.WriteAllText(tomlPath, corrupted);
+
+            // Catch, not Throws: Throws<T> is exact-type and Nett may wrap ours.
+            var thrown = Assert.Catch<Exception>(
+                () => Toml.ReadFile<SearchTask>(tomlPath, MetaMorpheusTask.tomlConfig),
+                "an unknown format name must not read as a silent default")!;
+
+            // ToString() so the assertion holds whether or not Nett wraps ours.
+            Assert.That(thrown.ToString(), Does.Contain("Uniprot2").And.Contain("Valid values are"));
         }
     }
 }

--- a/MetaMorpheus/Test/FastaHeaderParsingTest.cs
+++ b/MetaMorpheus/Test/FastaHeaderParsingTest.cs
@@ -1,0 +1,263 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using EngineLayer;
+using EngineLayer.DatabaseLoading;
+using Nett;
+using Proteomics;
+using NUnit.Framework;
+using TaskLayer;
+using UsefulProteomicsDatabases;
+
+namespace Test
+{
+    [TestFixture]
+    public static class FastaHeaderParsingTest
+    {
+        // A legacy NCBI defline: the pipes are field separators, and the accession is the fourth field.
+        private const string LegacyNcbiHeader =
+            ">gi|16128008|ref|NP_414555.1| thr operon leader peptide [Escherichia coli str. K-12 substr. MG1655]";
+
+        // Taken from mzLib's Test/Transcriptomics/TestData/ModomicsUnmodifiedTrimmed.fasta.
+        private const string ModomicsHeader =
+            ">id:1|Name:tdbR00000010|SOterm:SO:0000254|Type:tRNA|Subtype:Ala|Feature:VGC|Cellular_Localization:prokaryotic cytosol|Species:Escherichia coli";
+
+        private const string UniProtHeader =
+            ">sp|P12345|AATM_RABIT Aspartate aminotransferase, mitochondrial OS=Oryctolagus cuniculus OX=9986 GN=GOT2 PE=1 SV=2";
+
+        private static string WriteFasta(string fileName, string header, string sequence)
+        {
+            string path = Path.Combine(TestContext.CurrentContext.TestDirectory, fileName);
+            Directory.CreateDirectory(Path.GetDirectoryName(path));
+            File.WriteAllLines(path, new[] { header, sequence });
+            return path;
+        }
+
+        private static List<Protein> Load(string path, FastaHeaderParsingParameters headerParsing)
+        {
+            var commonParameters = new CommonParameters(fastaHeaderParsing: headerParsing);
+            return DatabaseLoadingEngine.LoadProteinDb(path, true, DecoyType.None, new List<string>(), false,
+                out _, out _, commonParameters).ToList();
+        }
+
+        [Test]
+        public static void DefaultIsUniProtAndKeepsTheRegexesMetaMorpheusHasAlwaysPassed()
+        {
+            var regexes = new FastaHeaderParsingParameters().GetFieldRegexes();
+
+            Assert.That(new FastaHeaderParsingParameters().HeaderFormat, Is.EqualTo(FastaHeaderFormat.UniProt));
+            Assert.That(regexes.Accession, Is.SameAs(ProteinDbLoader.UniprotAccessionRegex));
+            Assert.That(regexes.FullName, Is.SameAs(ProteinDbLoader.UniprotFullNameRegex));
+            // Name has always been parsed with the full-name regex, and organism id has never been
+            // parsed at all. Both are preserved so the default produces identical output.
+            Assert.That(regexes.Name, Is.SameAs(ProteinDbLoader.UniprotFullNameRegex));
+            Assert.That(regexes.GeneName, Is.SameAs(ProteinDbLoader.UniprotGeneNameRegex));
+            Assert.That(regexes.Organism, Is.SameAs(ProteinDbLoader.UniprotOrganismRegex));
+            Assert.That(regexes.OrganismId, Is.Null);
+        }
+
+        [Test]
+        public static void UniProtDefaultStillParsesAUniProtHeader()
+        {
+            string path = WriteFasta(Path.Combine("FastaHeaderParsing", "uniprot.fasta"), UniProtHeader, "PEPTIDEK");
+            var protein = Load(path, new FastaHeaderParsingParameters()).Single();
+
+            Assert.That(protein.Accession, Is.EqualTo("P12345"));
+            Assert.That(protein.Organism, Is.EqualTo("Oryctolagus cuniculus"));
+            Assert.That(protein.GeneNames.Single().Item2, Is.EqualTo("GOT2"));
+        }
+
+        [Test]
+        public static void UniProtDefaultGluesLegacyNcbiFieldsTogetherAndACustomRegexDoesNot()
+        {
+            string path = WriteFasta(Path.Combine("FastaHeaderParsing", "legacyNcbi.fasta"), LegacyNcbiHeader, "PEPTIDEK");
+
+            var withDefault = Load(path, new FastaHeaderParsingParameters()).Single();
+            Assert.That(withDefault.Accession, Is.EqualTo("16128008|ref|NP_414555.1"));
+            Assert.That(withDefault.Accession, Does.Contain("|"),
+                "the accession contains the character MetaMorpheus uses to separate multiple values");
+
+            var withCustom = Load(path, new FastaHeaderParsingParameters(FastaHeaderFormat.Custom,
+                accessionRegex: @">.*\|(.*)\|")).Single();
+            Assert.That(withCustom.Accession, Is.EqualTo("NP_414555.1"));
+            Assert.That(withCustom.Organism, Is.Null.Or.Empty, "no organism regex was given, so the field is skipped");
+        }
+
+        [Test]
+        public static void NcbiPresetParsesALegacyDefline()
+        {
+            string path = WriteFasta(Path.Combine("FastaHeaderParsing", "ncbiPreset.fasta"), LegacyNcbiHeader, "PEPTIDEK");
+            var protein = Load(path, new FastaHeaderParsingParameters(FastaHeaderFormat.Ncbi)).Single();
+
+            Assert.That(protein.Accession, Is.EqualTo("NP_414555.1"));
+            Assert.That(protein.FullName, Is.EqualTo("thr operon leader peptide"));
+            Assert.That(protein.Organism, Is.EqualTo("Escherichia coli str. K-12 substr. MG1655"));
+        }
+
+        [Test]
+        public static void ModomicsPresetParsesAModomicsDefline()
+        {
+            string path = WriteFasta(Path.Combine("FastaHeaderParsing", "modomicsPreset.fasta"), ModomicsHeader, "PEPTIDEK");
+            var protein = Load(path, new FastaHeaderParsingParameters(FastaHeaderFormat.Modomics)).Single();
+
+            // Name, not SOterm: SOterm repeats across entries, so it collides as an accession.
+            Assert.That(protein.Accession, Is.EqualTo("tdbR00000010"));
+            Assert.That(protein.Name, Is.EqualTo("SO:0000254"));
+            Assert.That(protein.FullName, Is.EqualTo("tRNA"));
+            Assert.That(protein.Organism, Is.EqualTo("Escherichia coli"));
+        }
+
+        [Test]
+        public static void ModomicsHeaderIsUnusableUnderTheUniProtDefault()
+        {
+            string path = WriteFasta(Path.Combine("FastaHeaderParsing", "modomicsDefault.fasta"), ModomicsHeader, "PEPTIDEK");
+            var protein = Load(path, new FastaHeaderParsingParameters()).Single();
+
+            Assert.That(protein.Accession, Does.StartWith("Name:tdbR00000010|"));
+            Assert.That(protein.Accession.Count(c => c == '|'), Is.GreaterThan(1));
+        }
+
+        [Test]
+        public static void ATaskTomlRoundTripsTheCustomHeaderRegexes()
+        {
+            var task = new SearchTask
+            {
+                CommonParameters = new CommonParameters(fastaHeaderParsing:
+                    new FastaHeaderParsingParameters(FastaHeaderFormat.Custom,
+                        accessionRegex: @">.*\|(.*)\|",
+                        fullNameRegex: @">[^ ]*\s(.*)$",
+                        organismRegex: @"\[([^\]]+)\]\s*$"))
+            };
+
+            string tomlPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "FastaHeaderParsing", "roundTrip.toml");
+            Directory.CreateDirectory(Path.GetDirectoryName(tomlPath));
+            Toml.WriteFile(task, tomlPath, MetaMorpheusTask.tomlConfig);
+
+            string written = File.ReadAllText(tomlPath);
+            Assert.That(written, Does.Contain("HeaderFormat"), "the setting must be visible in the toml");
+
+            var readBack = Toml.ReadFile<SearchTask>(tomlPath, MetaMorpheusTask.tomlConfig);
+            var headerParsing = readBack.CommonParameters.FastaHeaderParsing;
+
+            Assert.That(headerParsing.HeaderFormat, Is.EqualTo(FastaHeaderFormat.Custom));
+            Assert.That(headerParsing.CustomAccessionRegex, Is.EqualTo(@">.*\|(.*)\|"));
+            Assert.That(headerParsing.CustomFullNameRegex, Is.EqualTo(@">[^ ]*\s(.*)$"));
+            Assert.That(headerParsing.CustomOrganismRegex, Is.EqualTo(@"\[([^\]]+)\]\s*$"));
+            Assert.That(headerParsing.CustomNameRegex, Is.Empty);
+            Assert.That(headerParsing.CustomGeneNameRegex, Is.Empty);
+            Assert.That(headerParsing.CustomOrganismIdRegex, Is.Empty);
+        }
+
+        [Test]
+        public static void ADefaultTaskTomlRoundTripsToTheUniProtDefault()
+        {
+            string tomlPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "FastaHeaderParsing", "defaultRoundTrip.toml");
+            Directory.CreateDirectory(Path.GetDirectoryName(tomlPath));
+            Toml.WriteFile(new SearchTask(), tomlPath, MetaMorpheusTask.tomlConfig);
+
+            var readBack = Toml.ReadFile<SearchTask>(tomlPath, MetaMorpheusTask.tomlConfig);
+            Assert.That(readBack.CommonParameters.FastaHeaderParsing.HeaderFormat, Is.EqualTo(FastaHeaderFormat.UniProt));
+            Assert.That(readBack.CommonParameters.FastaHeaderParsing.CustomAccessionRegex, Is.Empty);
+        }
+
+        [Test]
+        public static void ATomlWrittenBeforeThisSettingExistedStillReadsAsUniProt()
+        {
+            string tomlPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "FastaHeaderParsing", "legacy.toml");
+            Directory.CreateDirectory(Path.GetDirectoryName(tomlPath));
+            Toml.WriteFile(new SearchTask(), tomlPath, MetaMorpheusTask.tomlConfig);
+
+            // Strip the new table to imitate a toml saved by an earlier version.
+            var kept = new List<string>();
+            bool inSection = false;
+            foreach (string line in File.ReadAllLines(tomlPath))
+            {
+                if (line.StartsWith("["))
+                    inSection = line.Trim() == "[CommonParameters.FastaHeaderParsing]";
+                if (!inSection)
+                    kept.Add(line);
+            }
+            File.WriteAllLines(tomlPath, kept);
+            Assert.That(File.ReadAllText(tomlPath), Does.Not.Contain("FastaHeaderParsing"));
+
+            var readBack = Toml.ReadFile<SearchTask>(tomlPath, MetaMorpheusTask.tomlConfig);
+            Assert.That(readBack.CommonParameters.FastaHeaderParsing, Is.Not.Null);
+            Assert.That(readBack.CommonParameters.FastaHeaderParsing.HeaderFormat, Is.EqualTo(FastaHeaderFormat.UniProt));
+        }
+
+        [Test]
+        public static void PresetsNeedNoValidationAndAMalformedCustomRegexFailsIt()
+        {
+            foreach (FastaHeaderFormat format in Enum.GetValues<FastaHeaderFormat>().Where(f => f != FastaHeaderFormat.Custom))
+                Assert.That(new FastaHeaderParsingParameters(format).Validate(out _), Is.True, format.ToString());
+
+            var unbalanced = new FastaHeaderParsingParameters(FastaHeaderFormat.Custom, accessionRegex: @">(.*\|");
+            Assert.That(unbalanced.Validate(out var errors), Is.False);
+            Assert.That(errors.Single(), Does.Contain("accession").And.Contain("not usable"));
+        }
+
+        [Test]
+        public static void ACustomFormatWithoutAnAccessionRegexIsRefused()
+        {
+            var noAccession = new FastaHeaderParsingParameters(FastaHeaderFormat.Custom, organismRegex: @"OS=(\S+)");
+            Assert.That(noAccession.Validate(out var errors), Is.False);
+            Assert.That(errors.Single(), Does.Contain("requires an accession regex"));
+        }
+
+        [Test]
+        public static void ARegexWithNoCaptureGroupIsRefused()
+        {
+            var noGroup = new FastaHeaderParsingParameters(FastaHeaderFormat.Custom, accessionRegex: @">\S+");
+            Assert.That(noGroup.Validate(out var errors), Is.False);
+            Assert.That(errors.Single(), Does.Contain("no capture group"));
+        }
+
+        [Test]
+        public static void ACatastrophicallyBacktrackingRegexIsRefused()
+        {
+            var runaway = new FastaHeaderParsingParameters(FastaHeaderFormat.Custom,
+                accessionRegex: @"^(\s*\w+|\W)*(z9q)$");
+            Assert.That(runaway.Validate(out var errors), Is.False);
+            Assert.That(errors.Single(), Does.Contain("longer than"));
+        }
+
+        [Test]
+        public static void AMalformedRegexStopsTheRunWithAWarningAndStartsNoEngine()
+        {
+            var startedEngines = new List<string>();
+            void RecordEngine(object sender, SingleEngineEventArgs e) => startedEngines.Add(e.MyEngine.GetType().Name);
+
+            string fastaPath = WriteFasta(Path.Combine("FastaHeaderParsing", "gateDb.fasta"), UniProtHeader, "PEPTIDEK");
+            string mzmlPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "PrunedDbSpectra.mzml");
+            string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestFastaHeaderRegexGate");
+
+            var task = new SearchTask
+            {
+                CommonParameters = new CommonParameters(fastaHeaderParsing:
+                    new FastaHeaderParsingParameters(FastaHeaderFormat.Custom, accessionRegex: @">(.*\|"))
+            };
+
+            MetaMorpheusEngine.StartingSingleEngineHander += RecordEngine;
+            EverythingRunnerEngine engine;
+            try
+            {
+                engine = new EverythingRunnerEngine(
+                    new List<(string, MetaMorpheusTask)> { ("Task1-SearchTask", task) },
+                    new List<string> { mzmlPath },
+                    new List<DbForTask> { new DbForTask(fastaPath, false) },
+                    outputFolder);
+                engine.Run();
+            }
+            finally
+            {
+                MetaMorpheusEngine.StartingSingleEngineHander -= RecordEngine;
+            }
+
+            Assert.That(startedEngines, Is.Empty, "no engine should start: " + string.Join(", ", startedEngines));
+            Assert.That(engine.Warnings, Is.Not.Empty);
+            Assert.That(engine.Warnings.Single(), Does.StartWith("Cannot proceed. Task1-SearchTask:")
+                .And.Contain("not usable"));
+        }
+    }
+}

--- a/MetaMorpheus/Test/FastaHeaderParsingTest.cs
+++ b/MetaMorpheus/Test/FastaHeaderParsingTest.cs
@@ -24,6 +24,10 @@ namespace Test
         private const string ModomicsHeader =
             ">id:1|Name:tdbR00000010|SOterm:SO:0000254|Type:tRNA|Subtype:Ala|Feature:VGC|Cellular_Localization:prokaryotic cytosol|Species:Escherichia coli";
 
+        // Gencode: exactly seven pipes, which is what DetectFastaHeaderFormat keys on.
+        private const string GencodeHeader =
+            ">ENSMUSP00000034487.2|ENSMUST00000034487.3|ENSMUSG00000018620.3|OTTMUSG00000062304.1|OTTMUST00000151979.1|Mmp20-201|Mmp20|482";
+
         private const string UniProtHeader =
             ">sp|P12345|AATM_RABIT Aspartate aminotransferase, mitochondrial OS=Oryctolagus cuniculus OX=9986 GN=GOT2 PE=1 SV=2";
 
@@ -285,6 +289,79 @@ namespace Test
 
             // ToString() so the assertion holds whether or not Nett wraps ours.
             Assert.That(thrown.ToString(), Does.Contain("Uniprot2").And.Contain("Valid values are"));
+        }
+
+        [Test]
+        public static void AutoDetectsGencodeWhereTheUniProtPresetManglesIt()
+        {
+            string path = WriteFasta(Path.Combine("FastaHeaderParsing", "gencodeAuto.fasta"), GencodeHeader, "PEPTIDEK");
+
+            // Stated as an invariant rather than a value: the pinned mzLib captures every field
+            // between the outer pipes, and mzLib's pending accession fix would capture the last one
+            // (a gene symbol). Neither is the Gencode accession, which is the point.
+            var mangled = Load(path, new FastaHeaderParsingParameters(FastaHeaderFormat.UniProt)).Single();
+            Assert.That(mangled.Accession, Is.Not.EqualTo("ENSMUSP00000034487.2"));
+
+            var detected = Load(path, new FastaHeaderParsingParameters(FastaHeaderFormat.Auto)).Single();
+            Assert.That(detected.Accession, Is.EqualTo("ENSMUSP00000034487.2"));
+            Assert.That(detected.GeneNames.Single().Item2, Is.EqualTo("Mmp20"));
+        }
+
+        [Test]
+        public static void AutoChangesNameAndTaxonomyIdOnAUniProtHeader()
+        {
+            string path = WriteFasta(Path.Combine("FastaHeaderParsing", "uniprotAuto.fasta"), UniProtHeader, "PEPTIDEK");
+
+            var preset = Load(path, new FastaHeaderParsingParameters(FastaHeaderFormat.UniProt)).Single();
+            var auto = Load(path, new FastaHeaderParsingParameters(FastaHeaderFormat.Auto)).Single();
+
+            // Same accession, but Auto is not a synonym for the UniProt preset: mzLib's detection
+            // uses UniprotNameRegex for Name and defaults an organism id regex, neither of which
+            // MetaMorpheus has ever passed. Pinned so the difference is documented, not discovered.
+            Assert.That(auto.Accession, Is.EqualTo(preset.Accession));
+            Assert.That(preset.Name, Is.EqualTo("Aspartate aminotransferase, mitochondrial"));
+            Assert.That(auto.Name, Is.EqualTo("AATM_RABIT"));
+            Assert.That(preset.NcbiTaxonomyId, Is.Null.Or.Empty);
+            Assert.That(auto.NcbiTaxonomyId, Is.EqualTo("9986"));
+        }
+
+        [Test]
+        public static void AutoRefusesAnUndetectableHeaderWithAWarningInsteadOfThrowing()
+        {
+            var startedEngines = new List<string>();
+            void RecordEngine(object sender, SingleEngineEventArgs e) => startedEngines.Add(e.MyEngine.GetType().Name);
+
+            // Not UniProt (no two-letter code and pipe), no Ensembl field markers, not seven pipes.
+            // mzLib would throw MzLibException on this, which reaches a GUI user as a crash report.
+            string fastaPath = WriteFasta(Path.Combine("FastaHeaderParsing", "undetectable.fasta"),
+                ">rat_reductase", "PEPTIDEK");
+            string mzmlPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "PrunedDbSpectra.mzml");
+            string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, "TestFastaHeaderAutoGate");
+
+            var task = new SearchTask
+            {
+                CommonParameters = new CommonParameters(fastaHeaderParsing:
+                    new FastaHeaderParsingParameters(FastaHeaderFormat.Auto))
+            };
+
+            MetaMorpheusEngine.StartingSingleEngineHander += RecordEngine;
+            EverythingRunnerEngine engine;
+            try
+            {
+                engine = new EverythingRunnerEngine(
+                    new List<(string, MetaMorpheusTask)> { ("Task1-SearchTask", task) },
+                    new List<string> { mzmlPath },
+                    new List<DbForTask> { new DbForTask(fastaPath, false) },
+                    outputFolder);
+                engine.Run();
+            }
+            finally
+            {
+                MetaMorpheusEngine.StartingSingleEngineHander -= RecordEngine;
+            }
+
+            Assert.That(startedEngines, Is.Empty, "no engine should start: " + string.Join(", ", startedEngines));
+            Assert.That(engine.Warnings.Single(), Does.Contain("could not be detected automatically"));
         }
     }
 }


### PR DESCRIPTION
🤖 MetaMorpheus parsed every `.fasta` with the UniProt header regexes, unconditionally. There was no way to change that, so a non-UniProt defline produced an accession that is not an accession — and accession is the join key in every output file we write. This adds a per-task setting, in the TOML and in the GUI, that picks a header format or supplies your own regexes.

Closes #1936.

`ProteinDbLoader.LoadProteinFasta` has always accepted caller-supplied field regexes, so **this is a MetaMorpheus-only change: no mzLib release, no pin bump.** The setting lives on `CommonParameters`, which `DatabaseLoadingEngine` already receives, so nothing had to be threaded anywhere.

## What you get

`[CommonParameters.FastaHeaderParsing]` in every task TOML — one enum and six strings, no nested object graph:

```toml
[CommonParameters.FastaHeaderParsing]
HeaderFormat = "Custom"
CustomAccessionRegex = ">.*\\|(.*)\\|"
CustomFullNameRegex = ""
CustomNameRegex = ""
CustomGeneNameRegex = ""
CustomOrganismRegex = "\\[([^\\]]+)\\]\\s*$"
CustomOrganismIdRegex = ""
```

Formats are `UniProt` (default), `Ensembl`, `Gencode`, `Ncbi`, `Auto` and `Custom`. The three mzLib presets are referenced by name rather than copied, so if mzLib's UniProt accession regex is improved we inherit it. `Ncbi` is new here because mzLib has no protein-path preset for it. An empty custom pattern means that field is skipped, and `Custom` requires an accession pattern — see `Auto` below for why that argument being null is significant.

The GUI panel is one `UserControl` added to the five task windows that load a database. Each gains one XAML line and two code-behind lines, so the panel exists once rather than five times. The CMD front end needs no new flag: `-t` already carries the TOML.

## `Auto`, and the root cause it exposes

`LoadProteinFasta` calls `DetectFastaHeaderFormat` **only when the caller passes no accession regex**. MetaMorpheus has always passed one, so it opted out of detection entirely — which is why an Ensembl or Gencode database is mangled here while mzLib's own tests, which pass nothing, parse those files correctly. That is the actual root cause of #1921, and it is a bigger effect than the regex itself.

`Auto` returns an empty regex set, because the empty set is how detection is requested. It is the only option that copes with a Gencode or Ensembl database without the user having to know which one they have.

Two things make it opt-in rather than the default.

**`Auto` is not a synonym for the `UniProt` preset.** Detection assigns `UniprotNameRegex` to `Name` where MetaMorpheus hardcodes `UniprotFullNameRegex`, and does `organismIdRegex ??= UniprotOrganismIdRegex`. So on a UniProt database `Auto` changes `Name` on every entry — `Aspartate aminotransferase, mitochondrial` becomes `AATM_RABIT` — and starts populating `NcbiTaxonomyId`, which is null today. Both are arguably more correct; both move output. A test pins the difference so it is documented rather than discovered.

**Detection throws on a header it cannot classify**, and `Unknown` is easy to reach: a plain `>rat_reductase` defline is none of UniProt, Ensembl or Gencode, and `MzLibException("Unknown fasta header format: …")` reaches a GUI user as a crash-report prompt. The runner gate therefore classifies the sampled deflines up front and refuses with a warning naming the offending header, reusing the deflines it already reads for regex validation. `FastaHeaderType` has no NCBI case, so `Auto` does not help legacy NCBI — the `Ncbi` preset and the companion mzLib PR (smith-chem-wisc/mzLib#1251) cover that.

## Nothing changes by default, and here is the measurement

Both vignette databases — `uniprot-mouse-reviewed-2-5-2018.fasta` (16,954 entries) and `uniprot-cRAP-2-2-2018.fasta` (115) — loaded twice in one process, once through the old literal argument list and once through the new UniProt preset, comparing accession, name, full name, organism, taxonomy database references, gene names and sequence on every entry: **0 differences out of 17,069.** Two tests also pin the preset to mzLib's own constants by reference identity, so a future divergence in either repo fails rather than drifting.

Two existing behaviours are preserved deliberately rather than tidied, and both are worth a decision:

- **`Name` is parsed with the *full-name* regex**, which is what `LoadProteinDb` has always passed. Passing `UniprotNameRegex` instead — presumably what was meant — changes `Name` on **17,069 of 17,069** entries, from `Alcohol dehydrogenase 1` to `ADH1_YEAST`. That is a wholesale output change and does not belong here.
- **Organism id is not parsed.** mzLib's auto-detect branch defaults `organismIdRegex` to `UniprotOrganismIdRegex`, but that branch never runs from MetaMorpheus because we always pass an accession regex, so `Protein.NcbiTaxonomyId` is null today. Passing it changes nothing on those two files — but only because neither carries an `OX=` field (0 of 17,069 headers do; UniProt added `OX=` after 2018). So it is inert on that input and **not** provably inert on a current download, which is why the preset leaves it out.

Opting *in* to `Auto` or to any non-UniProt format changes accessions and therefore every downstream file — `.psmtsv`, protein groups, quantification, `.mzID`, pruned databases. Results are not comparable across the setting.

## Modomics is not where the issue text says it is, and this PR does not reach it

This is the finding that changed the design. **Modomics FASTA is already parsed — by mzLib's `RnaDbLoader`, on the oligo path, not `ProteinDbLoader`.** `RnaFastaHeaderType.Modomics` and an eight-entry `ModomicsFieldRegexes` both exist in the pinned 1.0.587 package, and `DetectRnaFastaHeaderType` selects them on any line starting `>id`. So Modomics headers were never unsupported; they were supported somewhere this setting cannot reach.

`DatabaseLoadingEngine.LoadOligoDb` and `LoadProteinDb` are separate methods. An oligo run reaches `RnaDbLoader.LoadRnaFasta`, which in 1.0.587 takes **no regex parameters at all** — only location, decoy and terminus arguments — with a closed format list and hardcoded `public static readonly` regex dictionaries. **Making the oligo path customizable is therefore an mzLib change and cannot be done from here.** It also throws `MzLibException("Unknown fasta header format: …")` on an unrecognised RNA header, which reaches a GUI user as the crash-report prompt — the same failure mode the `Warn` gate below avoids on the protein path.

An earlier revision of this branch carried a `Modomics` preset for the *protein* path. It has been removed: since a Modomics database is loaded as an oligo, the preset could only ever fire on someone loading RNA into a protein search, which means digesting ACGU with a protease. A dropdown entry named for the motivating case that cannot serve it is worse than no entry, because it looks like the feature works. A test still records what the UniProt default does to such a header, so the gap is documented rather than silently absent:

```
>id:1|Name:tdbR00000010|SOterm:SO:0000254|Type:tRNA|Subtype:Ala|Feature:VGC|Cellular_Localization:prokaryotic cytosol|Species:Escherichia coli
```

yields the accession `Name:tdbR00000010|SOterm:SO:0000254|…|Cellular_Localization:prokaryotic cytosol`.

## A bad configuration is a warning, not a crash

The gate is in `EverythingRunnerEngine.Run`, inside the per-task loop next to the existing database and spectra gates — not before it, since `CurrentXmlDbFilenameList` grows as tasks chain. It reports with `Warn` + `FinishedAllTasks` + `return`. A `MetaMorpheusException` thrown from the task would instead reach a GUI user as "Would you like to report this crash?" with a mailto to mm_support, which is the wrong answer to a typo in a textbox. The throw inside `GetFieldRegexes` stays as a backstop for anything calling `RunTask` directly.

`Validate` refuses a pattern that does not compile, a pattern with no capture group, and a pattern that is too slow to match. That last one needs care: mzLib's `FastaHeaderFieldRegex` constructor is `Regex = new Regex(pattern)` with **no match timeout**, so a 250 ms ceiling applied only to canned sample headers would prove nothing about the user's own file. The runner therefore reads the first few deflines out of each FASTA in the run and validates against those as well as the canned ones. It narrows the window rather than closing it — a timeout on the load itself would need an mzLib change — and the doc comment says so rather than implying more.

An unrecognised format *name* is handled too. The TOML converter used `Enum.Parse`, so `HeaderFormat = "Uniprot2"` failed during the TOML read with a bare "Requested value was not found", before the gate exists to catch it. It now names the legal values. Treating a config typo as a message is the whole premise here; the enum was the one field where it wasn't.

## Tests

Eighteen tests in `Test/FastaHeaderParsingTest.cs`, all green. Fixtures are written at test time, so no `CopyToOutputDirectory` entry was needed, and every path is built with `Path.Combine`.

The gate test asserts on `engine.Warnings` and on an empty list of engines collected from `MetaMorpheusEngine.StartingSingleEngineHander`. It deliberately does not check that the output folder is empty: every result file is written by `PostSearchAnalysisTask`, so that assertion would pass whether or not the search ran. One test strips the new table out of a written TOML to confirm an older TOML still reads as UniProt — as do all five 2019-vintage vignette configs. Reverting any of the three mechanisms added in the last two commits fails exactly the tests written for them. The Gencode assertion is stated as an invariant rather than a value, because the pinned mzLib 1.0.587 and the pending accession fix mangle that header differently and neither yields the Gencode accession — which is the point.

Tests were run on macOS through a throwaway net10.0 NUnit harness, since `Test/Test.csproj` targets `net10.0-windows` and cannot execute here. `Test.csproj` and `GUI.csproj` both compile clean with `EnableWindowsTargeting`, and that does run the WPF markup compiler over the new XAML — but the GUI cannot be *run* on macOS, so **the panel's layout, tooltips and enable/disable behaviour are unverified.** The GUI also does not validate on OK; a bad pattern surfaces at Run, via the warning above.

## Related, separate

`ProteinDbLoader.UniprotAccessionRegex` is `[|](.+)[|]`, unanchored, so on a four-pipe `gi|` defline it captures across all of them. That is a defect in the default itself and ships separately as smith-chem-wisc/mzLib#1251; this PR does not touch it. The two are complementary — because the presets here reference mzLib's regex by name rather than copying it, that fix improves the `UniProt` preset with no change here. The `Ncbi` preset gives affected users an answer in the meantime.

Not touched: the `|` protein-group separator, which is a format-versioning decision of its own. Custom regexes for the oligo path are the natural follow-up and belong in mzLib.
