### PR TITLE
Make the rewritten experimental design name the files that were written

### DIFF
--- a/MetaMorpheus/TaskLayer/AveragingTask/SpectralAveragingTask.cs
+++ b/MetaMorpheus/TaskLayer/AveragingTask/SpectralAveragingTask.cs
@@ -155,7 +155,9 @@ namespace TaskLayer
             {
                 var originalUnaveragedFilePath = unaveragedSpectraFile.FullFilePathWithExtension;
                 var originalUnaveragedFilenameWithoutExtension = GlobalVariables.GetFilenameWithoutExtension(originalUnaveragedFilePath);
-                string averagedFilePath = Path.Combine(outputFolder, originalUnaveragedFilenameWithoutExtension + AveragingSuffix + ".mzML");
+                // ToSafeOutputPath here too, or a name the run loop trimmed is named untrimmed.
+                string averagedFilePath = Path.Combine(outputFolder, originalUnaveragedFilenameWithoutExtension + AveragingSuffix + ".mzML")
+                    .ToSafeOutputPath(AveragingSuffix + ".mzML");
 
                 var averagedSpectraFile = new SpectraFileInfo(averagedFilePath,
                     unaveragedSpectraFile.Condition, unaveragedSpectraFile.BiologicalReplicate, unaveragedSpectraFile.TechnicalReplicate, unaveragedSpectraFile.Fraction);

--- a/MetaMorpheus/TaskLayer/AveragingTask/SpectralAveragingTask.cs
+++ b/MetaMorpheus/TaskLayer/AveragingTask/SpectralAveragingTask.cs
@@ -64,6 +64,8 @@ namespace TaskLayer
                 var originalFileExtension = GlobalVariables.GetFileExtension(originalUnaveragedFilepath);
                 if (originalFileExtension.Equals(".mgf", StringComparison.OrdinalIgnoreCase) || originalFileExtension.Equals(".d", StringComparison.OrdinalIgnoreCase) || originalFileExtension.Equals(".msalign", StringComparison.OrdinalIgnoreCase) || BrukerDataDirectory.IsInnerFileExtension(originalFileExtension))
                 {
+                    // record it, or the new experimental design names a -averaged.mzML that was never written
+                    unsuccessfulyAveragedFilePaths.Add(originalUnaveragedFilepath);
                     Warn("Averaging for " + originalFileExtension + " files is not supported.");
                     FinishedDataFile(originalUnaveragedFilepath, new List<string> { taskId, "Individual Spectra Files", originalUnaveragedFilepath });
                     ReportProgress(new ProgressEventArgs(100, "Done!", new List<string> { taskId, "Individual Spectra Files", originalUnaveragedFilepathWithoutExtenstion }));

--- a/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationTask.cs
+++ b/MetaMorpheus/TaskLayer/CalibrationTask/CalibrationTask.cs
@@ -551,14 +551,18 @@ namespace TaskLayer
             foreach (SpectraFileInfo originalSpectraFile in oldExperDesign)
             {
                 var originalFileName = originalSpectraFile.FilenameWithoutExtension;
-                var k = unsuccessfullyCalibratedFilePaths.FirstOrDefault(fn => fn.Contains(originalFileName));
+                // Compare whole names, not substrings: "run_1" is a substring of "run_10", so a
+                // substring match hands run_1's design row the file belonging to run_10.
+                var k = unsuccessfullyCalibratedFilePaths.FirstOrDefault(
+                    fn => GlobalVariables.GetFilenameWithoutExtension(fn) == originalFileName);
                 if (k != null)
                 {
                     newExperDesign.Add(new SpectraFileInfo(k, originalSpectraFile.Condition, originalSpectraFile.BiologicalReplicate, originalSpectraFile.TechnicalReplicate, originalSpectraFile.Fraction));
                 }
                 else
                 {
-                    SpectraFileInfo calibratedSpectraFile = new(Path.Combine(outputFolder, originalFileName + CalibSuffix + ".mzML"),
+                    // ToSafeOutputPath here too, or a name the run loop trimmed is named untrimmed.
+                    SpectraFileInfo calibratedSpectraFile = new(Path.Combine(outputFolder, originalFileName + CalibSuffix + ".mzML").ToSafeOutputPath(CalibSuffix + ".mzML"),
                     originalSpectraFile.Condition, originalSpectraFile.BiologicalReplicate, originalSpectraFile.TechnicalReplicate, originalSpectraFile.Fraction);
                     newExperDesign.Add(calibratedSpectraFile);
                 }

--- a/MetaMorpheus/Test/AveragingTests.cs
+++ b/MetaMorpheus/Test/AveragingTests.cs
@@ -238,6 +238,57 @@ namespace Test
             Directory.Delete(testPath, true);
         }
 
+        /// <summary>
+        /// A file type the averaging task cannot average is skipped, and EverythingRunnerEngine hands
+        /// the next task its original path. Its experimental design row must keep that path rather than
+        /// naming a -averaged.mzML that was never written. Issue #2192.
+        /// </summary>
+        [Test]
+        public static void SkippedFileKeepsItsOriginalPathInTheNewExperimentalDesign()
+        {
+            string testPath = Path.Combine(TestFolder, "AveragingSkippedFileDesign");
+            string outputFolder = Path.Combine(testPath, "Task1-Average");
+            Directory.CreateDirectory(testPath);
+            Directory.CreateDirectory(outputFolder);
+
+            string averagable = Path.Combine(testPath, "sample1.mzML");
+            File.Copy(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "SmallCalibratible_Yeast.mzML"), averagable, true);
+            string notAveragable = Path.Combine(testPath, "sample2.mgf");
+            File.Copy(Path.Combine(TestContext.CurrentContext.TestDirectory, "TestData", "ok.mgf"), notAveragable, true);
+
+            _ = ExperimentalDesign.WriteExperimentalDesignToFile(new List<SpectraFileInfo>
+            {
+                new(averagable, "condition1", 0, 0, 0),
+                new(notAveragable, "condition2", 0, 0, 0),
+            });
+
+            SpectralAveragingParameters options = new()
+            {
+                SpectraFileAveragingType = SpectraFileAveragingType.AverageDdaScans,
+                NumberOfScansToAverage = 5,
+            };
+            SpectralAveragingTask averagingTask = new(options) { CommonParameters = commonParameters };
+            averagingTask.RunTask(outputFolder, new List<DbForTask>(), new List<string> { averagable, notAveragable }, "test");
+
+            string averagedPath = Path.Combine(outputFolder, "sample1-averaged.mzML");
+            Assert.That(File.Exists(averagedPath));
+            Assert.That(File.Exists(Path.Combine(outputFolder, "sample2-averaged.mzML")), Is.False);
+
+            string newDesignPath = Path.Combine(outputFolder, GlobalVariables.ExperimentalDesignFileName);
+            Assert.That(File.Exists(newDesignPath));
+
+            var design = ExperimentalDesign.ReadExperimentalDesign(newDesignPath,
+                new List<string> { averagedPath, notAveragable }, out var errors);
+
+            Assert.That(errors, Is.Empty);
+            Assert.That(design.Count, Is.EqualTo(2));
+            Assert.That(design.Any(p => p.FullFilePathWithExtension == notAveragable));
+            Assert.That(design.Any(p => p.FullFilePathWithExtension == averagedPath));
+
+            Directory.Delete(testPath, true);
+        }
+
+
         [Test]
         public static void TestExperimentalDesignError()
         {

--- a/MetaMorpheus/Test/ExperimentalDesignRewriteTests.cs
+++ b/MetaMorpheus/Test/ExperimentalDesignRewriteTests.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using EngineLayer;
+using EngineLayer.Util;
+using MassSpectrometry;
+using NUnit.Framework;
+using TaskLayer;
+
+namespace Test
+{
+    /// <summary>
+    /// Covers the experimental design that calibration rewrites for the next task. Every row of it has
+    /// to name the file calibration actually wrote, or quantification looks for something that is not
+    /// there and skips - which is what #2192 reported.
+    /// </summary>
+    [TestFixture]
+    [ExcludeFromCodeCoverage]
+    public static class ExperimentalDesignRewriteTests
+    {
+        /// <summary>
+        /// WriteNewExperimentalDesignFile is private; reaching it directly is much cheaper than driving
+        /// a calibration failure end to end, and it is the unit whose contract is at issue.
+        /// </summary>
+        private static void RewriteDesign(string oldDesignPath, string outputFolder,
+            List<string> currentRawFileList, List<string> unsuccessfullyCalibrated)
+        {
+            var method = typeof(CalibrationTask).GetMethod("WriteNewExperimentalDesignFile",
+                BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.That(method, Is.Not.Null, "CalibrationTask.WriteNewExperimentalDesignFile was renamed");
+            method.Invoke(null, new object[] { oldDesignPath, outputFolder, currentRawFileList, unsuccessfullyCalibrated });
+        }
+
+        private static (string InDir, string OutDir) MakeDirs(string name)
+        {
+            string root = Path.Combine(TestContext.CurrentContext.TestDirectory, name);
+            if (Directory.Exists(root)) Directory.Delete(root, true);
+            string inDir = Path.Combine(root, "in");
+            string outDir = Path.Combine(root, "out");
+            Directory.CreateDirectory(inDir);
+            Directory.CreateDirectory(outDir);
+            return (inDir, outDir);
+        }
+
+        /// <summary>The FileName column of the rewritten design, in order.</summary>
+        private static List<string> DesignFileNames(string outputFolder)
+        {
+            string path = Path.Combine(outputFolder, GlobalVariables.ExperimentalDesignFileName);
+            Assert.That(File.Exists(path), "no experimental design was written");
+            return File.ReadAllLines(path).Skip(1)
+                .Where(l => !string.IsNullOrWhiteSpace(l))
+                .Select(l => l.Split('\t')[0]).ToList();
+        }
+
+        [Test]
+        public static void OneFileNameBeingAPrefixOfAnotherDoesNotPairThemTogether()
+        {
+            var (inDir, outDir) = MakeDirs("DesignRewritePrefix");
+
+            // "run_1" is a substring of "run_10", which is the whole point.
+            string calibratable = Path.Combine(inDir, "run_1.mzML");
+            string failed = Path.Combine(inDir, "run_10.mzML");
+            File.WriteAllText(calibratable, "x");
+            File.WriteAllText(failed, "x");
+
+            string oldDesign = ExperimentalDesign.WriteExperimentalDesignToFile(new List<SpectraFileInfo>
+            {
+                new SpectraFileInfo(calibratable, "CondA", 0, 0, 0),
+                new SpectraFileInfo(failed, "CondB", 0, 0, 0)
+            });
+
+            // run_10 failed calibration, so its uncalibrated copy sits in the output folder.
+            RewriteDesign(oldDesign, outDir, new List<string> { calibratable, failed },
+                new List<string> { Path.Combine(outDir, "run_10.mzML") });
+
+            var names = DesignFileNames(outDir);
+
+            Assert.That(names, Has.Count.EqualTo(2));
+            Assert.That(names, Is.Unique, "a file was named twice, so one row lost its own data: " + string.Join(", ", names));
+            Assert.That(names, Does.Contain("run_1-calib.mzML"),
+                "run_1 calibrated successfully, so its row must name its calibrated file: " + string.Join(", ", names));
+            Assert.That(names, Does.Contain("run_10.mzML"));
+        }
+
+        [Test]
+        public static void ADesignRowNamesTheTrimmedPathTheRunLoopActuallyWrote()
+        {
+            var (inDir, outDir) = MakeDirs("DesignRewriteLongName");
+
+            // Long enough that the calibrated path trips PathSafety's cap, as it does in the run loop.
+            string longFile = Path.Combine(inDir, new string('a', 250) + ".mzML");
+            File.WriteAllText(longFile, "x");
+
+            string oldDesign = ExperimentalDesign.WriteExperimentalDesignToFile(
+                new List<SpectraFileInfo> { new SpectraFileInfo(longFile, "CondA", 0, 0, 0) });
+
+            // What CalibrationTask's run loop writes for this file.
+            string writtenByRunLoop = Path.GetFileName(
+                Path.Combine(outDir, Path.GetFileNameWithoutExtension(longFile) + "-calib" + ".mzML")
+                    .ToSafeOutputPath("-calib.mzML"));
+            Assert.That(writtenByRunLoop.Length, Is.LessThan(250),
+                "premise: this name must actually be trimmed, or the test proves nothing");
+
+            RewriteDesign(oldDesign, outDir, new List<string> { longFile }, new List<string>());
+
+            Assert.That(DesignFileNames(outDir).Single(), Is.EqualTo(writtenByRunLoop));
+        }
+    }
+}


### PR DESCRIPTION
🤖 #2192 reported quantification skipping with "the experimental design did not contain the file(s)". Its own cause was fixed as part of the timsTOF work in #2520, and I closed it on that basis. While verifying, three further routes to the same symptom turned out to be live on master, and one of them is worse than the original: instead of naming a file that does not exist, it names the wrong file that does.

Calibration and averaging both rewrite the experimental design for the next task. The invariant is simple — every row must name the file the run loop actually wrote — and each task breaks it differently.

## Averaging never recorded a skipped file

The list is declared `unsuccessfulyAveragedFilePaths` at `SpectralAveragingTask.cs:45` (one `l`), passed to the design writer at `:125`, received under the correctly spelled parameter at `:136`, read via `Contains` at `:161` — and never added to. So a `.mgf`, `.d`, `.msalign` or Bruker file, which averaging does not support, got a design row naming an `-averaged.mzML` that was never written. Calibration records exactly this case at `CalibrationTask.cs:414`.

The spelling mismatch is probably why it lasted: grep the correct spelling and you find the parameter, not the field.

## Calibration paired by substring, and mispaired

`FirstOrDefault(fn => fn.Contains(originalFileName))` matches `run_1` against a stored path for `run_10`. Measured on a two-file design where `run_10` failed calibration:

```
old design:                     new design:
run_1.mzML    CondA             run_10.mzML   CondA
run_10.mzML   CondB             run_10.mzML   CondB
```

`run_1`'s row names `run_10.mzML` under `run_1`'s condition; `run_1-calib.mzML` appears nowhere despite having been written; and `run_10.mzML` appears twice under two conditions. That is silent mislabelling rather than the loud error #2192 produced, which makes it the one I would most want out of the tree.

Now compared on whole filenames. The list holds two forms — an original input path from `:414`, an output path from `:461` — so the filename without extension is what both have in common.

## Both design writers omitted `ToSafeOutputPath`

Their run loops apply it (`CalibrationTask.cs:89`, `SpectralAveragingTask.cs:63`); the design writers did not. A name the run loop trimmed to fit the path cap was named untrimmed in the design. Measured: the run loop wrote a 133-character name while the design named the 261-character one. Reachable through a long filename, and more plausibly through a deep output folder, since the cap is on the whole path.

## The symmetry worth noticing

Averaging pairs by exact equality, so it was never exposed to the substring problem. Calibration populates its list, so it was never exposed to the empty one. Each task had half of the correct implementation, which is why neither showed up as a pattern until both were read side by side.

## Output

Where these fire: a run that previously skipped quantification now quantifies, and a run that previously mispaired now pairs correctly. Otherwise unaffected — the trimming path differs only for names at the cap, and the substring path only for filenames that are prefixes of each other.

## Tests

`Test/ExperimentalDesignRewriteTests.cs` drives the private design writer by reflection, which is much cheaper than provoking a real calibration failure and tests the unit whose contract is actually at issue. `Test/AveragingTests.cs` covers the skip-list case end to end through the averaging task, and asserts the negative too — that no `-averaged.mzML` was written for the skipped file.

All three confirmed failing against the unfixed code. The prefix test reports `run_10.mzML, run_10.mzML`; the trimming test reports 133 against 261. Verified by reverting the production changes and rerunning, not by inspection.

`Test/Test.csproj` is `net*.0-windows` and cannot execute on macOS, so these ran through a throwaway net10.0 harness inside the repo tree, since deleted. Solution builds clean on `-c UbuntuMac`, and `Test.csproj` and `GUI.csproj` both compile with `EnableWindowsTargeting`. CI is the first real run.

## Deliberately not included

`Test/CalibrationTests.cs`'s `ExperimentalDesignCalibrationAndSearchWithOneCalibratibleAndOneNoncalibratible` is this area's own test and asserts only that `ExperimentalDesign.tsv` exists — under the comment "test to see if quantification ran correctly". `PostSearchAnalysisTask` copies that file at `:295` before the read at `:306` whose failure path is `Warn` + `return`, so it passes whether or not quantification ran, and it would have stayed green throughout #2192's life. Worth fixing, but #2773 and #2780 are both open against that file, so it belongs after they land.
