### PR TITLE
One seeding recipe for every user-editable custom file

### DIFF
--- a/MetaMorpheus/CMD/Program.cs
+++ b/MetaMorpheus/CMD/Program.cs
@@ -207,6 +207,16 @@ namespace MetaMorpheusCommandLine
                 }
             }
 
+            // anything else startup noticed, such as a custom protease that collided with a built-in
+            foreach (var warning in GlobalVariables.StartupWarnings)
+            {
+                if (settings.Verbosity == CommandLineSettings.VerbosityType.minimal || settings.Verbosity == CommandLineSettings.VerbosityType.normal)
+                {
+                    Console.WriteLine(warning);
+                }
+            }
+            GlobalVariables.StartupWarnings.Clear();
+
             List<(string, MetaMorpheusTask)> taskList = new List<(string, MetaMorpheusTask)>();
 
             var tasks = settings.Tasks.ToList();

--- a/MetaMorpheus/EngineLayer/CrosslinkSearch/Crosslinker.cs
+++ b/MetaMorpheus/EngineLayer/CrosslinkSearch/Crosslinker.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using MassSpectrometry;
 using System.Globalization;
@@ -75,6 +76,13 @@ namespace EngineLayer
             return cleaveDissociationTypes;
         }
 
+        /// <summary>
+        /// Columns in a crosslinker tsv row: Name, CrosslinkAminoAcid, CrosslinkerAminoAcid2, Cleavable,
+        /// DissociationType, CrosslinkerTotalMass, CrosslinkerShortMass, CrosslinkerLongMass, QuenchMassH2O,
+        /// QuenchMassNH2, QuenchMassTris.
+        /// </summary>
+        private const int ExpectedColumnCount = 11;
+
         public static IEnumerable<Crosslinker> LoadCrosslinkers(string CrosslinkerLocation)
         {
             using (StreamReader crosslinkers = new StreamReader(CrosslinkerLocation))
@@ -88,6 +96,20 @@ namespace EngineLayer
                     if (lineCount == 1)
                     {
                         continue;
+                    }
+
+                    // CustomCrosslinkers.tsv is edited by hand, so a blank line or a '#' note in it is a
+                    // thing that happens. Both used to reach ParseCrosslinkerFromString and come back as
+                    // an unhandled IndexOutOfRangeException during startup, before any window opened.
+                    if (string.IsNullOrWhiteSpace(line) || line.StartsWith("#", StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    if (line.Split('\t').Length < ExpectedColumnCount)
+                    {
+                        throw new MetaMorpheusException($"Line {lineCount} of {Path.GetFileName(CrosslinkerLocation)} has "
+                            + $"{line.Split('\t').Length} tab-separated column(s); {ExpectedColumnCount} are required. The line was: {line}");
                     }
 
                     yield return ParseCrosslinkerFromString(line);

--- a/MetaMorpheus/EngineLayer/GlobalVariables.cs
+++ b/MetaMorpheus/EngineLayer/GlobalVariables.cs
@@ -1,4 +1,4 @@
-global using obo = Omics.Modifications.IO.obo;
+﻿global using obo = Omics.Modifications.IO.obo;
 using Chemistry;
 using Easy.Common.Extensions;
 using EngineLayer.GlycoSearch;
@@ -46,6 +46,37 @@ namespace EngineLayer
 
         public static List<string> ErrorsReadingMods;
 
+        /// <summary>
+        /// Non-fatal things the user should know about that were noticed while starting up, and that are
+        /// not about reading a modification. Surfaced beside <see cref="ErrorsReadingMods"/> by both front
+        /// ends. Kept separate because that list's name is a promise about what is in it.
+        /// </summary>
+        public static List<string> StartupWarnings { get; private set; } = new List<string>();
+
+        // mzLib keeps these as private constants, so the names are repeated rather than referenced.
+        // They are the shipped files whose banner and header row seed the custom counterparts.
+        private const string EmbeddedProteasesResourceName = "Proteomics.ProteolyticDigestion.proteases.tsv";
+        private const string EmbeddedRnasesResourceName = "Transcriptomics.Digestion.rnases.tsv";
+
+        /// <summary>Template seeded into Mods\CustomModifications.txt and Mods\RnaCustomModifications.txt.</summary>
+        /// <remarks>
+        /// The first line is the title CustomModWindow writes when it creates the file itself, so the GUI's
+        /// append path and this template agree. The rest are '#' banner lines, which the modification format
+        /// treats as comments -- see the shipped Mods.txt, which opens the same way.
+        /// </remarks>
+        private static string CustomModificationsTemplate(string analyte) =>
+            "Custom Modifications" + Environment.NewLine +
+            "################################## " + analyte + " modifications you add are stored here." + Environment.NewLine +
+            "################################## Modifications added through the GUI are appended below this banner." + Environment.NewLine +
+            "################################## One entry per modification, terminated by a line containing only //" + Environment.NewLine +
+            "##################################   ID   <name>            the modification's name" + Environment.NewLine +
+            "##################################   TG   <residues>        target, e.g. S or T or Y" + Environment.NewLine +
+            "##################################   PP   <location>        Anywhere. / N-terminal. / C-terminal. / Peptide N-terminal. / Peptide C-terminal." + Environment.NewLine +
+            "##################################   CF   <formula>         chemical formula, e.g. H1 N1 O2" + Environment.NewLine +
+            "##################################   MM   <mass>            monoisotopic mass, if no formula is given" + Environment.NewLine +
+            "##################################   MT   <type>            the group it is listed under" + Environment.NewLine +
+            "################################## See Mods.txt in this folder for worked examples." + Environment.NewLine;
+
         // File locations
         public static string DataDir { get; private set; }
         public static string UserSpecifiedDataDir { get; set; }
@@ -85,6 +116,8 @@ namespace EngineLayer
             _InvalidAminoAcids = new char[] { 'X', 'B', 'J', 'Z', ':', '|', ';', '[', ']', '{', '}', '(', ')', '+', '-' };
             ExperimentalDesignFileName = "ExperimentalDesign.tsv";
             SeparationTypes = new List<string> { { "HPLC" }, { "CZE" } };
+
+            StartupWarnings = new List<string>();
 
             SetMetaMorpheusVersion();
             SetUpDataDirectory();
@@ -394,6 +427,13 @@ namespace EngineLayer
 
             // load custom crosslinkers
             string customCrosslinkerLocation = Path.Combine(DataDir, @"Data", @"CustomCrosslinkers.tsv");
+
+            // Header row only, with no banner: LoadCrosslinkers skips line 1 and parses every line after
+            // it, so a comment banner here would be read as a crosslinker and throw on its columns.
+            CustomDataFile.EnsureExists(customCrosslinkerLocation,
+                () => CustomDataFile.BannerAndHeaderFromFile(crosslinkerLocation, "Name\t"),
+                "custom crosslinker");
+
             if (File.Exists(customCrosslinkerLocation))
             {
                 AddCrosslinkers(Crosslinker.LoadCrosslinkers(customCrosslinkerLocation));
@@ -411,6 +451,11 @@ namespace EngineLayer
             PsiModDeserialized = Loaders.LoadPsiMod(Path.Combine(DataDir, @"Data", @"PSI-MOD.obo.xml"));
             var formalChargesDictionary = Loaders.GetFormalChargesDictionary(PsiModDeserialized);
             UniprotDeseralized = Loaders.LoadUniprot(Path.Combine(DataDir, @"Data", @"ptmlist.txt"), formalChargesDictionary).ToList();
+
+            // Seeded before the sweep below picks it up. The template is a title line plus a '#' banner,
+            // so it contributes no modifications until the user or the GUI adds one.
+            CustomDataFile.EnsureExists(Path.Combine(DataDir, @"Mods", "CustomModifications.txt"),
+                () => CustomModificationsTemplate("Protein"), "custom modification");
 
             foreach (var modFile in Directory.GetFiles(Path.Combine(DataDir, @"Mods")))
             {
@@ -456,6 +501,8 @@ namespace EngineLayer
             }
 
             var customModsPath = Path.Combine(DataDir, @"Mods", "RnaCustomModifications.txt");
+            CustomDataFile.EnsureExists(customModsPath,
+                () => CustomModificationsTemplate("RNA"), "custom RNA modification");
             if (File.Exists(customModsPath))
             {
                 AddMods(ModificationLoader.ReadModsFromFile(customModsPath, out var errorMods), false, true);
@@ -591,49 +638,30 @@ namespace EngineLayer
 
         private static void LoadDigestionAgents()
         {
+            // Seed first, then load: the template is header-only, so a freshly seeded file contributes
+            // nothing and the two steps are independent. See CustomDataFile for the recipe every custom
+            // file follows.
+            CustomDataFile.EnsureExists(CustomProteasePath,
+                () => CustomDataFile.BannerAndHeaderFrom(typeof(ProteaseDictionary).Assembly,
+                    EmbeddedProteasesResourceName, "Name\t"),
+                "custom protease");
+
+            CustomDataFile.EnsureExists(CustomRnasePath,
+                () => CustomDataFile.BannerAndHeaderFrom(typeof(RnaseDictionary).Assembly,
+                    EmbeddedRnasesResourceName, "Name\t"),
+                "custom rnase");
+
             if (File.Exists(CustomProteasePath))
             {
                 try
                 {
                     var mods = ProteaseDictionary.LoadEmbeddedProteaseMods();
                     var result = ProteaseDictionary.LoadAndMergeCustomProteases(CustomProteasePath, mods);
+                    ReportSkippedCustomEntries(result.Skipped, "protease", CustomProteasePath);
                 }
                 catch (Exception e)
                 {
                     throw new MetaMorpheusException($"Error loading custom proteases with error message: {e.Message}", e);
-                }
-            }
-            else
-            {
-                try
-                {
-                    var assembly = typeof(ProteaseDictionary).Assembly;
-
-                    // private hard-coded string path in MzLib
-                    string EmbeddedProteaseResourceName = "Proteomics.ProteolyticDigestion.proteases.tsv"; 
-
-                    var stream = assembly.GetManifestResourceStream(EmbeddedProteaseResourceName);
-                    var reader = new StreamReader(stream);
-
-                    string fileContent = reader.ReadToEnd();
-                    string[] lines = fileContent.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-
-                    bool foundHeader = false;
-                    using var sw = new StreamWriter(File.Create(CustomProteasePath));
-                    foreach (string line in lines) 
-                    {
-                        if (!foundHeader && !line.StartsWith("#") && line.TrimStart().StartsWith("Name\t"))
-                        {
-                            sw.WriteLine(line);
-                            foundHeader = true;
-                            break;
-                        }
-                        sw.WriteLine(line);
-                    }
-                }
-                catch (Exception e)
-                {
-                    throw new MetaMorpheusException($"Error creating default custom protease file with error message: {e.Message}", e);
                 }
             }
 
@@ -642,45 +670,31 @@ namespace EngineLayer
                 try
                 {
                     var result = RnaseDictionary.LoadAndMergeCustomRnases(CustomRnasePath);
+                    ReportSkippedCustomEntries(result.Skipped, "rnase", CustomRnasePath);
                 }
                 catch (Exception e)
                 {
                     throw new MetaMorpheusException($"Error loading custom rnases with error message: {e.Message}", e);
                 }
             }
-            else
+        }
+
+        /// <summary>
+        /// mzLib refuses to let a custom digestion agent shadow one of its own, and reports the collision
+        /// through <c>CustomDigestionAgentLoadResult.Skipped</c> rather than throwing, specifically so the
+        /// caller can tell the user. Nothing consumed that before, so a user who named a custom protease
+        /// "trypsin" got silence and a protease that was not theirs.
+        /// </summary>
+        private static void ReportSkippedCustomEntries(IReadOnlyList<string> skipped, string kind, string path)
+        {
+            if (skipped == null || skipped.Count == 0)
             {
-                try
-                {
-                    var assembly = typeof(RnaseDictionary).Assembly;
-
-                    // private hard-coded string path in MzLib
-                    string EmbeddedProteaseResourceName = "Transcriptomics.Digestion.rnases.tsv";
-
-                    var stream = assembly.GetManifestResourceStream(EmbeddedProteaseResourceName);
-                    var reader = new StreamReader(stream);
-
-                    string fileContent = reader.ReadToEnd();
-                    string[] lines = fileContent.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-
-                    bool foundHeader = false;
-                    using var sw = new StreamWriter(File.Create(CustomRnasePath));
-                    foreach (string line in lines)
-                    {
-                        if (!foundHeader && !line.StartsWith("#") && line.TrimStart().StartsWith("Name\t"))
-                        {
-                            sw.WriteLine(line);
-                            foundHeader = true;
-                            break;
-                        }
-                        sw.WriteLine(line);
-                    }
-                }
-                catch (Exception e)
-                {
-                    throw new MetaMorpheusException($"Error creating default custom rnase file with error message: {e.Message}", e);
-                }
+                return;
             }
+
+            StartupWarnings.Add($"{skipped.Count} custom {kind}(s) in {Path.GetFileName(path)} were ignored because "
+                + $"a built-in {kind} already uses the same name: {string.Join(", ", skipped.Select(p => "'" + p + "'"))}. "
+                + $"Rename them in {path} if you meant to define your own.");
         }
     }
 }

--- a/MetaMorpheus/EngineLayer/Util/CustomDataFile.cs
+++ b/MetaMorpheus/EngineLayer/Util/CustomDataFile.cs
@@ -1,0 +1,151 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace EngineLayer
+{
+    /// <summary>
+    /// The one place MetaMorpheus creates a data file that the USER is expected to edit.
+    ///
+    /// <para>
+    /// Every such file -- custom proteases, rnases, crosslinkers, modifications, RNA modifications,
+    /// monosaccharides -- follows the same recipe, and it exists because breaking it produced a
+    /// data-loss bug (#2752: a user's edited custom monosaccharides were overwritten on install,
+    /// repair and upgrade). The rules are:
+    /// </para>
+    ///
+    /// <list type="number">
+    ///   <item><description>
+    ///     <b>Never touch a file that exists.</b> Seeding is guarded by <c>!File.Exists</c>. An
+    ///     existing custom file is never rewritten, reformatted, migrated or validated on startup.
+    ///     This is the rule that actually protects the user's work; everything else supports it.
+    ///   </description></item>
+    ///   <item><description>
+    ///     <b>Seed a documented template, not an empty file and not a copy of the data.</b> The
+    ///     template is the shipped sibling's comment banner plus its header row, and no data rows --
+    ///     so the user opens a file that explains its own format and has nothing to delete first.
+    ///     <see cref="BannerAndHeaderFrom(Stream, string)"/> derives exactly that from the shipped file,
+    ///     which keeps the two from drifting.
+    ///   </description></item>
+    ///   <item><description>
+    ///     <b>The template ships inside an assembly, never as a file on disk.</b> It must not appear
+    ///     in <c>Product.wxs</c> as a <c>&lt;File&gt;</c> and must not carry a
+    ///     <c>&lt;None Update ... CopyToOutputDirectory&gt;</c> rule. Those two are what let an
+    ///     installer or a build overwrite the user's copy, and both were removed by the #2752 fix.
+    ///   </description></item>
+    ///   <item><description>
+    ///     <b>Failing to seed is reported, not swallowed.</b> The user gets a
+    ///     <see cref="MetaMorpheusException"/> naming the file, rather than a silently absent one.
+    ///   </description></item>
+    /// </list>
+    ///
+    /// <para>
+    /// One deliberate exception: <c>CustomAminoAcids.txt</c> is seeded with a full A-Z dump of the
+    /// existing residues rather than a bare header, because its whole purpose is letting a user
+    /// adjust the mass of a residue that already exists. A header-only template would make the
+    /// common case harder, not easier. See <c>GlobalVariables.WriteAminoAcidsFile</c>.
+    /// </para>
+    /// </summary>
+    public static class CustomDataFile
+    {
+        /// <summary>
+        /// Creates <paramref name="path"/> from <paramref name="buildTemplate"/> if, and only if, it does
+        /// not already exist. An existing file -- which is to say, one the user may have edited -- is left
+        /// exactly as it is.
+        /// </summary>
+        /// <param name="path">Full path to the custom file.</param>
+        /// <param name="buildTemplate">
+        /// Produces the template contents. Deferred rather than passed as a string so that the cost of
+        /// reading an embedded resource is not paid on every startup, which is the common case where the
+        /// file is already there.
+        /// </param>
+        /// <param name="description">
+        /// What the file is for, in words, used in the exception message when seeding fails.
+        /// </param>
+        public static void EnsureExists(string path, Func<string> buildTemplate, string description)
+        {
+            if (File.Exists(path))
+            {
+                return;
+            }
+
+            try
+            {
+                string directory = Path.GetDirectoryName(path);
+                if (!string.IsNullOrEmpty(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                }
+
+                File.WriteAllText(path, buildTemplate());
+            }
+            catch (Exception e)
+            {
+                throw new MetaMorpheusException(
+                    $"Error creating the default {description} file at {path}: {e.Message}", e);
+            }
+        }
+
+        /// <summary>
+        /// The comment banner and header row of a shipped tab-separated file, with every data row
+        /// dropped -- the template a user should be handed for the custom counterpart.
+        /// </summary>
+        /// <param name="shipped">The shipped file. Disposed by this method.</param>
+        /// <param name="headerPrefix">
+        /// How the header row starts, e.g. <c>"Name\t"</c>. Everything up to and including the first line
+        /// that starts with this (ignoring leading whitespace, and skipping comment lines) is kept.
+        /// </param>
+        public static string BannerAndHeaderFrom(Stream shipped, string headerPrefix)
+        {
+            var template = new StringBuilder();
+
+            using (var reader = new StreamReader(shipped))
+            {
+                string line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    bool isComment = line.StartsWith("#", StringComparison.Ordinal);
+                    bool isHeader = !isComment && line.TrimStart().StartsWith(headerPrefix, StringComparison.Ordinal);
+
+                    if (!isComment && !isHeader)
+                    {
+                        // a data row: the banner is over and the header was already written, or there
+                        // was no header to find
+                        break;
+                    }
+
+                    template.AppendLine(line);
+
+                    if (isHeader)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return template.ToString();
+        }
+
+        /// <summary>
+        /// <see cref="BannerAndHeaderFrom(Stream, string)"/> over an embedded resource.
+        /// </summary>
+        public static string BannerAndHeaderFrom(Assembly assembly, string resourceName, string headerPrefix)
+        {
+            Stream stream = assembly.GetManifestResourceStream(resourceName)
+                ?? throw new MetaMorpheusException(
+                    $"Embedded resource '{resourceName}' was not found in {assembly.GetName().Name}.");
+
+            return BannerAndHeaderFrom(stream, headerPrefix);
+        }
+
+        /// <summary>
+        /// <see cref="BannerAndHeaderFrom(Stream, string)"/> over a shipped file on disk.
+        /// </summary>
+        public static string BannerAndHeaderFromFile(string shippedPath, string headerPrefix)
+        {
+            return BannerAndHeaderFrom(File.OpenRead(shippedPath), headerPrefix);
+        }
+    }
+}

--- a/MetaMorpheus/GUI/MainWindow.xaml.cs
+++ b/MetaMorpheus/GUI/MainWindow.xaml.cs
@@ -1633,6 +1633,13 @@ namespace MetaMorpheusGUI
                 NotificationHandler(null, new StringEventArgs(error, null));
             }
             GlobalVariables.ErrorsReadingMods.Clear();
+
+            // and anything else startup noticed, such as a custom protease that collided with a built-in
+            foreach (var warning in GlobalVariables.StartupWarnings)
+            {
+                NotificationHandler(null, new StringEventArgs(warning, null));
+            }
+            GlobalVariables.StartupWarnings.Clear();
         }
 
         private void UpdateOutputFolderTextbox()

--- a/MetaMorpheus/Test/CustomDataFileTests.cs
+++ b/MetaMorpheus/Test/CustomDataFileTests.cs
@@ -161,9 +161,18 @@ namespace Test
         /// Every custom file is seeded by startup, and none of them is a file the installer or the build
         /// also writes -- so listing them here is the inventory that a new custom file has to join.
         /// </summary>
+        /// <remarks>
+        /// Runs the startup itself rather than reading whatever the process happens to have lying around.
+        /// Test order is not fixed, and CustomAminoAcidsTest deletes CustomAminoAcids.txt when it finishes
+        /// ("Delete so it doesn't crash the next time") without seeding it again -- so asserting on ambient
+        /// state passes or fails depending on what ran first. Re-running SetUpGlobalVariables is what the
+        /// application does on launch, and is the pattern LoadDigestionAgentTest already uses to put the
+        /// globals back.
+        /// </remarks>
         [Test]
         public static void EveryKnownCustomFileIsSeededByStartup()
         {
+            GlobalVariables.SetUpGlobalVariables();
             string d = GlobalVariables.DataDir;
             var expected = new Dictionary<string, string>
             {

--- a/MetaMorpheus/Test/CustomDataFileTests.cs
+++ b/MetaMorpheus/Test/CustomDataFileTests.cs
@@ -1,0 +1,230 @@
+using EngineLayer;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Test
+{
+    /// <summary>
+    /// The custom-file contract, enforced. Every file a user is expected to edit must be seeded with a
+    /// template when it is absent and left strictly alone when it is present -- that second half is the
+    /// one that matters, and the one #2752 broke.
+    /// </summary>
+    [TestFixture]
+    public static class CustomDataFileTests
+    {
+        private static string _dir;
+
+        [SetUp]
+        public static void SetUp()
+        {
+            _dir = Path.Combine(TestContext.CurrentContext.TestDirectory, "CustomDataFileTests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+        }
+
+        [TearDown]
+        public static void TearDown()
+        {
+            if (Directory.Exists(_dir)) Directory.Delete(_dir, true);
+        }
+
+        /// <summary>
+        /// The rule the whole class exists for: an existing file is never touched, whatever is in it --
+        /// including content the template would never have produced.
+        /// </summary>
+        [Test]
+        public static void EnsureExists_NeverRewritesAnExistingFile()
+        {
+            string path = Path.Combine(_dir, "already_here.tsv");
+            const string userContent = "the user typed this\tand meant it\n";
+            File.WriteAllText(path, userContent);
+
+            CustomDataFile.EnsureExists(path, () => "TEMPLATE THAT MUST NOT APPEAR", "test");
+
+            Assert.That(File.ReadAllText(path), Is.EqualTo(userContent));
+        }
+
+        /// <summary>
+        /// An empty file is still the user's file. Seeding it would silently replace a file someone had
+        /// truncated on purpose, and "it was empty so I overwrote it" is exactly the reasoning that loses
+        /// data.
+        /// </summary>
+        [Test]
+        public static void EnsureExists_TreatsAnEmptyExistingFileAsTheUsers()
+        {
+            string path = Path.Combine(_dir, "empty.tsv");
+            File.WriteAllText(path, string.Empty);
+
+            CustomDataFile.EnsureExists(path, () => "TEMPLATE", "test");
+
+            Assert.That(File.ReadAllText(path), Is.Empty);
+        }
+
+        [Test]
+        public static void EnsureExists_SeedsWhenAbsent_AndCreatesTheDirectory()
+        {
+            string path = Path.Combine(_dir, "nested", "seeded.tsv");
+            Assert.That(File.Exists(path), Is.False, "precondition");
+
+            CustomDataFile.EnsureExists(path, () => "Name\tValue", "test");
+
+            Assert.That(File.ReadAllText(path), Is.EqualTo("Name\tValue"));
+        }
+
+        /// <summary>
+        /// The template must not be built when the file already exists -- reading an embedded resource on
+        /// every startup for a file that is already there is waste, and the deferred Func is the only
+        /// thing preventing it.
+        /// </summary>
+        [Test]
+        public static void EnsureExists_DoesNotBuildTheTemplateWhenTheFileExists()
+        {
+            string path = Path.Combine(_dir, "present.tsv");
+            File.WriteAllText(path, "x");
+            bool built = false;
+
+            CustomDataFile.EnsureExists(path, () => { built = true; return "y"; }, "test");
+
+            Assert.That(built, Is.False);
+        }
+
+        [Test]
+        public static void EnsureExists_ReportsAFailureRatherThanLeavingTheFileMissing()
+        {
+            string path = Path.Combine(_dir, "boom.tsv");
+
+            var ex = Assert.Throws<MetaMorpheusException>(() =>
+                CustomDataFile.EnsureExists(path, () => throw new InvalidOperationException("no template"), "test thing"));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.Message, Does.Contain("test thing"), "the message has to say which file");
+                Assert.That(ex.Message, Does.Contain(path));
+                Assert.That(File.Exists(path), Is.False);
+            });
+        }
+
+        /// <summary>
+        /// The template is the shipped file's banner and header with the data dropped. Keeping the banner
+        /// is the point: the user opens a file that documents its own format, which is what makes the
+        /// custom-protease template worth copying everywhere else.
+        /// </summary>
+        [Test]
+        public static void BannerAndHeader_KeepsCommentsAndHeader_AndDropsEveryDataRow()
+        {
+            string shipped = Path.Combine(_dir, "shipped.tsv");
+            File.WriteAllLines(shipped, new[]
+            {
+                "# what this file is",
+                "# how to edit it",
+                "Name\tSites\tMass",
+                "Trypsin\tKR\t0",
+                "LysC\tK\t0",
+            });
+
+            string template = CustomDataFile.BannerAndHeaderFromFile(shipped, "Name\t");
+
+            var lines = template.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
+            Assert.Multiple(() =>
+            {
+                Assert.That(lines, Is.EqualTo(new[] { "# what this file is", "# how to edit it", "Name\tSites\tMass" }));
+                Assert.That(template, Does.Not.Contain("Trypsin"), "a data row would become a fake custom entry");
+                Assert.That(template, Does.Not.Contain("LysC"));
+            });
+        }
+
+        /// <summary>
+        /// Every shipped file whose custom counterpart we seed must actually contain the header we look
+        /// for. If a header is renamed upstream this silently produces a data-row-free but header-free
+        /// template, and the user's first custom entry lands in a file the parser rejects.
+        /// </summary>
+        [Test]
+        public static void BannerAndHeader_FindsTheHeaderInTheRealShippedCrosslinkerFile()
+        {
+            string shipped = Path.Combine(GlobalVariables.DataDir, "Data", "Crosslinkers.tsv");
+            Assume.That(File.Exists(shipped), "shipped crosslinker file is required for this test");
+
+            string template = CustomDataFile.BannerAndHeaderFromFile(shipped, "Name\t");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(template, Does.StartWith("Name\t"));
+                Assert.That(template.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries).Length,
+                    Is.EqualTo(1), "LoadCrosslinkers skips only line 1, so this template must be exactly the header");
+                Assert.That(template, Does.Not.Contain("DSSO"), "no shipped crosslinker may leak into the custom file");
+            });
+        }
+
+        /// <summary>
+        /// Every custom file is seeded by startup, and none of them is a file the installer or the build
+        /// also writes -- so listing them here is the inventory that a new custom file has to join.
+        /// </summary>
+        [Test]
+        public static void EveryKnownCustomFileIsSeededByStartup()
+        {
+            string d = GlobalVariables.DataDir;
+            var expected = new Dictionary<string, string>
+            {
+                ["custom proteases"] = GlobalVariables.CustomProteasePath,
+                ["custom rnases"] = GlobalVariables.CustomRnasePath,
+                ["custom monosaccharides"] = GlobalVariables.CustomMonosaccharidePath,
+                ["custom crosslinkers"] = Path.Combine(d, "Data", "CustomCrosslinkers.tsv"),
+                ["custom modifications"] = Path.Combine(d, "Mods", "CustomModifications.txt"),
+                ["custom RNA modifications"] = Path.Combine(d, "Mods", "RnaCustomModifications.txt"),
+                ["custom amino acids"] = Path.Combine(d, "CustomAminoAcids", "CustomAminoAcids.txt"),
+            };
+
+            var missing = expected.Where(p => !File.Exists(p.Value)).Select(p => p.Key).ToList();
+            Assert.That(missing, Is.Empty, "not seeded by SetUpGlobalVariables: " + string.Join(", ", missing));
+        }
+
+        /// <summary>
+        /// A hand-edited crosslinker file picks up blank lines and notes. Both used to reach
+        /// ParseCrosslinkerFromString and surface as an unhandled IndexOutOfRangeException during startup,
+        /// before any window opened, with nothing naming the file.
+        /// </summary>
+        [Test]
+        public static void LoadCrosslinkers_SkipsBlankAndCommentLines()
+        {
+            string path = Path.Combine(_dir, "CustomCrosslinkers.tsv");
+            File.WriteAllLines(path, new[]
+            {
+                "Name\tCrosslinkAminoAcid\tCrosslinkerAminoAcid2\tCleavable\tDissociationType\tCrosslinkerTotalMass\tCrosslinkerShortMass\tCrosslinkerLongMass\tQuenchMassH2O\tQuenchMassNH2\tQuenchMassTris",
+                "# a note the user left themselves",
+                "",
+                "MyLinker\tK\tK\tT\tCID|HCD\t158.0038\t54.01056\t85.982635\t176.0143\t175.0303\t279.0777",
+                "   ",
+            });
+
+            var loaded = Crosslinker.LoadCrosslinkers(path).ToList();
+
+            Assert.That(loaded.Select(p => p.CrosslinkerName), Is.EqualTo(new[] { "MyLinker" }));
+        }
+
+        /// <summary>
+        /// A genuinely malformed row still has to fail -- but as a message naming the file and the line,
+        /// not as IndexOutOfRangeException from inside a LINQ iterator.
+        /// </summary>
+        [Test]
+        public static void LoadCrosslinkers_NamesTheFileAndLineForAShortRow()
+        {
+            string path = Path.Combine(_dir, "CustomCrosslinkers.tsv");
+            File.WriteAllLines(path, new[]
+            {
+                "Name\tCrosslinkAminoAcid\tCrosslinkerAminoAcid2\tCleavable\tDissociationType\tCrosslinkerTotalMass\tCrosslinkerShortMass\tCrosslinkerLongMass\tQuenchMassH2O\tQuenchMassNH2\tQuenchMassTris",
+                "OopsOnlyThree\tK\tK",
+            });
+
+            var ex = Assert.Throws<MetaMorpheusException>(() => Crosslinker.LoadCrosslinkers(path).ToList());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.Message, Does.Contain("CustomCrosslinkers.tsv"));
+                Assert.That(ex.Message, Does.Contain("Line 2"));
+                Assert.That(ex.Message, Does.Contain("OopsOnlyThree"), "the offending line is what the user has to fix");
+            });
+        }
+    }
+}

--- a/MetaMorpheus/Test/CustomFileCollisionTests.cs
+++ b/MetaMorpheus/Test/CustomFileCollisionTests.cs
@@ -1,0 +1,131 @@
+using EngineLayer;
+using NUnit.Framework;
+using Proteomics.ProteolyticDigestion;
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace Test
+{
+    /// <summary>
+    /// mzLib refuses to let a custom digestion agent shadow one of its own and reports it through
+    /// CustomDigestionAgentLoadResult.Skipped rather than throwing, so that the caller can tell the user.
+    /// Nothing consumed that before, so a user who named a custom protease after a built-in got silence
+    /// and a protease that was not theirs. These cover the reporting, and the embedded-resource half of
+    /// the template builder.
+    /// </summary>
+    [TestFixture]
+    public static class CustomFileCollisionTests
+    {
+        private static string _backup;
+        private static bool _hadFile;
+
+        [SetUp]
+        public static void SetUp()
+        {
+            _hadFile = File.Exists(GlobalVariables.CustomProteasePath);
+            if (_hadFile)
+            {
+                _backup = GlobalVariables.CustomProteasePath + ".bak";
+                File.Copy(GlobalVariables.CustomProteasePath, _backup, true);
+            }
+        }
+
+        [TearDown]
+        public static void TearDown()
+        {
+            if (_hadFile && _backup != null && File.Exists(_backup))
+            {
+                File.Copy(_backup, GlobalVariables.CustomProteasePath, true);
+                File.Delete(_backup);
+            }
+            else if (!_hadFile && File.Exists(GlobalVariables.CustomProteasePath))
+            {
+                File.Delete(GlobalVariables.CustomProteasePath);
+            }
+
+            _backup = null;
+            GlobalVariables.SetUpGlobalVariables();
+        }
+
+        /// <summary>
+        /// A custom protease that reuses a built-in's name is refused by mzLib -- silently, until now. The
+        /// user has to be told, because the protease they get is not the one they wrote.
+        /// </summary>
+        [Test]
+        public static void ACustomProteaseThatShadowsABuiltInIsReportedToTheUser()
+        {
+            string shadowed = ProteaseDictionary.Dictionary.Keys.First();
+
+            File.WriteAllLines(GlobalVariables.CustomProteasePath, new[]
+            {
+                "Name\tMotif\tSpecificity\tPSI-MS Accession\tPSI-MS Name\tCleavage Modification",
+                $"{shadowed}\tX|\tfull\t\t\t",
+            });
+
+            GlobalVariables.SetUpGlobalVariables();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(GlobalVariables.StartupWarnings.Any(w => w.Contains(shadowed)),
+                    Is.True, "the shadowed name has to be named: " + string.Join(" | ", GlobalVariables.StartupWarnings));
+                Assert.That(GlobalVariables.StartupWarnings.Any(w => w.Contains("proteases_custom.tsv")),
+                    Is.True, "and the file to fix it in");
+                // the built-in definition is the one that survives, which is the reason to warn at all
+                Assert.That(ProteaseDictionary.Dictionary[shadowed].DigestionMotifs.Any(m => m.InducingCleavage == "X"),
+                    Is.False, "the custom entry must not have replaced the built-in");
+            });
+        }
+
+        /// <summary>
+        /// The counterpart: a custom protease with a name of its own is not reported. Without this, the
+        /// assertion above would be satisfied by warning unconditionally, which is worse than silence.
+        /// </summary>
+        [Test]
+        public static void ACustomProteaseWithItsOwnNameIsNotReported()
+        {
+            File.WriteAllLines(GlobalVariables.CustomProteasePath, new[]
+            {
+                "Name\tMotif\tSpecificity\tPSI-MS Accession\tPSI-MS Name\tCleavage Modification",
+                "NotAShadowingName_ForTest\tX|\tfull\t\t\t",
+            });
+
+            GlobalVariables.SetUpGlobalVariables();
+
+            Assert.That(GlobalVariables.StartupWarnings.Any(w => w.Contains("could not be") || w.Contains("ignored")),
+                Is.False, "nothing to report: " + string.Join(" | ", GlobalVariables.StartupWarnings));
+        }
+
+        /// <summary>
+        /// The seeded custom-protease template is derived from mzLib's embedded proteases.tsv, which is
+        /// where the "banner plus header, no data rows" shape this whole policy copies comes from.
+        /// </summary>
+        [Test]
+        public static void TheProteaseTemplateComesFromMzLibsEmbeddedFile_AndCarriesNoProteases()
+        {
+            string template = CustomDataFile.BannerAndHeaderFrom(typeof(ProteaseDictionary).Assembly,
+                "Proteomics.ProteolyticDigestion.proteases.tsv", "Name\t");
+
+            var lines = template.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
+            Assert.Multiple(() =>
+            {
+                Assert.That(lines.Last(), Does.StartWith("Name\t"), "the header is the last line kept");
+                Assert.That(lines.Count(l => l.StartsWith("#")), Is.GreaterThan(0),
+                    "the banner is the part that makes the template worth seeding");
+                Assert.That(lines.Any(l => l.StartsWith("Arg-C\t")), Is.False,
+                    "a shipped protease in the custom file would look like the user's own");
+            });
+        }
+
+        [Test]
+        public static void AMissingEmbeddedTemplateIsReportedByName()
+        {
+            var ex = Assert.Throws<MetaMorpheusException>(() =>
+                CustomDataFile.BannerAndHeaderFrom(typeof(ProteaseDictionary).Assembly,
+                    "Proteomics.ProteolyticDigestion.this.resource.does.not.exist.tsv", "Name\t"));
+
+            Assert.That(ex!.Message, Does.Contain("this.resource.does.not.exist.tsv"));
+        }
+    }
+}

--- a/MetaMorpheus/Test/GuiTests/LoadDigestionAgentTest.cs
+++ b/MetaMorpheus/Test/GuiTests/LoadDigestionAgentTest.cs
@@ -408,7 +408,10 @@ namespace Test.GuiTests
 
                 var ex = Assert.Throws<MetaMorpheusException>(() => InvokeLoadDigestionAgents());
 
-                Assert.That(ex!.Message, Does.Contain("Error creating default custom protease file with error message:"));
+                // Seeding moved to CustomDataFile.EnsureExists, which names the file it could not create.
+                // The old message said only "custom protease file", which did not tell the user where to look.
+                Assert.That(ex!.Message, Does.Contain("custom protease"));
+                Assert.That(ex.Message, Does.Contain(customPath), "the message has to name the file that failed");
                 Assert.That(ex.InnerException, Is.Not.Null);
             }
             finally
@@ -453,7 +456,10 @@ namespace Test.GuiTests
 
                 var ex = Assert.Throws<MetaMorpheusException>(() => InvokeLoadDigestionAgents());
 
-                Assert.That(ex!.Message, Does.Contain("Error creating default custom rnase file with error message:"));
+                // Seeding moved to CustomDataFile.EnsureExists, which names the file it could not create.
+                // The old message said only "custom rnase file", which did not tell the user where to look.
+                Assert.That(ex!.Message, Does.Contain("custom rnase"));
+                Assert.That(ex.Message, Does.Contain(customPath), "the message has to name the file that failed");
                 Assert.That(ex.InnerException, Is.Not.Null);
             }
             finally


### PR DESCRIPTION
🤖 MetaMorpheus ships seven files a user is expected to edit, and every one of them was handled differently. #2752 is what that costs: a `CopyToOutputDirectory` rule plus an installer component overwrote a user's edited custom monosaccharides on install, repair and upgrade. That was fixed for monosaccharides alone. This applies the same contract to the rest, and adds a test that a new custom file has to join.

## The recipe

Documented on `CustomDataFile`, and taken from the **custom-protease seeding**, which already did the right thing and is the model for the others:

1. **Never touch a file that exists.** Seeding is guarded by `!File.Exists`. An empty file counts as the user's — truncating one on purpose is a thing people do, and *"it was empty so I replaced it"* is how data gets lost.
2. **Seed a documented template**: the shipped sibling's comment banner plus its header row, and **no data rows**. The user opens a file that explains its own format and has nothing to delete first. `BannerAndHeaderFrom` derives it from the shipped file, so the template cannot drift from what it documents.
3. **The template ships inside an assembly.** Never a `<File>` in `Product.wxs`, never a `<None Update ... CopyToOutputDirectory>` rule. Those two are exactly what let a build or an installer overwrite the user's copy, and both were what #2752 removed.
4. **A failure to seed is reported**, naming the file, rather than swallowed.

## What changes, per file

| File | Before | After |
|---|---|---|
| `proteases_custom.tsv` | 30 lines of inline seeding | calls the helper |
| `rnase_custom.tsv` | 30 near-identical lines | calls the helper |
| `CustomCrosslinkers.tsv` | **never seeded** | seeded with a template |
| `CustomModifications.txt` | **never seeded** | seeded with a template |
| `RnaCustomModifications.txt` | **never seeded** | seeded with a template |
| `MonosaccharidesCustom.tsv` | already canonical | unchanged |
| `CustomAminoAcids.txt` | full A–Z dump | unchanged, documented as the deliberate exception |

The two digestion-agent blocks were near-identical copies of each other, and carried the mzLib resource names inline annotated `// private hard-coded string path in MzLib`. Those are now named constants.

The three that were never seeded required a user to know both the filename and the format before they could start. The **crosslinker template is the header row alone**, deliberately: `LoadCrosslinkers` skips only line 1 and parses everything after it, so a banner there would be read as a crosslinker.

`CustomAminoAcids.txt` is left as it is and the reason is written down. It seeds a full A–Z dump of the existing residues rather than a header because its purpose is *adjusting a residue that already exists*; a bare header would make the common case harder, not easier.

## Two things found on the way

**`LoadCrosslinkers` crashed on a hand-edited file.** A blank line or a `#` note in `CustomCrosslinkers.tsv` reached `ParseCrosslinkerFromString` and came back as an unhandled `IndexOutOfRangeException` during startup — before any window opened, with nothing naming the file. I hit this by appending a comment to the seeded file to check it would not be overwritten. Blank and comment lines are now skipped, and a genuinely short row throws a `MetaMorpheusException` naming the file, the line number and the line.

**mzLib's collision reports had no consumer.** `LoadAndMergeCustomProteases` and `LoadAndMergeCustomRnases` refuse to let a custom entry shadow a built-in and report it through `CustomDigestionAgentLoadResult.Skipped` *rather than throwing, specifically so the caller can tell the user* — mzLib documents that as a guarantee. Both results were discarded. Someone who named a custom protease `trypsin` got silence and a protease that was not theirs. Those now reach the user through `GlobalVariables.StartupWarnings`, surfaced beside `ErrorsReadingMods` by both the GUI and the CLI. It is a separate list because `ErrorsReadingMods`' name is a promise about what is in it.

## Verification

Against a real `DataDir`, not a mock:

- All seven custom files are seeded on a clean start.
- After appending a sentinel to each and restarting, **zero were rewritten**.
- Protein modification, RNA modification and crosslinker counts are **identical** whether the custom files are freshly seeded, user-edited, or deleted and reseeded — so the templates contribute nothing. (4325 / 35 / 6 in all three states, with 0 errors and 0 warnings.)

`CustomDataFileTests` pins the contract: an existing file is never rewritten, an empty one counts as the user's, the template is not even built when the file is present, a seeding failure names the file, the banner/header extraction drops every data row, the real shipped crosslinker file yields a one-line template, every known custom file is seeded by startup, and the crosslinker loader tolerates blank and comment lines while naming the file and line for a malformed row.

55 digestion-agent, custom-file and crosslink tests pass. The solution builds with 0 errors.

## Two tests changed, and why

`TestCustomProteaseCreationCatchIsHitWhenCustomPathIsDirectory` and its rnase twin asserted the exact text `"Error creating default custom protease file with error message:"`. The new message names the file that could not be created, which the old one did not. Both assertions now check for that instead — they are stronger than before, not weaker.

## Not in this PR

`RnaCustomModifications.txt`, `CustomModifications.txt` and `CustomCrosslinkers.tsv` live under `Mods\` and `Data\`, whose WiX components carry `<RemoveFolder On="both"/>` — removal on *install* as well as uninstall. MSI only removes an empty directory, so this is latent rather than a live bug, and none of those files has a `<File>` component that could overwrite it. But it is the same "the installer owns this folder, the user's file is in it" arrangement that became #2752, and it deserves its own issue rather than being bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UbCbEbFSY76K9CnjeLZff2
