### PR TITLE
chore(mzlib): bump the pin to 1.0.588

### DIFF
--- a/MetaMorpheus/CMD/CMD.csproj
+++ b/MetaMorpheus/CMD/CMD.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.587" />
+    <PackageReference Include="mzLib" Version="1.0.588" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.118" />

--- a/MetaMorpheus/EngineLayer/EngineLayer.csproj
+++ b/MetaMorpheus/EngineLayer/EngineLayer.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.587" />
+    <PackageReference Include="mzLib" Version="1.0.588" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />

--- a/MetaMorpheus/GUI/GUI.csproj
+++ b/MetaMorpheus/GUI/GUI.csproj
@@ -62,7 +62,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.587" />
+    <PackageReference Include="mzLib" Version="1.0.588" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0" />

--- a/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
+++ b/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="itext7" Version="9.7.0" />
     <PackageReference Include="itext7.bouncy-castle-adapter" Version="9.7.0" />
-    <PackageReference Include="mzLib" Version="1.0.587" />
+    <PackageReference Include="mzLib" Version="1.0.588" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.0.0" />
     <PackageReference Include="Svg" Version="3.4.7" />
   </ItemGroup>

--- a/MetaMorpheus/TaskLayer/TaskLayer.csproj
+++ b/MetaMorpheus/TaskLayer/TaskLayer.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.587" />
+    <PackageReference Include="mzLib" Version="1.0.588" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />

--- a/MetaMorpheus/Test/Test.csproj
+++ b/MetaMorpheus/Test/Test.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.587" />
+    <PackageReference Include="mzLib" Version="1.0.588" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />


### PR DESCRIPTION
mzLib released **1.0.588**. This repository pinned `1.0.587`.

### Pin sites updated

- `MetaMorpheus/CMD/CMD.csproj`
- `MetaMorpheus/EngineLayer/EngineLayer.csproj`
- `MetaMorpheus/GUI/GUI.csproj`
- `MetaMorpheus/GuiFunctions/GuiFunctions.csproj`
- `MetaMorpheus/TaskLayer/TaskLayer.csproj`
- `MetaMorpheus/Test/Test.csproj`

### What to look at before merging

The checks on this pull request are the gate: they say whether this repository still
builds and still passes its own tests against the new package. What they cannot say is
whether mzLib **changed a value it reports**, because a re-baselined expectation is
indistinguishable from a correct one until someone reads the release notes.

A version bump here is only sometimes a version string. Of the four consumers bumped
for mzLib 1.0.585, one was; the others needed a framework migration, a namespace fix
after drifting nineteen releases, and thirteen test updates. **If CI is red, read it
as work to do rather than as a broken release.**

Release notes: https://github.com/smith-chem-wisc/mzLib/releases/tag/1.0.588

---
Opened by `.github/workflows/upstream-watch.yml`.
