### PR TITLE
Let a user pick individual glycans instead of a whole glycan database

### DIFF
--- a/MetaMorpheus/CMD/CMD.csproj
+++ b/MetaMorpheus/CMD/CMD.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.588" />
+    <PackageReference Include="mzLib" Version="1.0.589" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />
     <PackageReference Include="System.Data.SQLite.Core" Version="1.0.118" />

--- a/MetaMorpheus/CMD/Program.cs
+++ b/MetaMorpheus/CMD/Program.cs
@@ -207,6 +207,16 @@ namespace MetaMorpheusCommandLine
                 }
             }
 
+            // anything else startup noticed, such as a custom protease that collided with a built-in
+            foreach (var warning in GlobalVariables.StartupWarnings)
+            {
+                if (settings.Verbosity == CommandLineSettings.VerbosityType.minimal || settings.Verbosity == CommandLineSettings.VerbosityType.normal)
+                {
+                    Console.WriteLine(warning);
+                }
+            }
+            GlobalVariables.StartupWarnings.Clear();
+
             List<(string, MetaMorpheusTask)> taskList = new List<(string, MetaMorpheusTask)>();
 
             var tasks = settings.Tasks.ToList();

--- a/MetaMorpheus/EngineLayer/CrosslinkSearch/Crosslinker.cs
+++ b/MetaMorpheus/EngineLayer/CrosslinkSearch/Crosslinker.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using MassSpectrometry;
 using System.Globalization;
@@ -75,6 +76,13 @@ namespace EngineLayer
             return cleaveDissociationTypes;
         }
 
+        /// <summary>
+        /// Columns in a crosslinker tsv row: Name, CrosslinkAminoAcid, CrosslinkerAminoAcid2, Cleavable,
+        /// DissociationType, CrosslinkerTotalMass, CrosslinkerShortMass, CrosslinkerLongMass, QuenchMassH2O,
+        /// QuenchMassNH2, QuenchMassTris.
+        /// </summary>
+        private const int ExpectedColumnCount = 11;
+
         public static IEnumerable<Crosslinker> LoadCrosslinkers(string CrosslinkerLocation)
         {
             using (StreamReader crosslinkers = new StreamReader(CrosslinkerLocation))
@@ -88,6 +96,20 @@ namespace EngineLayer
                     if (lineCount == 1)
                     {
                         continue;
+                    }
+
+                    // CustomCrosslinkers.tsv is edited by hand, so a blank line or a '#' note in it is a
+                    // thing that happens. Both used to reach ParseCrosslinkerFromString and come back as
+                    // an unhandled IndexOutOfRangeException during startup, before any window opened.
+                    if (string.IsNullOrWhiteSpace(line) || line.StartsWith("#", StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    if (line.Split('\t').Length < ExpectedColumnCount)
+                    {
+                        throw new MetaMorpheusException($"Line {lineCount} of {Path.GetFileName(CrosslinkerLocation)} has "
+                            + $"{line.Split('\t').Length} tab-separated column(s); {ExpectedColumnCount} are required. The line was: {line}");
                     }
 
                     yield return ParseCrosslinkerFromString(line);

--- a/MetaMorpheus/EngineLayer/EngineLayer.csproj
+++ b/MetaMorpheus/EngineLayer/EngineLayer.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.588" />
+    <PackageReference Include="mzLib" Version="1.0.589" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />

--- a/MetaMorpheus/EngineLayer/EngineLayer.csproj
+++ b/MetaMorpheus/EngineLayer/EngineLayer.csproj
@@ -20,10 +20,16 @@
 
   <ItemGroup>
     <None Remove="Glycan_Mods\MonosaccharidesCustom.tsv" />
+    <None Remove="Glycan_Mods\OGlycan_Custom.gdb" />
   </ItemGroup>
   
+  <!-- Templates for the user-editable custom files. Embedded, deliberately: they must NOT carry a
+       CopyToOutputDirectory rule and must NOT appear in Product.wxs as a <File>, because either one
+       lets a build or an installer overwrite the copy the user has edited. That was #2752. The whole
+       recipe is written down on EngineLayer\Util\CustomDataFile.cs. -->
   <ItemGroup>
     <EmbeddedResource Include="Glycan_Mods\MonosaccharidesCustom.tsv" />
+    <EmbeddedResource Include="Glycan_Mods\OGlycan_Custom.gdb" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MetaMorpheus/EngineLayer/EngineLayer.csproj
+++ b/MetaMorpheus/EngineLayer/EngineLayer.csproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <None Remove="Glycan_Mods\MonosaccharidesCustom.tsv" />
     <None Remove="Glycan_Mods\OGlycan_Custom.gdb" />
+    <None Remove="Glycan_Mods\NGlycan_Custom.gdb" />
   </ItemGroup>
   
   <!-- Templates for the user-editable custom files. Embedded, deliberately: they must NOT carry a
@@ -30,6 +31,7 @@
   <ItemGroup>
     <EmbeddedResource Include="Glycan_Mods\MonosaccharidesCustom.tsv" />
     <EmbeddedResource Include="Glycan_Mods\OGlycan_Custom.gdb" />
+    <EmbeddedResource Include="Glycan_Mods\NGlycan_Custom.gdb" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MetaMorpheus/EngineLayer/GlobalVariables.cs
+++ b/MetaMorpheus/EngineLayer/GlobalVariables.cs
@@ -1,4 +1,4 @@
-global using obo = Omics.Modifications.IO.obo;
+﻿global using obo = Omics.Modifications.IO.obo;
 using Chemistry;
 using Easy.Common.Extensions;
 using EngineLayer.GlycoSearch;
@@ -46,6 +46,37 @@ namespace EngineLayer
 
         public static List<string> ErrorsReadingMods;
 
+        /// <summary>
+        /// Non-fatal things the user should know about that were noticed while starting up, and that are
+        /// not about reading a modification. Surfaced beside <see cref="ErrorsReadingMods"/> by both front
+        /// ends. Kept separate because that list's name is a promise about what is in it.
+        /// </summary>
+        public static List<string> StartupWarnings { get; private set; } = new List<string>();
+
+        // mzLib keeps these as private constants, so the names are repeated rather than referenced.
+        // They are the shipped files whose banner and header row seed the custom counterparts.
+        private const string EmbeddedProteasesResourceName = "Proteomics.ProteolyticDigestion.proteases.tsv";
+        private const string EmbeddedRnasesResourceName = "Transcriptomics.Digestion.rnases.tsv";
+
+        /// <summary>Template seeded into Mods\CustomModifications.txt and Mods\RnaCustomModifications.txt.</summary>
+        /// <remarks>
+        /// The first line is the title CustomModWindow writes when it creates the file itself, so the GUI's
+        /// append path and this template agree. The rest are '#' banner lines, which the modification format
+        /// treats as comments -- see the shipped Mods.txt, which opens the same way.
+        /// </remarks>
+        private static string CustomModificationsTemplate(string analyte) =>
+            "Custom Modifications" + Environment.NewLine +
+            "################################## " + analyte + " modifications you add are stored here." + Environment.NewLine +
+            "################################## Modifications added through the GUI are appended below this banner." + Environment.NewLine +
+            "################################## One entry per modification, terminated by a line containing only //" + Environment.NewLine +
+            "##################################   ID   <name>            the modification's name" + Environment.NewLine +
+            "##################################   TG   <residues>        target, e.g. S or T or Y" + Environment.NewLine +
+            "##################################   PP   <location>        Anywhere. / N-terminal. / C-terminal. / Peptide N-terminal. / Peptide C-terminal." + Environment.NewLine +
+            "##################################   CF   <formula>         chemical formula, e.g. H1 N1 O2" + Environment.NewLine +
+            "##################################   MM   <mass>            monoisotopic mass, if no formula is given" + Environment.NewLine +
+            "##################################   MT   <type>            the group it is listed under" + Environment.NewLine +
+            "################################## See Mods.txt in this folder for worked examples." + Environment.NewLine;
+
         // File locations
         public static string DataDir { get; private set; }
         public static string UserSpecifiedDataDir { get; set; }
@@ -85,6 +116,8 @@ namespace EngineLayer
             _InvalidAminoAcids = new char[] { 'X', 'B', 'J', 'Z', ':', '|', ';', '[', ']', '{', '}', '(', ')', '+', '-' };
             ExperimentalDesignFileName = "ExperimentalDesign.tsv";
             SeparationTypes = new List<string> { { "HPLC" }, { "CZE" } };
+
+            StartupWarnings = new List<string>();
 
             SetMetaMorpheusVersion();
             SetUpDataDirectory();
@@ -394,6 +427,13 @@ namespace EngineLayer
 
             // load custom crosslinkers
             string customCrosslinkerLocation = Path.Combine(DataDir, @"Data", @"CustomCrosslinkers.tsv");
+
+            // Header row only, with no banner: LoadCrosslinkers skips line 1 and parses every line after
+            // it, so a comment banner here would be read as a crosslinker and throw on its columns.
+            CustomDataFile.EnsureExists(customCrosslinkerLocation,
+                () => CustomDataFile.BannerAndHeaderFromFile(crosslinkerLocation, "Name\t"),
+                "custom crosslinker");
+
             if (File.Exists(customCrosslinkerLocation))
             {
                 AddCrosslinkers(Crosslinker.LoadCrosslinkers(customCrosslinkerLocation));
@@ -411,6 +451,11 @@ namespace EngineLayer
             PsiModDeserialized = Loaders.LoadPsiMod(Path.Combine(DataDir, @"Data", @"PSI-MOD.obo.xml"));
             var formalChargesDictionary = Loaders.GetFormalChargesDictionary(PsiModDeserialized);
             UniprotDeseralized = Loaders.LoadUniprot(Path.Combine(DataDir, @"Data", @"ptmlist.txt"), formalChargesDictionary).ToList();
+
+            // Seeded before the sweep below picks it up. The template is a title line plus a '#' banner,
+            // so it contributes no modifications until the user or the GUI adds one.
+            CustomDataFile.EnsureExists(Path.Combine(DataDir, @"Mods", "CustomModifications.txt"),
+                () => CustomModificationsTemplate("Protein"), "custom modification");
 
             foreach (var modFile in Directory.GetFiles(Path.Combine(DataDir, @"Mods")))
             {
@@ -456,6 +501,8 @@ namespace EngineLayer
             }
 
             var customModsPath = Path.Combine(DataDir, @"Mods", "RnaCustomModifications.txt");
+            CustomDataFile.EnsureExists(customModsPath,
+                () => CustomModificationsTemplate("RNA"), "custom RNA modification");
             if (File.Exists(customModsPath))
             {
                 AddMods(ModificationLoader.ReadModsFromFile(customModsPath, out var errorMods), false, true);
@@ -591,49 +638,30 @@ namespace EngineLayer
 
         private static void LoadDigestionAgents()
         {
+            // Seed first, then load: the template is header-only, so a freshly seeded file contributes
+            // nothing and the two steps are independent. See CustomDataFile for the recipe every custom
+            // file follows.
+            CustomDataFile.EnsureExists(CustomProteasePath,
+                () => CustomDataFile.BannerAndHeaderFrom(typeof(ProteaseDictionary).Assembly,
+                    EmbeddedProteasesResourceName, "Name\t"),
+                "custom protease");
+
+            CustomDataFile.EnsureExists(CustomRnasePath,
+                () => CustomDataFile.BannerAndHeaderFrom(typeof(RnaseDictionary).Assembly,
+                    EmbeddedRnasesResourceName, "Name\t"),
+                "custom rnase");
+
             if (File.Exists(CustomProteasePath))
             {
                 try
                 {
                     var mods = ProteaseDictionary.LoadEmbeddedProteaseMods();
                     var result = ProteaseDictionary.LoadAndMergeCustomProteases(CustomProteasePath, mods);
+                    ReportSkippedCustomEntries(result.Skipped, "protease", CustomProteasePath);
                 }
                 catch (Exception e)
                 {
                     throw new MetaMorpheusException($"Error loading custom proteases with error message: {e.Message}", e);
-                }
-            }
-            else
-            {
-                try
-                {
-                    var assembly = typeof(ProteaseDictionary).Assembly;
-
-                    // private hard-coded string path in MzLib
-                    string EmbeddedProteaseResourceName = "Proteomics.ProteolyticDigestion.proteases.tsv"; 
-
-                    var stream = assembly.GetManifestResourceStream(EmbeddedProteaseResourceName);
-                    var reader = new StreamReader(stream);
-
-                    string fileContent = reader.ReadToEnd();
-                    string[] lines = fileContent.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-
-                    bool foundHeader = false;
-                    using var sw = new StreamWriter(File.Create(CustomProteasePath));
-                    foreach (string line in lines) 
-                    {
-                        if (!foundHeader && !line.StartsWith("#") && line.TrimStart().StartsWith("Name\t"))
-                        {
-                            sw.WriteLine(line);
-                            foundHeader = true;
-                            break;
-                        }
-                        sw.WriteLine(line);
-                    }
-                }
-                catch (Exception e)
-                {
-                    throw new MetaMorpheusException($"Error creating default custom protease file with error message: {e.Message}", e);
                 }
             }
 
@@ -642,45 +670,31 @@ namespace EngineLayer
                 try
                 {
                     var result = RnaseDictionary.LoadAndMergeCustomRnases(CustomRnasePath);
+                    ReportSkippedCustomEntries(result.Skipped, "rnase", CustomRnasePath);
                 }
                 catch (Exception e)
                 {
                     throw new MetaMorpheusException($"Error loading custom rnases with error message: {e.Message}", e);
                 }
             }
-            else
+        }
+
+        /// <summary>
+        /// mzLib refuses to let a custom digestion agent shadow one of its own, and reports the collision
+        /// through <c>CustomDigestionAgentLoadResult.Skipped</c> rather than throwing, specifically so the
+        /// caller can tell the user. Nothing consumed that before, so a user who named a custom protease
+        /// "trypsin" got silence and a protease that was not theirs.
+        /// </summary>
+        private static void ReportSkippedCustomEntries(IReadOnlyList<string> skipped, string kind, string path)
+        {
+            if (skipped == null || skipped.Count == 0)
             {
-                try
-                {
-                    var assembly = typeof(RnaseDictionary).Assembly;
-
-                    // private hard-coded string path in MzLib
-                    string EmbeddedProteaseResourceName = "Transcriptomics.Digestion.rnases.tsv";
-
-                    var stream = assembly.GetManifestResourceStream(EmbeddedProteaseResourceName);
-                    var reader = new StreamReader(stream);
-
-                    string fileContent = reader.ReadToEnd();
-                    string[] lines = fileContent.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-
-                    bool foundHeader = false;
-                    using var sw = new StreamWriter(File.Create(CustomRnasePath));
-                    foreach (string line in lines)
-                    {
-                        if (!foundHeader && !line.StartsWith("#") && line.TrimStart().StartsWith("Name\t"))
-                        {
-                            sw.WriteLine(line);
-                            foundHeader = true;
-                            break;
-                        }
-                        sw.WriteLine(line);
-                    }
-                }
-                catch (Exception e)
-                {
-                    throw new MetaMorpheusException($"Error creating default custom rnase file with error message: {e.Message}", e);
-                }
+                return;
             }
+
+            StartupWarnings.Add($"{skipped.Count} custom {kind}(s) in {Path.GetFileName(path)} were ignored because "
+                + $"a built-in {kind} already uses the same name: {string.Join(", ", skipped.Select(p => "'" + p + "'"))}. "
+                + $"Rename them in {path} if you meant to define your own.");
         }
     }
 }

--- a/MetaMorpheus/EngineLayer/GlobalVariables.cs
+++ b/MetaMorpheus/EngineLayer/GlobalVariables.cs
@@ -58,6 +58,9 @@ namespace EngineLayer
         private const string EmbeddedProteasesResourceName = "Proteomics.ProteolyticDigestion.proteases.tsv";
         private const string EmbeddedRnasesResourceName = "Transcriptomics.Digestion.rnases.tsv";
 
+        /// <summary>Template seeded into the user's OGlycan_Custom.gdb. Embedded in EngineLayer.</summary>
+        private const string EmbeddedCustomOGlycanResourceName = "EngineLayer.Glycan_Mods.OGlycan_Custom.gdb";
+
         /// <summary>Template seeded into Mods\CustomModifications.txt and Mods\RnaCustomModifications.txt.</summary>
         /// <remarks>
         /// The first line is the title CustomModWindow writes when it creates the file itself, so the GUI's
@@ -83,6 +86,18 @@ namespace EngineLayer
         public static string CustomProteasePath => Path.Combine(DataDir, "proteases_custom.tsv");
         public static string CustomRnasePath => Path.Combine(DataDir, "rnase_custom.tsv");
         public static string CustomMonosaccharidePath => Path.Combine(DataDir, "MonosaccharidesCustom.tsv");
+
+        /// <summary>
+        /// The user's own O-glycan database, offered in the GlycoSearch task beside the shipped ones.
+        /// </summary>
+        /// <remarks>
+        /// At the DataDir root rather than under Glycan_Mods\OGlycan\, for the same reason
+        /// MonosaccharidesCustom.tsv is: Product.wxs gives Glycan_Mods and both of its subfolders a
+        /// &lt;RemoveFolder On="both"/&gt;, so the installer owns those folders and a user's file in one of
+        /// them is not somewhere we should be putting it. The cost is that it is not picked up by the
+        /// directory sweep in LoadGlycans and has to be added to OGlycanDatabasePaths by name.
+        /// </remarks>
+        public static string CustomOGlycanDatabasePath => Path.Combine(DataDir, "OGlycan_Custom.gdb");
 
         public static bool StopLoops { get; set; }
         public static string MetaMorpheusVersion { get; private set; }
@@ -525,12 +540,27 @@ namespace EngineLayer
             GlycanDatabase.EnsureCustomMonosaccharideFileExists(CustomMonosaccharidePath);
             GlycanDatabase.LoadCustomMonosaccharides(CustomMonosaccharidePath);
 
+            // Seed the user's own database before anything reads it. It is header-less and its template is
+            // all comment lines, so a freshly seeded file contributes no glycans and the two steps below are
+            // independent of it. See CustomDataFile for the recipe every custom file follows.
+            CustomDataFile.EnsureExists(CustomOGlycanDatabasePath,
+                () => CustomDataFile.EmbeddedText(typeof(GlobalVariables).Assembly, EmbeddedCustomOGlycanResourceName),
+                "custom O-glycan database");
+
             OGlycanDatabasePaths = new List<string>();
             NGlycanDatabasePaths = new List<string>();
 
             foreach (var glycanFile in Directory.GetFiles(Path.Combine(DataDir, @"Glycan_Mods", @"OGlycan")))
             {
                 OGlycanDatabasePaths.Add(glycanFile);
+            }
+
+            // Added by name because it deliberately does not live in the swept folder -- see
+            // CustomOGlycanDatabasePath. Guarded so that a seeding failure earlier cannot put a path to a
+            // file that is not there into the list the task window offers.
+            if (File.Exists(CustomOGlycanDatabasePath))
+            {
+                OGlycanDatabasePaths.Add(CustomOGlycanDatabasePath);
             }
 
             foreach (var glycanFile in Directory.GetFiles(Path.Combine(DataDir, @"Glycan_Mods", @"NGlycan")))

--- a/MetaMorpheus/EngineLayer/GlobalVariables.cs
+++ b/MetaMorpheus/EngineLayer/GlobalVariables.cs
@@ -129,6 +129,28 @@ namespace EngineLayer
         public static List<string> OGlycanDatabasePaths { get; private set; }
         public static List<string> NGlycanDatabasePaths { get; private set; }
 
+        /// <summary>
+        /// The O-glycans of every database in <see cref="OGlycanDatabasePaths"/>, keyed by file name and
+        /// ordered by mass.
+        /// </summary>
+        /// <remarks>
+        /// <see cref="AllModsKnown"/> also holds every glycan, but flattens all databases together and so
+        /// cannot say which file a glycan came from. The task window groups its glycan tree by database, so
+        /// it needs the provenance this keeps. Keyed by file name -- not full path -- because that is what
+        /// the task parameters persist and what the database combo boxes already display.
+        ///
+        /// Loaded with ToGenerateIons:false, exactly like the AllModsKnown population below, so these are
+        /// for DISPLAY ONLY: their Ions are null, which also makes Glycan.Equals throw on them. The search
+        /// re-loads its glycans with ions; see GlycoSearchEngine.
+        /// </remarks>
+        public static Dictionary<string, List<Glycan>> OGlycansByDatabase { get; private set; }
+
+        /// <summary>
+        /// The N-glycans of every database in <see cref="NGlycanDatabasePaths"/>, keyed by file name and
+        /// ordered by mass. Display-only, for the same reasons as <see cref="OGlycansByDatabase"/>.
+        /// </summary>
+        public static Dictionary<string, List<Glycan>> NGlycansByDatabase { get; private set; }
+
         public static void SetUpGlobalVariables()
         {
             AcceptedDatabaseFormats = new List<string> { ".fasta", ".fa", ".xml", ".msp", ".msl" };
@@ -588,9 +610,16 @@ namespace EngineLayer
 
             //Add Glycan mod into AllModsKnownDictionary, currently this is for MetaDraw.
             //The reason why not include Glycan into modification database is for users to apply their own database.
+            OGlycansByDatabase = new Dictionary<string, List<Glycan>>();
+            NGlycansByDatabase = new Dictionary<string, List<Glycan>>();
+
             foreach (var path in OGlycanDatabasePaths)
             {
-                var oGlycans = GlycanDatabase.LoadGlycan(path, false, true);
+                var oGlycans = GlycanDatabase.LoadGlycan(path, false, true).ToList();
+                // Recorded per database, because the flattening below loses which file each glycan came from.
+                // Enumerate the LOADED OBJECTS, not the file's lines: a structure-format database can yield
+                // several Glycan objects from one line (Glycan.Struct2Glycan).
+                OGlycansByDatabase[Path.GetFileName(path)] = oGlycans.OrderBy(g => g.Mass).ToList();
                 foreach (var glycan in oGlycans)
                 {
                     if (!AllModsKnownDictionary.ContainsKey(glycan.IdWithMotif))
@@ -602,7 +631,8 @@ namespace EngineLayer
             }
             foreach (var path in NGlycanDatabasePaths)
             {
-                var nGlycans = GlycanDatabase.LoadGlycan(path, false, false);
+                var nGlycans = GlycanDatabase.LoadGlycan(path, false, false).ToList();
+                NGlycansByDatabase[Path.GetFileName(path)] = nGlycans.OrderBy(g => g.Mass).ToList();
                 foreach (var glycan in nGlycans)
                 {
                     if (!AllModsKnownDictionary.ContainsKey(glycan.IdWithMotif))

--- a/MetaMorpheus/EngineLayer/GlobalVariables.cs
+++ b/MetaMorpheus/EngineLayer/GlobalVariables.cs
@@ -61,6 +61,9 @@ namespace EngineLayer
         /// <summary>Template seeded into the user's OGlycan_Custom.gdb. Embedded in EngineLayer.</summary>
         private const string EmbeddedCustomOGlycanResourceName = "EngineLayer.Glycan_Mods.OGlycan_Custom.gdb";
 
+        /// <summary>Template seeded into the user's NGlycan_Custom.gdb. Embedded in EngineLayer.</summary>
+        private const string EmbeddedCustomNGlycanResourceName = "EngineLayer.Glycan_Mods.NGlycan_Custom.gdb";
+
         /// <summary>Template seeded into Mods\CustomModifications.txt and Mods\RnaCustomModifications.txt.</summary>
         /// <remarks>
         /// The first line is the title CustomModWindow writes when it creates the file itself, so the GUI's
@@ -98,6 +101,12 @@ namespace EngineLayer
         /// directory sweep in LoadGlycans and has to be added to OGlycanDatabasePaths by name.
         /// </remarks>
         public static string CustomOGlycanDatabasePath => Path.Combine(DataDir, "OGlycan_Custom.gdb");
+
+        /// <summary>
+        /// The user's own N-glycan database, offered in the GlycoSearch task beside the shipped ones.
+        /// At the DataDir root for the same reason as <see cref="CustomOGlycanDatabasePath"/>.
+        /// </summary>
+        public static string CustomNGlycanDatabasePath => Path.Combine(DataDir, "NGlycan_Custom.gdb");
 
         public static bool StopLoops { get; set; }
         public static string MetaMorpheusVersion { get; private set; }
@@ -547,6 +556,10 @@ namespace EngineLayer
                 () => CustomDataFile.EmbeddedText(typeof(GlobalVariables).Assembly, EmbeddedCustomOGlycanResourceName),
                 "custom O-glycan database");
 
+            CustomDataFile.EnsureExists(CustomNGlycanDatabasePath,
+                () => CustomDataFile.EmbeddedText(typeof(GlobalVariables).Assembly, EmbeddedCustomNGlycanResourceName),
+                "custom N-glycan database");
+
             OGlycanDatabasePaths = new List<string>();
             NGlycanDatabasePaths = new List<string>();
 
@@ -566,6 +579,11 @@ namespace EngineLayer
             foreach (var glycanFile in Directory.GetFiles(Path.Combine(DataDir, @"Glycan_Mods", @"NGlycan")))
             {
                 NGlycanDatabasePaths.Add(glycanFile);
+            }
+
+            if (File.Exists(CustomNGlycanDatabasePath))
+            {
+                NGlycanDatabasePaths.Add(CustomNGlycanDatabasePath);
             }
 
             //Add Glycan mod into AllModsKnownDictionary, currently this is for MetaDraw.

--- a/MetaMorpheus/EngineLayer/Glycan_Mods/NGlycan_Custom.gdb
+++ b/MetaMorpheus/EngineLayer/Glycan_Mods/NGlycan_Custom.gdb
@@ -1,0 +1,66 @@
+# ============================================================================
+# CUSTOM N-GLYCAN DATABASE
+# ============================================================================
+# This file is yours. MetaMorpheus creates it once, if it is missing, and then
+# never touches it again -- not on install, not on repair, not on upgrade.
+#
+# It is offered in the N-glycan database list of the GlycoSearch task alongside
+# the databases MetaMorpheus ships, so anything you add below can be searched
+# without replacing or editing a shipped file.
+#
+# Lines starting with '#' are comments and are ignored. Blank lines are ignored
+# too, so you may space the file out however you like. Indentation before '#'
+# is allowed.
+#
+# ============================================================================
+# FILE FORMAT -- one glycan per line, and ONE format for the whole file
+# ============================================================================
+# MetaMorpheus infers the format from the FIRST non-comment line and then reads
+# the entire file that way. Do not mix the two in one file.
+#
+# COMPOSITION format (what NGlycan.gdb uses, and what most published N-glycan
+# lists are distributed in). Counts only, no branching:
+#
+#     HexNAc(2)Hex(5)
+#     HexNAc(4)Hex(5)Fuc(1)NeuAc(1)
+#
+#   Names must be ones MetaMorpheus knows:
+#
+#     Hex        HexNAc     NeuAc      NeuGc      Fuc
+#     Phospho    Sulfo      Na         Ac         Xylose      Kdn
+#
+# STRUCTURE format. Nested parentheses are the tree, and each letter is one
+# monosaccharide written with its SINGLE-CHARACTER CODE:
+#
+#     (N(N(H(H(H)))))
+#
+#     H  Hex        N  HexNAc     A  NeuAc      G  NeuGc     F  Fuc
+#     P  Phospho    S  Sulfo      Y  Na         C  Ac        X  Xylose
+#     K  Kdn
+#
+#   Structure format carries the branching, so the Y-ion series is generated
+#   from the tree rather than inferred from the counts. Prefer it when you know
+#   the topology.
+#
+# Every glycan you list is searched on both N-X-S and N-X-T sequons; you do not
+# write the motif.
+#
+# ============================================================================
+# MONOSACCHARIDES MetaMorpheus DOES NOT SHIP WITH
+# ============================================================================
+# Declare them in MonosaccharidesCustom.tsv first -- it sits next to this file
+# in the same folder and documents its own format. Once declared, that
+# monosaccharide's name and single-character code are legal here, in both
+# formats. A name or code this file does not recognize is an error naming the
+# line, not a glycan silently given the wrong mass.
+#
+# ============================================================================
+# EXAMPLES (remove the leading '#' to enable, or write your own)
+# ============================================================================
+# HexNAc(2)Hex(5)
+# HexNAc(2)Hex(3)Fuc(1)
+# HexNAc(4)Hex(5)Fuc(1)NeuAc(1)
+#
+# ============================================================================
+# YOUR N-GLYCANS (add them below this line)
+# ============================================================================

--- a/MetaMorpheus/EngineLayer/Glycan_Mods/OGlycan_Custom.gdb
+++ b/MetaMorpheus/EngineLayer/Glycan_Mods/OGlycan_Custom.gdb
@@ -1,0 +1,60 @@
+# ============================================================================
+# CUSTOM O-GLYCAN DATABASE
+# ============================================================================
+# This file is yours. MetaMorpheus creates it once, if it is missing, and then
+# never touches it again -- not on install, not on repair, not on upgrade.
+#
+# It is offered in the O-glycan database list of the GlycoSearch task alongside
+# the databases MetaMorpheus ships, so anything you add below can be searched
+# without replacing or editing a shipped file.
+#
+# Lines starting with '#' are comments and are ignored. Blank lines are ignored
+# too, so you may space the file out however you like. Indentation before '#'
+# is allowed.
+#
+# ============================================================================
+# FILE FORMAT -- one glycan per line, and ONE format for the whole file
+# ============================================================================
+# MetaMorpheus infers the format from the FIRST non-comment line and then reads
+# the entire file that way. Do not mix the two in one file.
+#
+# STRUCTURE format (what OGlycan.gdb uses; preferred for O-glycans, because the
+# branching is what localization and child-ion generation work from):
+#
+#     (N(H(A)))
+#
+#   Nested parentheses are the tree. Each letter is one monosaccharide, written
+#   with its SINGLE-CHARACTER CODE:
+#
+#     H  Hex        N  HexNAc     A  NeuAc      G  NeuGc     F  Fuc
+#     P  Phospho    S  Sulfo      Y  Na         C  Ac        X  Xylose
+#     K  Kdn
+#
+# COMPOSITION format (what the shipped .txt databases use). Counts only, no
+# branching:
+#
+#     HexNAc(1)Hex(1)NeuAc(1)
+#
+# Every glycan you list is searched on both serine and threonine; you do not
+# write the residue.
+#
+# ============================================================================
+# MONOSACCHARIDES MetaMorpheus DOES NOT SHIP WITH
+# ============================================================================
+# Declare them in MonosaccharidesCustom.tsv first -- it sits next to this file
+# in the same folder and documents its own format. Once declared, that
+# monosaccharide's name and single-character code are legal here, in both
+# formats. A code this file does not recognize is an error naming the line, not
+# a glycan silently given the wrong mass.
+#
+# ============================================================================
+# EXAMPLES (remove the leading '#' to enable, or write your own)
+# ============================================================================
+# (N)
+# (N(H))
+# (N(H(A)))
+# (N(H(A))(A))
+#
+# ============================================================================
+# YOUR O-GLYCANS (add them below this line)
+# ============================================================================

--- a/MetaMorpheus/EngineLayer/GlycoSearch/GlycanDatabase.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/GlycanDatabase.cs
@@ -397,9 +397,16 @@ namespace EngineLayer
                 // Parsed exactly as LoadStructureGlycan would parse it: Struct2Glycan is the only thing that
                 // knows whether the nesting describes a tree it can actually build.
                 List<Glycan> parsed = Glycan.Struct2Glycan(entry, 1, isOGlycan);
-                if (parsed == null || parsed.Count == 0)
+
+                // "()" parses happily into a glycan of nothing, whose mass is zero. Searching for it is
+                // meaningless and it would widen every box it landed in, so it is refused here rather than
+                // left for the user to wonder about. The empty case is folded in: Struct2Glycan either
+                // throws or yields glycans, so "nothing came back" and "nothing in what came back" are the
+                // same answer to the user.
+                if (parsed == null || parsed.Count == 0 || parsed.All(g => g.Kind.Sum(count => (int)count) == 0))
                 {
-                    throw new MetaMorpheusException($"Could not add the glycan \"{entry}\": it did not parse into any glycan.");
+                    throw new MetaMorpheusException(
+                        $"Could not add the glycan \"{entry}\": it contains no monosaccharides.");
                 }
             }
             catch (MetaMorpheusException)
@@ -428,6 +435,7 @@ namespace EngineLayer
             CaptureCollection names = match.Groups["name"].Captures;
             CaptureCollection counts = match.Groups["count"].Captures;
             HashSet<string> seen = new HashSet<string>(StringComparer.Ordinal);
+            int total = 0;
 
             for (int i = 0; i < names.Count; i++)
             {
@@ -449,6 +457,14 @@ namespace EngineLayer
                     throw new MetaMorpheusException(
                         $"Could not add the glycan \"{entry}\": the count for '{name}' must be a whole number between 0 and 255.");
                 }
+                total += count;
+            }
+
+            // Same reason as the structure case: a composition that totals nothing is a zero-mass glycan.
+            if (total == 0)
+            {
+                throw new MetaMorpheusException(
+                    $"Could not add the glycan \"{entry}\": it contains no monosaccharides.");
             }
         }
 

--- a/MetaMorpheus/EngineLayer/GlycoSearch/GlycanDatabase.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/GlycanDatabase.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace EngineLayer
 {
@@ -21,13 +22,22 @@ namespace EngineLayer
         /// <returns> A glycan object collection </returns>
         public static IEnumerable<Glycan> LoadGlycan(string filePath, bool ToGenerateIons, bool IsOGlycan)
         {
+            // The format is inferred from the first DATA line; it is never declared. Comment and blank lines
+            // are skipped while sniffing because a documented database -- such as the seeded custom one --
+            // opens with a '#' banner, and judging the format from that banner routes the whole file to the
+            // wrong parser. A file with no data line is a legal empty database: either parser yields nothing
+            // for it, so which one is chosen does not matter.
             bool isKind = true;
             using (StreamReader lines = new StreamReader(filePath))
             {
                 while(lines.Peek() != -1)
                 {
                     string line = lines.ReadLine();
-                    if (!line.Contains("HexNAc"))  // use the first line to determine the format (kind / structure) of glycan database.
+                    if (IsCommentOrBlank(line))
+                    {
+                        continue;
+                    }
+                    if (!line.Contains("HexNAc"))  // use the first data line to determine the format (kind / structure) of glycan database.
                     {
                         isKind = false;
                     }
@@ -233,6 +243,262 @@ namespace EngineLayer
             }
         }
 
+
+        /// <summary>
+        /// The two ways a glycan database line can be written. A database file is read entirely as one or
+        /// the other -- the format is inferred from its first data line and never declared -- so an entry
+        /// being added has to agree with whatever is already in the file.
+        /// </summary>
+        public enum GlycanLineFormat
+        {
+            /// <summary>Nested single-character codes, e.g. <c>(N(H(A)))</c>. What OGlycan.gdb uses.</summary>
+            Structure,
+
+            /// <summary>Name-and-count, e.g. <c>HexNAc(2)Hex(5)</c>. What NGlycan.gdb uses.</summary>
+            Composition
+        }
+
+        /// <summary>
+        /// Validates one glycan the user has typed and appends it to their custom glycan database, in the
+        /// format that database is already written in.
+        ///
+        /// <para>
+        /// Return contract, and it differs deliberately from <see cref="PersistCustomMonosaccharide"/>:
+        /// this method throws <see cref="MetaMorpheusException"/> for every failure and returns normally
+        /// only once the glycan is on disk. There is no registered-but-not-saved middle state to report,
+        /// because a glycan database is not held in memory the way a monosaccharide is -- the search reads
+        /// the file when the engine is built. Which is also why an entry added now is picked up by a search
+        /// run in this same session; only MetaDraw's glycan list waits for a restart.
+        /// </para>
+        /// </summary>
+        /// <param name="glycanText">The glycan, as typed: a structure or a composition.</param>
+        /// <param name="databasePath">The custom database to append to. Created if it is not there.</param>
+        /// <param name="isOGlycan">
+        /// Whether this is an O-glycan database, so the entry is validated the same way the search will
+        /// read it and a glycan that parses here cannot fail to parse there.
+        /// </param>
+        public static void PersistCustomGlycan(string glycanText, string databasePath, bool isOGlycan)
+        {
+            string entry = (glycanText ?? string.Empty).Trim();
+            string fileName = Path.GetFileName(databasePath);
+
+            if (entry.Length == 0)
+            {
+                throw new MetaMorpheusException("Could not add the glycan: no glycan was given.");
+            }
+            if (IsCommentOrBlank(entry))
+            {
+                throw new MetaMorpheusException(
+                    $"Could not add the glycan: \"{entry}\" is a comment, not a glycan. Lines beginning with '#' are ignored when the database is read.");
+            }
+            if (entry.IndexOfAny(new[] { '\t', '\n', '\r' }) >= 0)
+            {
+                throw new MetaMorpheusException(
+                    "Could not add the glycan: one glycan per line, with no tabs or line breaks in it.");
+            }
+
+            GlycanLineFormat format = ValidateGlycanLine(entry, fileName, isOGlycan);
+
+            // The format is a property of the whole file, so an entry that disagreed with what is already
+            // there would silently change how every OTHER line in the file is read.
+            GlycanLineFormat? existingFormat = FormatOfExistingEntries(databasePath);
+            if (existingFormat.HasValue && existingFormat.Value != format)
+            {
+                throw new MetaMorpheusException(
+                    $"Could not add the glycan to '{fileName}': that file is written in {existingFormat.Value.ToString().ToLowerInvariant()} format " +
+                    $"and \"{entry}\" is {format.ToString().ToLowerInvariant()} format. A glycan database is read entirely as one format or the other, " +
+                    "so the two cannot be mixed in one file. Convert the entry, or keep it in a database of its own.");
+            }
+
+            if (ContainsEntry(databasePath, entry))
+            {
+                throw new MetaMorpheusException($"Could not add the glycan: '{fileName}' already contains \"{entry}\".");
+            }
+
+            try
+            {
+                string directory = Path.GetDirectoryName(databasePath);
+                if (!string.IsNullOrEmpty(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                }
+
+                if (!File.Exists(databasePath))
+                {
+                    File.WriteAllLines(databasePath, new[] { entry });
+                }
+                else
+                {
+                    // AppendAllLines never checks whether the file already ends in a newline. A hand-edited
+                    // .gdb very often does not -- NGlycan_ForNoSearch.gdb in the test data does not -- and
+                    // without this the new glycan is glued onto the end of the last one, corrupting both.
+                    string existing = File.ReadAllText(databasePath);
+                    if (existing.Length > 0 && !existing.EndsWith("\n"))
+                    {
+                        File.AppendAllText(databasePath, Environment.NewLine);
+                    }
+                    File.AppendAllLines(databasePath, new[] { entry });
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new MetaMorpheusException($"Could not save the glycan to '{databasePath}': {ex.Message}", ex);
+            }
+        }
+
+        /// <summary>
+        /// Works out which format a glycan line is written in, and checks that the parser the search will
+        /// use actually accepts it -- so a glycan the user is told was added cannot fail to load later.
+        /// </summary>
+        /// <exception cref="MetaMorpheusException">The line is neither format, or does not parse.</exception>
+        public static GlycanLineFormat ValidateGlycanLine(string entry, string fileName, bool isOGlycan)
+        {
+            if (entry.StartsWith("(", StringComparison.Ordinal))
+            {
+                ValidateStructureEntry(entry, fileName, isOGlycan);
+                return GlycanLineFormat.Structure;
+            }
+
+            ValidateCompositionEntry(entry);
+            return GlycanLineFormat.Composition;
+        }
+
+        private static void ValidateStructureEntry(string entry, string fileName, bool isOGlycan)
+        {
+            // The same character check the loader runs, so an unknown monosaccharide code is rejected here
+            // rather than being silently counted as zero mass at search time.
+            ValidateStructureLine(entry, fileName, 1);
+
+            int depth = 0;
+            foreach (char c in entry)
+            {
+                if (c == '(')
+                {
+                    depth++;
+                }
+                else if (c == ')')
+                {
+                    depth--;
+                    if (depth < 0)
+                    {
+                        throw new MetaMorpheusException(
+                            $"Could not add the glycan \"{entry}\": the parentheses do not balance -- a ')' closes a branch that was never opened.");
+                    }
+                }
+            }
+            if (depth != 0)
+            {
+                throw new MetaMorpheusException(
+                    $"Could not add the glycan \"{entry}\": the parentheses do not balance -- {depth} branch(es) are left open.");
+            }
+
+            try
+            {
+                // Parsed exactly as LoadStructureGlycan would parse it: Struct2Glycan is the only thing that
+                // knows whether the nesting describes a tree it can actually build.
+                List<Glycan> parsed = Glycan.Struct2Glycan(entry, 1, isOGlycan);
+                if (parsed == null || parsed.Count == 0)
+                {
+                    throw new MetaMorpheusException($"Could not add the glycan \"{entry}\": it did not parse into any glycan.");
+                }
+            }
+            catch (MetaMorpheusException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                throw new MetaMorpheusException($"Could not add the glycan \"{entry}\": {ex.Message}", ex);
+            }
+        }
+
+        private static void ValidateCompositionEntry(string entry)
+        {
+            // Name(count), repeated -- e.g. HexNAc(2)Hex(5)NeuAc(1). Checked here rather than by handing it
+            // to String2Kind, which throws KeyNotFoundException on an unknown name and quietly accepts a
+            // trailing unclosed group.
+            Match match = Regex.Match(entry, @"^(?:(?<name>[A-Za-z][A-Za-z0-9]*)\((?<count>\d+)\))+$");
+            if (!match.Success)
+            {
+                throw new MetaMorpheusException(
+                    $"Could not add the glycan \"{entry}\": it is neither a structure -- which starts with '(', e.g. (N(H(A))) -- " +
+                    "nor a composition, which is a name and a count repeated, e.g. HexNAc(2)Hex(5).");
+            }
+
+            CaptureCollection names = match.Groups["name"].Captures;
+            CaptureCollection counts = match.Groups["count"].Captures;
+            HashSet<string> seen = new HashSet<string>(StringComparer.Ordinal);
+
+            for (int i = 0; i < names.Count; i++)
+            {
+                string name = names[i].Value;
+                if (!Glycan.NameCharDic.ContainsKey(name))
+                {
+                    string allowed = string.Join(", ", Glycan.NameCharDic.Keys);
+                    throw new MetaMorpheusException(
+                        $"Could not add the glycan \"{entry}\": '{name}' is not a monosaccharide MetaMorpheus knows. Known: {allowed}. " +
+                        "A monosaccharide it does not ship with must be declared in MonosaccharidesCustom.tsv first.");
+                }
+                if (!seen.Add(name))
+                {
+                    throw new MetaMorpheusException(
+                        $"Could not add the glycan \"{entry}\": '{name}' appears more than once. Give each monosaccharide a single total count.");
+                }
+                if (!byte.TryParse(counts[i].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out byte count))
+                {
+                    throw new MetaMorpheusException(
+                        $"Could not add the glycan \"{entry}\": the count for '{name}' must be a whole number between 0 and 255.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// The format the entries already in a database are written in, or null when it holds no entries
+        /// yet -- a file that is missing, or one that is all banner, which is what a freshly seeded custom
+        /// database is.
+        /// </summary>
+        private static GlycanLineFormat? FormatOfExistingEntries(string databasePath)
+        {
+            if (!File.Exists(databasePath))
+            {
+                return null;
+            }
+
+            foreach (string line in File.ReadLines(databasePath))
+            {
+                if (IsCommentOrBlank(line))
+                {
+                    continue;
+                }
+                return line.TrimStart().StartsWith("(", StringComparison.Ordinal)
+                    ? GlycanLineFormat.Structure
+                    : GlycanLineFormat.Composition;
+            }
+
+            return null;
+        }
+
+        /// <summary>Whether the database already holds this exact glycan, so it is not added twice.</summary>
+        private static bool ContainsEntry(string databasePath, string entry)
+        {
+            if (!File.Exists(databasePath))
+            {
+                return false;
+            }
+
+            foreach (string line in File.ReadLines(databasePath))
+            {
+                // Split on tab first: the shipped .txt databases carry name and mass columns after the
+                // glycan, and it is the glycan that has to be unique.
+                if (!IsCommentOrBlank(line) && line.Split('\t')[0].Trim().Equals(entry, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         /// <summary>
         /// Ensure the MonosaccharidesCustom.tsv exists in the directory. If the file is missing, 
         /// write the embedded full 85-line documented template—instructions, column spec, the built-in name/code table,
@@ -292,7 +558,17 @@ namespace EngineLayer
                 int id = 1;
                 while (lines.Peek() != -1)
                 {
-                    string line = lines.ReadLine().Split('\t').First();
+                    string rawLine = lines.ReadLine();
+
+                    // Skipped explicitly rather than left to the Hex test below: a comment that quotes a
+                    // composition -- which the documented template does, to show the format -- would otherwise
+                    // reach String2Kind and die on a dictionary lookup naming neither the file nor the line.
+                    if (IsCommentOrBlank(rawLine))
+                    {
+                        continue;
+                    }
+
+                    string line = rawLine.Split('\t').First();
 
                     if (!(line.Contains("HexNAc") || line.Contains("Hex"))) // Make sure the line is a glycan line. The line should contain HexNAc or Hex.
                     {
@@ -376,14 +652,24 @@ namespace EngineLayer
             using (StreamReader glycans = new StreamReader(filePath))
             {
                 int id = 1;
+                int lineNumber = 0;
                 while (glycans.Peek() != -1)
                 {
                     string line = glycans.ReadLine();   // Read the line from the database file. Ex. (N(H(A))(A))
+                    lineNumber++;
+
+                    // A '#' banner or a blank spacer is not a glycan. Without this, the seeded template --
+                    // and any database a user has annotated -- reaches ValidateStructureLine and throws on
+                    // the '#' itself during startup, before any window opens.
+                    if (IsCommentOrBlank(line))
+                    {
+                        continue;
+                    }
 
                     // ValidateStructureLine catches characters the parser would otherwise silently
                     // miscount as zero-mass. It consults the live monosaccharide registry, so any
                     // codes registered via MonosaccharidesCustom.tsv are accepted here too.
-                    ValidateStructureLine(line.Trim());
+                    ValidateStructureLine(line.Trim(), filePath, lineNumber);
 
                     // For each glycan, two versions will be generated:
                     // For O-glycan, one modified on serine (S), and the other on threonine (T).
@@ -415,7 +701,7 @@ namespace EngineLayer
         // MonosaccharidesCustom.tsv). Struct2Glycan silently miscounts unknown chars (no entry in
         // CharMassDic), so we pre-validate to give the user a clear error instead of a silently
         // wrong glycan mass.
-        private static void ValidateStructureLine(string trimmedLine)
+        private static void ValidateStructureLine(string trimmedLine, string filePath, int lineNumber)
         {
             foreach (char c in trimmedLine)
             {
@@ -423,8 +709,10 @@ namespace EngineLayer
                 if (!Glycan.CharMassDic.ContainsKey(c))
                 {
                     string allowed = string.Concat(Glycan.CharMassDic.Keys);
-                    throw new FormatException(
-                        $"Unrecognized character '{c}' in glycan structure. Allowed: parentheses and one of {allowed}.");
+                    throw new MetaMorpheusException(
+                        $"Could not parse glycan structure in '{Path.GetFileName(filePath)}' at line {lineNumber}: \"{trimmedLine}\". " +
+                        $"Unrecognized character '{c}'. Allowed: parentheses and one of {allowed}. " +
+                        "A monosaccharide MetaMorpheus does not ship with must be declared in MonosaccharidesCustom.tsv first.");
                 }
             }
         }

--- a/MetaMorpheus/EngineLayer/GlycoSearch/GlycoSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/GlycoSearchEngine.cs
@@ -23,6 +23,7 @@ namespace EngineLayer.GlycoSearch
         private readonly bool OxoniumIonFilter; // To filt Oxonium Ion before searching a spectrum as glycopeptides. If we filter spectrum, it must contain oxonium ions such as 204 (HexNAc). 
         private readonly string _oglycanDatabase;
         private readonly string _nglycanDatabase;
+        private readonly List<(string, string)> _selectedGlycans; // (database file name, glycan IdWithMotif); null/empty = whole database
         private readonly GlycanBox[] GlycanBoxes; // GlycanBoxes for glycan search.
 
         private readonly Tolerance PrecusorSearchMode;
@@ -45,7 +46,8 @@ namespace EngineLayer.GlycoSearch
         // The constructor for GlycoSearchEngine, we can load the parameter for the searhcing like mode, topN, maxOGlycanNum, oxoniumIonFilter, datsbase, etc.
         public GlycoSearchEngine(List<GlycoSpectralMatch>[] globalCsms, Ms2ScanWithSpecificMass[] listOfSortedms2Scans, List<PeptideWithSetModifications> peptideIndex,
             List<int>[] fragmentIndex, List<int>[] secondFragmentIndex, int currentPartition, CommonParameters commonParameters, List<(string fileName, CommonParameters fileSpecificParameters)> fileSpecificParameters,
-             string oglycanDatabase, string nglycanDatabase, GlycoSearchType glycoSearchType, int glycoSearchTopNum, int maxOGlycanNum, bool oxoniumIonFilter, List<string> nestedIds)
+             string oglycanDatabase, string nglycanDatabase, GlycoSearchType glycoSearchType, int glycoSearchTopNum, int maxOGlycanNum, bool oxoniumIonFilter, List<string> nestedIds,
+             List<(string, string)> selectedGlycans = null)
             : base(null, listOfSortedms2Scans, peptideIndex, fragmentIndex, currentPartition, commonParameters, fileSpecificParameters, new OpenSearchMode(), 0, nestedIds)
         {
             this.GlobalGsms = globalCsms;
@@ -55,6 +57,7 @@ namespace EngineLayer.GlycoSearch
             this.OxoniumIonFilter = oxoniumIonFilter;
             this._oglycanDatabase = oglycanDatabase;
             this._nglycanDatabase = nglycanDatabase;
+            this._selectedGlycans = selectedGlycans;
             SecondFragmentIndex = secondFragmentIndex;
             PrecusorSearchMode = commonParameters.PrecursorMassTolerance;
             ProductSearchMode = new SinglePpmAroundZeroSearchMode(20); //For Oxonium ion only
@@ -62,23 +65,23 @@ namespace EngineLayer.GlycoSearch
 
             if (glycoSearchType == GlycoSearchType.OGlycanSearch) //if we do the O-glycan search, we need to load the O-glycan database and generate the glycoBox.
             {
-                GlycanBox.GlobalOGlycans = LoadGlycanDatabase(GlobalVariables.OGlycanDatabasePaths, _oglycanDatabase, "O-glycan", true);
+                GlycanBox.GlobalOGlycans = ApplySelection(LoadGlycanDatabase(GlobalVariables.OGlycanDatabasePaths, _oglycanDatabase, "O-glycan", true), _oglycanDatabase);
                 GlycanBox.OGlycanBoxes = GlycanBox.BuildOGlycanBoxes(_maxOGlycanNum, false).OrderBy(p => p.Mass).ToArray(); //generate glycan box for O-glycan search
                 GlycanBoxes = GlycanBox.OGlycanBoxes;
                 GlycoSpectralMatch.GlycanBoxes = GlycanBoxes;
             }
             else if (glycoSearchType == GlycoSearchType.NGlycanSearch) //because the there is only one glycan in N-glycanpeptide, so we don't need to build the n-glycanBox here.
             {
-                NGlycans = LoadGlycanDatabase(GlobalVariables.NGlycanDatabasePaths, _nglycanDatabase, "N-glycan", false).OrderBy(p => p.Mass).ToArray();
+                NGlycans = ApplySelection(LoadGlycanDatabase(GlobalVariables.NGlycanDatabasePaths, _nglycanDatabase, "N-glycan", false), _nglycanDatabase).OrderBy(p => p.Mass).ToArray();
                 //TO THINK: Glycan Decoy database.
                 //DecoyGlycans = Glycan.BuildTargetDecoyGlycans(NGlycans);
             }
             else if (glycoSearchType == GlycoSearchType.N_O_GlycanSearch) //search both N-glycan and O-glycan is still not tested and build completely yet.
             {
-                GlycanBox.GlobalOGlycans = LoadGlycanDatabase(GlobalVariables.OGlycanDatabasePaths, _oglycanDatabase, "O-glycan", true);
+                GlycanBox.GlobalOGlycans = ApplySelection(LoadGlycanDatabase(GlobalVariables.OGlycanDatabasePaths, _oglycanDatabase, "O-glycan", true), _oglycanDatabase);
                 GlycanBox.GlobalNGlycans = new Dictionary<int, Glycan>();
                 // For N-glycan, we use negative index to distinguish with O-glycan.
-                var nGlycans = LoadGlycanDatabase(GlobalVariables.NGlycanDatabasePaths, _nglycanDatabase, "N-glycan", false).OrderBy(p => p.Mass);
+                var nGlycans = ApplySelection(LoadGlycanDatabase(GlobalVariables.NGlycanDatabasePaths, _nglycanDatabase, "N-glycan", false), _nglycanDatabase).OrderBy(p => p.Mass);
                 int indexForNGlycan = -1;
                 foreach (var nGlycan in nGlycans)
                 {
@@ -115,6 +118,45 @@ namespace EngineLayer.GlycoSearch
         /// An empty database is now rejected up front, which matters more since a user can be handed one: a
         /// freshly seeded custom database is all banner and no glycans until they add some.
         /// </remarks>
+        /// <summary>
+        /// Narrows a loaded database to the glycans the user checked in the task window, if any.
+        /// </summary>
+        /// <remarks>
+        /// Applied HERE, before the glycans reach GlycanBox.GlobalOGlycans and before any box is built,
+        /// because GlycanBox identifies a glycan by its POSITION in that array
+        /// (BuildOGlycanBoxes enumerates Range(0, GlobalOGlycans.Length)). Filtering after the array is
+        /// assigned would silently re-point every box at a different glycan. Filtering here means the
+        /// dense re-index falls out for free.
+        ///
+        /// It is deliberately not applied inside GlycanDatabase.LoadGlycan: GlobalVariables shares that
+        /// method to populate AllModsKnown for MetaDraw, which must keep seeing every glycan.
+        ///
+        /// A selection naming none of THIS database means the whole database, so choosing individual
+        /// O-glycans does not silently narrow the N-glycan side too.
+        /// </remarks>
+        private Glycan[] ApplySelection(Glycan[] loaded, string databaseFileName)
+        {
+            if (_selectedGlycans == null || _selectedGlycans.Count == 0)
+            {
+                return loaded;
+            }
+
+            var wanted = new HashSet<string>(_selectedGlycans
+                .Where(s => s.Item1 == databaseFileName)
+                .Select(s => s.Item2));
+
+            if (wanted.Count == 0)
+            {
+                return loaded;
+            }
+
+            var subset = loaded.Where(g => wanted.Contains(g.IdWithMotif)).ToArray();
+
+            // Every checked glycan is gone from the file it named. Falling back to the whole database beats
+            // handing BuildOGlycanBoxes an empty array, whose failure surfaces much later and elsewhere.
+            return subset.Length == 0 ? loaded : subset;
+        }
+
         private static Glycan[] LoadGlycanDatabase(List<string> databasePaths, string databaseFileName, string kind, bool isOGlycan)
         {
             string path = databasePaths.FirstOrDefault(p => System.IO.Path.GetFileName(p) == databaseFileName);

--- a/MetaMorpheus/EngineLayer/GlycoSearch/GlycoSearchEngine.cs
+++ b/MetaMorpheus/EngineLayer/GlycoSearch/GlycoSearchEngine.cs
@@ -62,24 +62,23 @@ namespace EngineLayer.GlycoSearch
 
             if (glycoSearchType == GlycoSearchType.OGlycanSearch) //if we do the O-glycan search, we need to load the O-glycan database and generate the glycoBox.
             {
-                GlycanBox.GlobalOGlycans = GlycanDatabase.LoadGlycan(GlobalVariables.OGlycanDatabasePaths.Where(p => System.IO.Path.GetFileName(p) == _oglycanDatabase).First(), true, true).ToArray();
+                GlycanBox.GlobalOGlycans = LoadGlycanDatabase(GlobalVariables.OGlycanDatabasePaths, _oglycanDatabase, "O-glycan", true);
                 GlycanBox.OGlycanBoxes = GlycanBox.BuildOGlycanBoxes(_maxOGlycanNum, false).OrderBy(p => p.Mass).ToArray(); //generate glycan box for O-glycan search
                 GlycanBoxes = GlycanBox.OGlycanBoxes;
                 GlycoSpectralMatch.GlycanBoxes = GlycanBoxes;
             }
             else if (glycoSearchType == GlycoSearchType.NGlycanSearch) //because the there is only one glycan in N-glycanpeptide, so we don't need to build the n-glycanBox here.
             {
-                NGlycans = GlycanDatabase.LoadGlycan(GlobalVariables.NGlycanDatabasePaths.Where(p => System.IO.Path.GetFileName(p) == _nglycanDatabase).First(), true, false).OrderBy(p => p.Mass).ToArray();
+                NGlycans = LoadGlycanDatabase(GlobalVariables.NGlycanDatabasePaths, _nglycanDatabase, "N-glycan", false).OrderBy(p => p.Mass).ToArray();
                 //TO THINK: Glycan Decoy database.
                 //DecoyGlycans = Glycan.BuildTargetDecoyGlycans(NGlycans);
             }
             else if (glycoSearchType == GlycoSearchType.N_O_GlycanSearch) //search both N-glycan and O-glycan is still not tested and build completely yet.
             {
-                GlycanBox.GlobalOGlycans = GlycanDatabase.LoadGlycan(GlobalVariables.OGlycanDatabasePaths.Where(p => System.IO.Path.GetFileName(p) == _oglycanDatabase).First(), true, true).ToArray();
+                GlycanBox.GlobalOGlycans = LoadGlycanDatabase(GlobalVariables.OGlycanDatabasePaths, _oglycanDatabase, "O-glycan", true);
                 GlycanBox.GlobalNGlycans = new Dictionary<int, Glycan>();
                 // For N-glycan, we use negative index to distinguish with O-glycan.
-                var nGlycans = GlycanDatabase.LoadGlycan(GlobalVariables.NGlycanDatabasePaths.First(p => System.IO.Path.GetFileName(p) == _nglycanDatabase),
-                        true, false).OrderBy(p => p.Mass);
+                var nGlycans = LoadGlycanDatabase(GlobalVariables.NGlycanDatabasePaths, _nglycanDatabase, "N-glycan", false).OrderBy(p => p.Mass);
                 int indexForNGlycan = -1;
                 foreach (var nGlycan in nGlycans)
                 {
@@ -94,6 +93,46 @@ namespace EngineLayer.GlycoSearch
                 //DecoyGlycans = Glycan.BuildTargetDecoyGlycans(NGlycans);
             }
 
+        }
+
+        /// <summary>
+        /// Resolves a glycan database by file name and loads it, failing with something the user can act on.
+        /// </summary>
+        /// <remarks>
+        /// Both failures this replaces used to surface as <c>InvalidOperationException: Sequence contains no
+        /// elements</c>, which names neither the database nor the problem:
+        /// <list type="bullet">
+        ///   <item><description>
+        ///     a selected file that is no longer in the folder threw from the <c>.First()</c> on the path
+        ///     lookup, here in the constructor;
+        ///   </description></item>
+        ///   <item><description>
+        ///     a database holding no glycans built an EMPTY box array without complaint, and then threw much
+        ///     later from <c>GlycanBoxes.First().Mass</c> inside the parallel search loop -- or, if no scan
+        ///     reached that branch, returned zero results and looked like a search that simply found nothing.
+        ///   </description></item>
+        /// </list>
+        /// An empty database is now rejected up front, which matters more since a user can be handed one: a
+        /// freshly seeded custom database is all banner and no glycans until they add some.
+        /// </remarks>
+        private static Glycan[] LoadGlycanDatabase(List<string> databasePaths, string databaseFileName, string kind, bool isOGlycan)
+        {
+            string path = databasePaths.FirstOrDefault(p => System.IO.Path.GetFileName(p) == databaseFileName);
+            if (path == null)
+            {
+                throw new MetaMorpheusException(
+                    $"The {kind} database '{databaseFileName}' was not found. Available: {string.Join(", ", databasePaths.Select(System.IO.Path.GetFileName))}.");
+            }
+
+            Glycan[] glycans = GlycanDatabase.LoadGlycan(path, true, isOGlycan).ToArray();
+            if (glycans.Length == 0)
+            {
+                throw new MetaMorpheusException(
+                    $"The {kind} database '{databaseFileName}' contains no glycans, so there is nothing to search for. " +
+                    $"Add at least one glycan to it, or choose a different {kind} database.");
+            }
+
+            return glycans;
         }
 
         private Glycan[] NGlycans { get; }

--- a/MetaMorpheus/EngineLayer/Util/CustomDataFile.cs
+++ b/MetaMorpheus/EngineLayer/Util/CustomDataFile.cs
@@ -1,0 +1,151 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+namespace EngineLayer
+{
+    /// <summary>
+    /// The one place MetaMorpheus creates a data file that the USER is expected to edit.
+    ///
+    /// <para>
+    /// Every such file -- custom proteases, rnases, crosslinkers, modifications, RNA modifications,
+    /// monosaccharides -- follows the same recipe, and it exists because breaking it produced a
+    /// data-loss bug (#2752: a user's edited custom monosaccharides were overwritten on install,
+    /// repair and upgrade). The rules are:
+    /// </para>
+    ///
+    /// <list type="number">
+    ///   <item><description>
+    ///     <b>Never touch a file that exists.</b> Seeding is guarded by <c>!File.Exists</c>. An
+    ///     existing custom file is never rewritten, reformatted, migrated or validated on startup.
+    ///     This is the rule that actually protects the user's work; everything else supports it.
+    ///   </description></item>
+    ///   <item><description>
+    ///     <b>Seed a documented template, not an empty file and not a copy of the data.</b> The
+    ///     template is the shipped sibling's comment banner plus its header row, and no data rows --
+    ///     so the user opens a file that explains its own format and has nothing to delete first.
+    ///     <see cref="BannerAndHeaderFrom(Stream, string)"/> derives exactly that from the shipped file,
+    ///     which keeps the two from drifting.
+    ///   </description></item>
+    ///   <item><description>
+    ///     <b>The template ships inside an assembly, never as a file on disk.</b> It must not appear
+    ///     in <c>Product.wxs</c> as a <c>&lt;File&gt;</c> and must not carry a
+    ///     <c>&lt;None Update ... CopyToOutputDirectory&gt;</c> rule. Those two are what let an
+    ///     installer or a build overwrite the user's copy, and both were removed by the #2752 fix.
+    ///   </description></item>
+    ///   <item><description>
+    ///     <b>Failing to seed is reported, not swallowed.</b> The user gets a
+    ///     <see cref="MetaMorpheusException"/> naming the file, rather than a silently absent one.
+    ///   </description></item>
+    /// </list>
+    ///
+    /// <para>
+    /// One deliberate exception: <c>CustomAminoAcids.txt</c> is seeded with a full A-Z dump of the
+    /// existing residues rather than a bare header, because its whole purpose is letting a user
+    /// adjust the mass of a residue that already exists. A header-only template would make the
+    /// common case harder, not easier. See <c>GlobalVariables.WriteAminoAcidsFile</c>.
+    /// </para>
+    /// </summary>
+    public static class CustomDataFile
+    {
+        /// <summary>
+        /// Creates <paramref name="path"/> from <paramref name="buildTemplate"/> if, and only if, it does
+        /// not already exist. An existing file -- which is to say, one the user may have edited -- is left
+        /// exactly as it is.
+        /// </summary>
+        /// <param name="path">Full path to the custom file.</param>
+        /// <param name="buildTemplate">
+        /// Produces the template contents. Deferred rather than passed as a string so that the cost of
+        /// reading an embedded resource is not paid on every startup, which is the common case where the
+        /// file is already there.
+        /// </param>
+        /// <param name="description">
+        /// What the file is for, in words, used in the exception message when seeding fails.
+        /// </param>
+        public static void EnsureExists(string path, Func<string> buildTemplate, string description)
+        {
+            if (File.Exists(path))
+            {
+                return;
+            }
+
+            try
+            {
+                string directory = Path.GetDirectoryName(path);
+                if (!string.IsNullOrEmpty(directory))
+                {
+                    Directory.CreateDirectory(directory);
+                }
+
+                File.WriteAllText(path, buildTemplate());
+            }
+            catch (Exception e)
+            {
+                throw new MetaMorpheusException(
+                    $"Error creating the default {description} file at {path}: {e.Message}", e);
+            }
+        }
+
+        /// <summary>
+        /// The comment banner and header row of a shipped tab-separated file, with every data row
+        /// dropped -- the template a user should be handed for the custom counterpart.
+        /// </summary>
+        /// <param name="shipped">The shipped file. Disposed by this method.</param>
+        /// <param name="headerPrefix">
+        /// How the header row starts, e.g. <c>"Name\t"</c>. Everything up to and including the first line
+        /// that starts with this (ignoring leading whitespace, and skipping comment lines) is kept.
+        /// </param>
+        public static string BannerAndHeaderFrom(Stream shipped, string headerPrefix)
+        {
+            var template = new StringBuilder();
+
+            using (var reader = new StreamReader(shipped))
+            {
+                string line;
+                while ((line = reader.ReadLine()) != null)
+                {
+                    bool isComment = line.StartsWith("#", StringComparison.Ordinal);
+                    bool isHeader = !isComment && line.TrimStart().StartsWith(headerPrefix, StringComparison.Ordinal);
+
+                    if (!isComment && !isHeader)
+                    {
+                        // a data row: the banner is over and the header was already written, or there
+                        // was no header to find
+                        break;
+                    }
+
+                    template.AppendLine(line);
+
+                    if (isHeader)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return template.ToString();
+        }
+
+        /// <summary>
+        /// <see cref="BannerAndHeaderFrom(Stream, string)"/> over an embedded resource.
+        /// </summary>
+        public static string BannerAndHeaderFrom(Assembly assembly, string resourceName, string headerPrefix)
+        {
+            Stream stream = assembly.GetManifestResourceStream(resourceName)
+                ?? throw new MetaMorpheusException(
+                    $"Embedded resource '{resourceName}' was not found in {assembly.GetName().Name}.");
+
+            return BannerAndHeaderFrom(stream, headerPrefix);
+        }
+
+        /// <summary>
+        /// <see cref="BannerAndHeaderFrom(Stream, string)"/> over a shipped file on disk.
+        /// </summary>
+        public static string BannerAndHeaderFromFile(string shippedPath, string headerPrefix)
+        {
+            return BannerAndHeaderFrom(File.OpenRead(shippedPath), headerPrefix);
+        }
+    }
+}

--- a/MetaMorpheus/EngineLayer/Util/CustomDataFile.cs
+++ b/MetaMorpheus/EngineLayer/Util/CustomDataFile.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -138,6 +138,28 @@ namespace EngineLayer
                     $"Embedded resource '{resourceName}' was not found in {assembly.GetName().Name}.");
 
             return BannerAndHeaderFrom(stream, headerPrefix);
+        }
+
+        /// <summary>
+        /// The whole of an embedded template, verbatim -- for a file whose format has no header row to
+        /// stop at, so <see cref="BannerAndHeaderFrom(Assembly, string, string)"/> has nothing to derive.
+        /// A glycan database is one: it is a bare list of glycans, so its template is a hand-written
+        /// banner of comment lines and the rules of rule 2 are met by the banner alone.
+        /// </summary>
+        /// <remarks>
+        /// The template is still an embedded resource rather than a string literal here, so that what the
+        /// user is handed is reviewable as a file and cannot drift from the format it documents.
+        /// </remarks>
+        public static string EmbeddedText(Assembly assembly, string resourceName)
+        {
+            Stream stream = assembly.GetManifestResourceStream(resourceName)
+                ?? throw new MetaMorpheusException(
+                    $"Embedded resource '{resourceName}' was not found in {assembly.GetName().Name}.");
+
+            using (var reader = new StreamReader(stream))
+            {
+                return reader.ReadToEnd();
+            }
         }
 
         /// <summary>

--- a/MetaMorpheus/EngineLayer/Util/CustomDataFile.cs
+++ b/MetaMorpheus/EngineLayer/Util/CustomDataFile.cs
@@ -23,11 +23,14 @@ namespace EngineLayer
     ///     This is the rule that actually protects the user's work; everything else supports it.
     ///   </description></item>
     ///   <item><description>
-    ///     <b>Seed a documented template, not an empty file and not a copy of the data.</b> The
-    ///     template is the shipped sibling's comment banner plus its header row, and no data rows --
-    ///     so the user opens a file that explains its own format and has nothing to delete first.
-    ///     <see cref="BannerAndHeaderFrom(Stream, string)"/> derives exactly that from the shipped file,
-    ///     which keeps the two from drifting.
+    ///     <b>Seed a documented template, not an empty file and not a copy of the data.</b> Whatever
+    ///     shape it takes it carries no data rows, so the user opens a file that explains its own format
+    ///     and has nothing to delete first. Where the file has a shipped sibling that opens with a banner
+    ///     and a header row, <see cref="BannerAndHeaderFrom(Stream, string)"/> derives the template from
+    ///     it, which keeps the two from drifting. Where it does not -- a glycan database is a bare list,
+    ///     with no header row to stop at and no bannered sibling to derive from -- the template is a
+    ///     hand-written banner, read whole with <see cref="EmbeddedText(Assembly, string)"/>. It is still
+    ///     a file in the repository rather than a string literal, so it is reviewed like one.
     ///   </description></item>
     ///   <item><description>
     ///     <b>The template ships inside an assembly, never as a file on disk.</b> It must not appear

--- a/MetaMorpheus/GUI/GUI.csproj
+++ b/MetaMorpheus/GUI/GUI.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -62,7 +62,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.588" />
+    <PackageReference Include="mzLib" Version="1.0.589" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0" />

--- a/MetaMorpheus/GUI/MainWindow.xaml
+++ b/MetaMorpheus/GUI/MainWindow.xaml
@@ -913,9 +913,9 @@
                             <Button Grid.Row="3" Grid.Column="1" Content="Create new crosslinker" 
                                     HorizontalContentAlignment="Left" BorderThickness="0" Click="AddCustomCrosslinker_Click" />
 
-                            <Button Grid.Row="4" Grid.Column="1" Content="Create new O-glycan" 
-                                    HorizontalContentAlignment="Left" BorderThickness="0" Click="AddCustomOGlycan_Click"
-                                    ToolTip="Add a glycan to your own O-glycan database, which is offered beside the ones MetaMorpheus ships"/>
+                            <Button Grid.Row="4" Grid.Column="1" Content="Create new glycan" 
+                                    HorizontalContentAlignment="Left" BorderThickness="0" Click="AddCustomGlycan_Click"
+                                    ToolTip="Add a glycan to your own O-glycan or N-glycan database, which are offered beside the ones MetaMorpheus ships"/>
 
                             <Button Grid.Row="5" Grid.Column="1" Content="Close program and open global settings" 
                                     HorizontalContentAlignment="Left" BorderThickness="0" Click="MenuItem_OpenSettings_Click" />

--- a/MetaMorpheus/GUI/MainWindow.xaml
+++ b/MetaMorpheus/GUI/MainWindow.xaml
@@ -913,6 +913,10 @@
                             <Button Grid.Row="3" Grid.Column="1" Content="Create new crosslinker" 
                                     HorizontalContentAlignment="Left" BorderThickness="0" Click="AddCustomCrosslinker_Click" />
 
+                            <Button Grid.Row="4" Grid.Column="1" Content="Create new O-glycan" 
+                                    HorizontalContentAlignment="Left" BorderThickness="0" Click="AddCustomOGlycan_Click"
+                                    ToolTip="Add a glycan to your own O-glycan database, which is offered beside the ones MetaMorpheus ships"/>
+
                             <Button Grid.Row="5" Grid.Column="1" Content="Close program and open global settings" 
                                     HorizontalContentAlignment="Left" BorderThickness="0" Click="MenuItem_OpenSettings_Click" />
 

--- a/MetaMorpheus/GUI/MainWindow.xaml.cs
+++ b/MetaMorpheus/GUI/MainWindow.xaml.cs
@@ -1633,6 +1633,13 @@ namespace MetaMorpheusGUI
                 NotificationHandler(null, new StringEventArgs(error, null));
             }
             GlobalVariables.ErrorsReadingMods.Clear();
+
+            // and anything else startup noticed, such as a custom protease that collided with a built-in
+            foreach (var warning in GlobalVariables.StartupWarnings)
+            {
+                NotificationHandler(null, new StringEventArgs(warning, null));
+            }
+            GlobalVariables.StartupWarnings.Clear();
         }
 
         private void UpdateOutputFolderTextbox()

--- a/MetaMorpheus/GUI/MainWindow.xaml.cs
+++ b/MetaMorpheus/GUI/MainWindow.xaml.cs
@@ -1,4 +1,4 @@
-using EngineLayer;
+﻿using EngineLayer;
 using EngineLayer.Util;
 using IO.ThermoRawFileReader;
 using Microsoft.Win32;
@@ -1345,6 +1345,12 @@ namespace MetaMorpheusGUI
         private void AddCustomMonosaccharide_Click(object sender, RoutedEventArgs e)
         {
             var dialog = new CustomMonosaccharideWindow();
+            dialog.ShowDialog();
+        }
+
+        private void AddCustomOGlycan_Click(object sender, RoutedEventArgs e)
+        {
+            var dialog = new CustomGlycanWindow();
             dialog.ShowDialog();
         }
 

--- a/MetaMorpheus/GUI/MainWindow.xaml.cs
+++ b/MetaMorpheus/GUI/MainWindow.xaml.cs
@@ -1348,7 +1348,7 @@ namespace MetaMorpheusGUI
             dialog.ShowDialog();
         }
 
-        private void AddCustomOGlycan_Click(object sender, RoutedEventArgs e)
+        private void AddCustomGlycan_Click(object sender, RoutedEventArgs e)
         {
             var dialog = new CustomGlycanWindow();
             dialog.ShowDialog();

--- a/MetaMorpheus/GUI/TaskWindows/GlycoSearchTaskWindow.xaml
+++ b/MetaMorpheus/GUI/TaskWindows/GlycoSearchTaskWindow.xaml
@@ -152,6 +152,8 @@
                             Pick individual glycans instead of a whole database. Each database above appears here as a group;
                             checking a group is the same as searching that entire database, which is the default.
                             Leaving every box unchecked also searches the whole selected database.
+                            A glycan is listed once per attachment site, so the same composition appears more
+                            than once -- on S and on T, for instance.
                         </TextBlock>
                     </GroupBox.ToolTip>
                     <Expander x:Name="GlycanSelectionExpander">
@@ -188,17 +190,18 @@
                                 </TextBox>
                                 <Label x:Name="GlycanSelectionSummary" Content="" Foreground="Gray" VerticalAlignment="Center"/>
                             </StackPanel>
-                            <TreeView x:Name="glycanTreeView" Grid.Row="1" ItemsSource="{Binding}" DataContext="{x:Type guiFunctions:ModTypeForTreeViewModel}" Height="400">
+                            <TreeView x:Name="glycanTreeView" Grid.Row="1" ItemsSource="{Binding}" DataContext="{x:Type guiFunctions:ModTypeForTreeViewModel}" Height="400"
+                                      VirtualizingStackPanel.IsVirtualizing="True" VirtualizingStackPanel.VirtualizationMode="Recycling">
                                 <TreeView.Resources>
                                     <HierarchicalDataTemplate DataType="{x:Type guiFunctions:ModTypeForTreeViewModel}" ItemsSource="{Binding Children}">
-                                        <StackPanel Orientation="Horizontal" Background="{Binding Background}">
-                                            <CheckBox IsChecked="{Binding Use}" />
+                                        <StackPanel Orientation="Horizontal" Background="{Binding Background}" AutomationProperties.Name="{Binding DisplayName}">
+                                            <CheckBox IsChecked="{Binding Use}" AutomationProperties.Name="{Binding DisplayName}" />
                                             <TextBlock Text="{Binding DisplayName}" FontWeight="Bold" />
                                         </StackPanel>
                                     </HierarchicalDataTemplate>
                                     <DataTemplate DataType="{x:Type guiFunctions:ModForTreeViewModel}">
-                                        <StackPanel Orientation="Horizontal" Background="{Binding Background}" ToolTip="{Binding ToolTipStuff}">
-                                            <CheckBox IsChecked="{Binding Use}" />
+                                        <StackPanel Orientation="Horizontal" Background="{Binding Background}" ToolTip="{Binding ToolTipStuff}" AutomationProperties.Name="{Binding DisplayName}">
+                                            <CheckBox IsChecked="{Binding Use}" AutomationProperties.Name="{Binding DisplayName}" />
                                             <TextBlock Text="{Binding DisplayName}" TextTrimming="CharacterEllipsis" />
                                         </StackPanel>
                                     </DataTemplate>
@@ -206,6 +209,7 @@
                                 <TreeView.ItemContainerStyle>
                                     <Style TargetType="TreeViewItem">
                                         <Setter Property="IsExpanded" Value="{Binding Expanded}"/>
+                                        <Setter Property="AutomationProperties.Name" Value="{Binding DisplayName}"/>
                                     </Style>
                                 </TreeView.ItemContainerStyle>
                             </TreeView>

--- a/MetaMorpheus/GUI/TaskWindows/GlycoSearchTaskWindow.xaml
+++ b/MetaMorpheus/GUI/TaskWindows/GlycoSearchTaskWindow.xaml
@@ -188,7 +188,7 @@
                                         </Style>
                                     </TextBox.Style>
                                 </TextBox>
-                                <Label x:Name="GlycanSelectionSummary" Content="" Foreground="Gray" VerticalAlignment="Center"/>
+                                <Label x:Name="GlycanSelectionSummary" Content="{Binding Summary}" Foreground="Gray" VerticalAlignment="Center"/>
                             </StackPanel>
                             <TreeView x:Name="glycanTreeView" Grid.Row="1" ItemsSource="{Binding}" DataContext="{x:Type guiFunctions:ModTypeForTreeViewModel}" Height="400"
                                       VirtualizingStackPanel.IsVirtualizing="True" VirtualizingStackPanel.VirtualizationMode="Recycling">

--- a/MetaMorpheus/GUI/TaskWindows/GlycoSearchTaskWindow.xaml
+++ b/MetaMorpheus/GUI/TaskWindows/GlycoSearchTaskWindow.xaml
@@ -146,6 +146,72 @@
                         </Grid>
                     </Expander>
                 </GroupBox>
+                <GroupBox Header="Individual Glycans" DockPanel.Dock="Top" ToolTipService.ShowDuration="999999" ToolTipService.InitialShowDelay="500">
+                    <GroupBox.ToolTip>
+                        <TextBlock>
+                            Pick individual glycans instead of a whole database. Each database above appears here as a group;
+                            checking a group is the same as searching that entire database, which is the default.
+                            Leaving every box unchecked also searches the whole selected database.
+                        </TextBlock>
+                    </GroupBox.ToolTip>
+                    <Expander x:Name="GlycanSelectionExpander">
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="25"/>
+                                <RowDefinition Height="1*"/>
+                            </Grid.RowDefinitions>
+                            <StackPanel Orientation="Horizontal" Grid.Row="0">
+                                <Label Content="Glycans"/>
+                                <TextBox x:Name="SearchGlycan" TextChanged="TextChanged_Glycan" HorizontalAlignment="Left" Margin="5,0,0,0" Height="22" Width="220">
+                                    <TextBox.Style>
+                                        <Style TargetType="TextBox" xmlns:sys="clr-namespace:System;assembly=mscorlib">
+                                            <Style.Resources>
+                                                <VisualBrush x:Key="CueBannerBrush" AlignmentX="Left" AlignmentY="Center" Stretch="None">
+                                                    <VisualBrush.Visual>
+                                                        <Label Content="Search name, code or mass..." Foreground="Gray" />
+                                                    </VisualBrush.Visual>
+                                                </VisualBrush>
+                                            </Style.Resources>
+                                            <Style.Triggers>
+                                                <Trigger Property="Text" Value="{x:Static sys:String.Empty}">
+                                                    <Setter Property="Background" Value="{StaticResource CueBannerBrush}" />
+                                                </Trigger>
+                                                <Trigger Property="Text" Value="{x:Null}">
+                                                    <Setter Property="Background" Value="{StaticResource CueBannerBrush}" />
+                                                </Trigger>
+                                                <Trigger Property="IsKeyboardFocused" Value="True">
+                                                    <Setter Property="Background" Value="White" />
+                                                </Trigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBox.Style>
+                                </TextBox>
+                                <Label x:Name="GlycanSelectionSummary" Content="" Foreground="Gray" VerticalAlignment="Center"/>
+                            </StackPanel>
+                            <TreeView x:Name="glycanTreeView" Grid.Row="1" ItemsSource="{Binding}" DataContext="{x:Type guiFunctions:ModTypeForTreeViewModel}" Height="400">
+                                <TreeView.Resources>
+                                    <HierarchicalDataTemplate DataType="{x:Type guiFunctions:ModTypeForTreeViewModel}" ItemsSource="{Binding Children}">
+                                        <StackPanel Orientation="Horizontal" Background="{Binding Background}">
+                                            <CheckBox IsChecked="{Binding Use}" />
+                                            <TextBlock Text="{Binding DisplayName}" FontWeight="Bold" />
+                                        </StackPanel>
+                                    </HierarchicalDataTemplate>
+                                    <DataTemplate DataType="{x:Type guiFunctions:ModForTreeViewModel}">
+                                        <StackPanel Orientation="Horizontal" Background="{Binding Background}" ToolTip="{Binding ToolTipStuff}">
+                                            <CheckBox IsChecked="{Binding Use}" />
+                                            <TextBlock Text="{Binding DisplayName}" TextTrimming="CharacterEllipsis" />
+                                        </StackPanel>
+                                    </DataTemplate>
+                                </TreeView.Resources>
+                                <TreeView.ItemContainerStyle>
+                                    <Style TargetType="TreeViewItem">
+                                        <Setter Property="IsExpanded" Value="{Binding Expanded}"/>
+                                    </Style>
+                                </TreeView.ItemContainerStyle>
+                            </TreeView>
+                        </Grid>
+                    </Expander>
+                </GroupBox>
                 <GroupBox Header="Search Parameters" DockPanel.Dock="Top">
                     <Expander x:Name="SearchModeExpander">
                         <Expander.Style>

--- a/MetaMorpheus/GUI/TaskWindows/GlycoSearchTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/GlycoSearchTaskWindow.xaml.cs
@@ -30,8 +30,7 @@ namespace MetaMorpheusGUI
         private readonly ObservableCollection<ModTypeForTreeViewModel> FixedModTypeForTreeViewObservableCollection = new ObservableCollection<ModTypeForTreeViewModel>();
         private readonly ObservableCollection<ModTypeForTreeViewModel> VariableModTypeForTreeViewObservableCollection = new ObservableCollection<ModTypeForTreeViewModel>();
         private readonly ObservableCollection<ModTypeForGrid> ModSelectionGridItems = new ObservableCollection<ModTypeForGrid>();
-        private readonly ObservableCollection<ModTypeForTreeViewModel> GlycanTypeForTreeViewObservableCollection = new ObservableCollection<ModTypeForTreeViewModel>();
-        private bool _syncingGlycanCheckState;
+        private GlycanSelectionViewModel GlycanSelectionViewModel;
         private CustomFragmentationWindow CustomFragmentationWindow;
         private DeconHostViewModel DeconHostViewModel;
 
@@ -78,7 +77,7 @@ namespace MetaMorpheusGUI
 
             CmbOGlycanDatabase.ItemsSource = GlobalVariables.OGlycanDatabasePaths.Select(p=> Path.GetFileName(p));
             CmbNGlycanDatabase.ItemsSource = GlobalVariables.NGlycanDatabasePaths.Select(p => Path.GetFileName(p));
-            PopulateGlycanTree();
+
 
             foreach (Protease protease in ProteaseDictionary.Dictionary.Values)
             {
@@ -269,40 +268,14 @@ namespace MetaMorpheusGUI
                 ye.VerifyCheckState();
             }
 
-            foreach (var glycan in task._glycoSearchParameters.SelectedGlycans ?? new List<(string, string)>())
-            {
-                var theDatabase = GlycanTypeForTreeViewObservableCollection.FirstOrDefault(b => b.DisplayName.Equals(glycan.Item1));
-                if (theDatabase != null)
-                {
-                    var theGlycan = theDatabase.Children.FirstOrDefault(b => b.ModName.Equals(glycan.Item2));
-                    if (theGlycan != null)
-                    {
-                        theGlycan.Use = true;
-                    }
-                    else
-                    {
-                        // The database is still here but no longer holds this glycan -- surfaced in red,
-                        // the same way the modification trees surface a mod this install does not have.
-                        theDatabase.Children.Add(new ModForTreeViewModel("UNKNOWN GLYCAN!", true, glycan.Item2, true, theDatabase));
-                    }
-                }
-                else
-                {
-                    theDatabase = new ModTypeForTreeViewModel(glycan.Item1, true);
-                    GlycanTypeForTreeViewObservableCollection.Add(theDatabase);
-                    theDatabase.Children.Add(new ModForTreeViewModel("UNKNOWN GLYCAN!", true, glycan.Item2, true, theDatabase));
-                }
-            }
-
-            // Last, and required: the group checkboxes are only pulled into agreement with their children here.
-            // Skipped for an empty database: VerifyCheckState leaves Use null when there is nothing to
-            // inspect, and null renders as the indeterminate box -- so a database holding no glycans would
-            // be the only one that looked partly selected.
-            foreach (var ye in GlycanTypeForTreeViewObservableCollection.Where(db => db.Children.Count > 0))
-            {
-                ye.VerifyCheckState();
-            }
-            UpdateGlycanSelectionSummary();
+            // The tree is built here, not in PopulateChoices, because it needs the saved selection.
+            // GlobalVariables is read on this side of the boundary; the view model takes the glycans
+            // as an argument so a test can hand it its own.
+            GlycanSelectionViewModel = new GlycanSelectionViewModel(
+                GlobalVariables.OGlycansByDatabase.Concat(GlobalVariables.NGlycansByDatabase),
+                task._glycoSearchParameters.SelectedGlycans);
+            glycanTreeView.DataContext = GlycanSelectionViewModel.Databases;
+            GlycanSelectionSummary.DataContext = GlycanSelectionViewModel;
 
             WritePrunedDBCheckBox.IsChecked = task._glycoSearchParameters.WritePrunedDataBase;
             UpdateModSelectionGrid();
@@ -352,14 +325,7 @@ namespace MetaMorpheusGUI
             TheTask._glycoSearchParameters.OGlycanDatabasefile = CmbOGlycanDatabase.SelectedItem.ToString();
             TheTask._glycoSearchParameters.NGlycanDatabasefile = CmbNGlycanDatabase.SelectedItem.ToString();
 
-            // Only the leaves are read back, and always from the master collection rather than the tree's
-            // DataContext -- so a selection made while the search box is filtered is still saved in full.
-            TheTask._glycoSearchParameters.SelectedGlycans = new List<(string, string)>();
-            foreach (var database in GlycanTypeForTreeViewObservableCollection)
-            {
-                TheTask._glycoSearchParameters.SelectedGlycans.AddRange(
-                    database.Children.Where(b => b.Use).Select(b => (b.Parent.DisplayName, b.ModName)));
-            }
+            TheTask._glycoSearchParameters.SelectedGlycans = GlycanSelectionViewModel.ToSelectedGlycans();
             TheTask._glycoSearchParameters.GlycoSearchTopNum = int.Parse(txtTopNum.Text, CultureInfo.InvariantCulture);
             TheTask._glycoSearchParameters.MaximumOGlycanAllowed = int.Parse(TbMaxOGlycanNum.Text, CultureInfo.InvariantCulture);
             TheTask._glycoSearchParameters.OxoniumIonFilt = CkbOxoniumIonFilt.IsChecked.Value;
@@ -561,174 +527,6 @@ namespace MetaMorpheusGUI
             }
         }
 
-        /// <summary>
-        /// Fills the glycan tree: one group per glycan database, its glycans as checkable children.
-        /// </summary>
-        /// <remarks>
-        /// Grouped by DATABASE rather than by ModificationType (which is what the modification trees group
-        /// by, and which would put every O-glycan in one bucket regardless of the file it came from).
-        /// Checking a group is therefore the same statement as picking that database in the combo box above.
-        ///
-        /// Reuses ModTypeForTreeViewModel/ModForTreeViewModel unchanged -- a glycan is a Modification, so
-        /// the existing nodes already fit and no glycan-specific view-model is needed.
-        /// </remarks>
-        private void PopulateGlycanTree()
-        {
-            foreach (var database in GlobalVariables.OGlycansByDatabase.Concat(GlobalVariables.NGlycansByDatabase))
-            {
-                // DisplayName is the bare file name on purpose: it is half of the persisted key
-                // (databaseFileName, IdWithMotif) that the read-back projects and the engine matches on,
-                // so decorating it here -- with a count, say -- would break both.
-                var theDatabase = new ModTypeForTreeViewModel(database.Key, false);
-                GlycanTypeForTreeViewObservableCollection.Add(theDatabase);
-
-                foreach (var glycan in database.Value)
-                {
-                    var node = new ModForTreeViewModel(
-                        GlycanToolTip(glycan), false, glycan.IdWithMotif, false, theDatabase, GlycanLabel(glycan));
-                    node.PropertyChanged += GlycanUseChanged;
-                    theDatabase.Children.Add(node);
-                }
-
-                if (theDatabase.Children.Count == 0)
-                {
-                    theDatabase.Use = false;
-                }
-            }
-
-            glycanTreeView.DataContext = GlycanTypeForTreeViewObservableCollection;
-            UpdateGlycanSelectionSummary();
-        }
-
-        /// <summary>
-        /// The row label: the identifier, the expanded composition, and the mass.
-        /// </summary>
-        /// <remarks>
-        /// IdWithMotif alone is a composition code ("H5N4A2 on N"), which is unreadable unless you already
-        /// know the letters, and unsearchable in the terms people actually use -- typing "HexNAc" would
-        /// match nothing. Spelling the monosaccharides out and appending the mass makes both work, because
-        /// the tree searches this label.
-        /// </remarks>
-        private static string GlycanLabel(Glycan glycan)
-        {
-            var expanded = ExpandComposition(glycan.Composition);
-            var mass = glycan.Mass / 1E5; // Glycan.Mass is monoisotopic mass scaled by 1e5
-
-            return string.IsNullOrEmpty(expanded)
-                ? string.Format(CultureInfo.InvariantCulture, "{0}   —   {1:F2} Da", glycan.IdWithMotif, mass)
-                : string.Format(CultureInfo.InvariantCulture, "{0}   —   {1}   —   {2:F2} Da", glycan.IdWithMotif, expanded, mass);
-        }
-
-        private static string GlycanToolTip(Glycan glycan)
-        {
-            var lines = new List<string>
-            {
-                "Composition: " + glycan.Composition,
-                "Expanded:    " + ExpandComposition(glycan.Composition),
-                string.Format(CultureInfo.InvariantCulture, "Mass:        {0:F5} Da", glycan.Mass / 1E5),
-                "Type:        " + glycan.Type,
-            };
-
-            // Only structure-format databases carry a structure string; composition databases leave it null.
-            if (!string.IsNullOrEmpty(glycan.Struc))
-            {
-                lines.Add("Structure:   " + glycan.Struc);
-            }
-
-            return string.Join(Environment.NewLine, lines);
-        }
-
-        /// <summary>
-        /// Turns a composition code such as "H5N4A2" into "Hex(5)HexNAc(4)NeuAc(2)".
-        /// </summary>
-        /// <remarks>
-        /// Built from Glycan.NameCharDic so custom monosaccharides registered at startup are spelled out
-        /// too, rather than silently falling back to their letter.
-        /// </remarks>
-        private static string ExpandComposition(string composition)
-        {
-            if (string.IsNullOrWhiteSpace(composition))
-            {
-                return string.Empty;
-            }
-
-            var nameByCode = new Dictionary<char, string>();
-            foreach (var entry in Glycan.NameCharDic)
-            {
-                nameByCode[entry.Value.Item1] = entry.Key;
-            }
-
-            var expanded = new System.Text.StringBuilder();
-            int i = 0;
-            while (i < composition.Length)
-            {
-                char code = composition[i++];
-                int start = i;
-                while (i < composition.Length && char.IsDigit(composition[i]))
-                {
-                    i++;
-                }
-
-                var count = i > start ? composition.Substring(start, i - start) : "1";
-                expanded.Append(nameByCode.TryGetValue(code, out var name) ? name : code.ToString())
-                        .Append('(').Append(count).Append(')');
-            }
-
-            return expanded.ToString();
-        }
-
-        /// <summary>
-        /// Keeps the database checkbox and the summary in step with the glycans underneath them.
-        /// </summary>
-        /// <remarks>
-        /// ModForTreeViewModel.Use notifies only itself -- nothing tells the parent a child changed, and
-        /// VerifyCheckState is a manual pull the window has to make. The modification trees only ever make
-        /// it while restoring a saved task, which is why a group there still reads as fully checked right
-        /// after you uncheck something inside it. Subscribing here fixes that for the glycan tree without
-        /// touching the shared view-models, which MetaDraw also uses.
-        ///
-        /// The re-entrancy guard is required, not defensive: VerifyCheckState assigns the parent's Use, and
-        /// a non-null assignment cascades back down to every child, each of which raises PropertyChanged
-        /// again. Checking the last box in a group would otherwise recurse forever.
-        /// </remarks>
-        private void GlycanUseChanged(object sender, PropertyChangedEventArgs e)
-        {
-            if (_syncingGlycanCheckState || e.PropertyName != nameof(ModForTreeViewModel.Use))
-            {
-                return;
-            }
-
-            _syncingGlycanCheckState = true;
-            try
-            {
-                if (sender is ModForTreeViewModel glycan && glycan.Parent != null && glycan.Parent.Children.Count > 0)
-                {
-                    glycan.Parent.VerifyCheckState();
-                }
-
-                UpdateGlycanSelectionSummary();
-            }
-            finally
-            {
-                _syncingGlycanCheckState = false;
-            }
-        }
-
-        private void UpdateGlycanSelectionSummary()
-        {
-            int selected = GlycanTypeForTreeViewObservableCollection.Sum(db => db.Children.Count(c => c.Use));
-            int total = GlycanTypeForTreeViewObservableCollection.Sum(db => db.Children.Count);
-
-            int databases = GlycanTypeForTreeViewObservableCollection.Count(db => db.Children.Any(c => c.Use));
-
-            // "entries", not "glycans": a glycan is listed once per attachment site, so the 12 lines of
-            // OGlycan.gdb are 24 rows here (on S and on T). Counting them as glycans invites the reader to
-            // compare this number with the file and find it wrong.
-            GlycanSelectionSummary.Content = selected == 0
-                ? string.Format(CultureInfo.InvariantCulture, "   none checked — the whole selected database will be searched ({0} entries available)", total)
-                : string.Format(CultureInfo.InvariantCulture, "   {0} of {1} entries checked, across {2} database{3}", selected, total, databases, databases == 1 ? "" : "s");
-        }
-
         private void TextChanged_Glycan(object sender, TextChangedEventArgs args)
         {
             SearchModifications.SetTimer();
@@ -764,7 +562,7 @@ namespace MetaMorpheusGUI
             if (SearchModifications.GlycanSearch)
             {
                 // Searches the row label, not just the identifier, so "HexNAc", "2222" and "H5N4A2" all work.
-                SearchModifications.FilterTree(SearchGlycan, glycanTreeView, GlycanTypeForTreeViewObservableCollection, m => m.DisplayName);
+                SearchModifications.FilterTree(SearchGlycan, glycanTreeView, GlycanSelectionViewModel.Databases, m => m.DisplayName);
                 SearchModifications.GlycanSearch = false;
             }
         }

--- a/MetaMorpheus/GUI/TaskWindows/GlycoSearchTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/GlycoSearchTaskWindow.xaml.cs
@@ -31,6 +31,7 @@ namespace MetaMorpheusGUI
         private readonly ObservableCollection<ModTypeForTreeViewModel> VariableModTypeForTreeViewObservableCollection = new ObservableCollection<ModTypeForTreeViewModel>();
         private readonly ObservableCollection<ModTypeForGrid> ModSelectionGridItems = new ObservableCollection<ModTypeForGrid>();
         private readonly ObservableCollection<ModTypeForTreeViewModel> GlycanTypeForTreeViewObservableCollection = new ObservableCollection<ModTypeForTreeViewModel>();
+        private bool _syncingGlycanCheckState;
         private CustomFragmentationWindow CustomFragmentationWindow;
         private DeconHostViewModel DeconHostViewModel;
 
@@ -294,7 +295,10 @@ namespace MetaMorpheusGUI
             }
 
             // Last, and required: the group checkboxes are only pulled into agreement with their children here.
-            foreach (var ye in GlycanTypeForTreeViewObservableCollection)
+            // Skipped for an empty database: VerifyCheckState leaves Use null when there is nothing to
+            // inspect, and null renders as the indeterminate box -- so a database holding no glycans would
+            // be the only one that looked partly selected.
+            foreach (var ye in GlycanTypeForTreeViewObservableCollection.Where(db => db.Children.Count > 0))
             {
                 ye.VerifyCheckState();
             }
@@ -580,8 +584,15 @@ namespace MetaMorpheusGUI
 
                 foreach (var glycan in database.Value)
                 {
-                    theDatabase.Children.Add(new ModForTreeViewModel(
-                        GlycanToolTip(glycan), false, glycan.IdWithMotif, false, theDatabase, GlycanLabel(glycan)));
+                    var node = new ModForTreeViewModel(
+                        GlycanToolTip(glycan), false, glycan.IdWithMotif, false, theDatabase, GlycanLabel(glycan));
+                    node.PropertyChanged += GlycanUseChanged;
+                    theDatabase.Children.Add(node);
+                }
+
+                if (theDatabase.Children.Count == 0)
+                {
+                    theDatabase.Use = false;
                 }
             }
 
@@ -666,14 +677,56 @@ namespace MetaMorpheusGUI
             return expanded.ToString();
         }
 
+        /// <summary>
+        /// Keeps the database checkbox and the summary in step with the glycans underneath them.
+        /// </summary>
+        /// <remarks>
+        /// ModForTreeViewModel.Use notifies only itself -- nothing tells the parent a child changed, and
+        /// VerifyCheckState is a manual pull the window has to make. The modification trees only ever make
+        /// it while restoring a saved task, which is why a group there still reads as fully checked right
+        /// after you uncheck something inside it. Subscribing here fixes that for the glycan tree without
+        /// touching the shared view-models, which MetaDraw also uses.
+        ///
+        /// The re-entrancy guard is required, not defensive: VerifyCheckState assigns the parent's Use, and
+        /// a non-null assignment cascades back down to every child, each of which raises PropertyChanged
+        /// again. Checking the last box in a group would otherwise recurse forever.
+        /// </remarks>
+        private void GlycanUseChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (_syncingGlycanCheckState || e.PropertyName != nameof(ModForTreeViewModel.Use))
+            {
+                return;
+            }
+
+            _syncingGlycanCheckState = true;
+            try
+            {
+                if (sender is ModForTreeViewModel glycan && glycan.Parent != null && glycan.Parent.Children.Count > 0)
+                {
+                    glycan.Parent.VerifyCheckState();
+                }
+
+                UpdateGlycanSelectionSummary();
+            }
+            finally
+            {
+                _syncingGlycanCheckState = false;
+            }
+        }
+
         private void UpdateGlycanSelectionSummary()
         {
             int selected = GlycanTypeForTreeViewObservableCollection.Sum(db => db.Children.Count(c => c.Use));
             int total = GlycanTypeForTreeViewObservableCollection.Sum(db => db.Children.Count);
 
+            int databases = GlycanTypeForTreeViewObservableCollection.Count(db => db.Children.Any(c => c.Use));
+
+            // "entries", not "glycans": a glycan is listed once per attachment site, so the 12 lines of
+            // OGlycan.gdb are 24 rows here (on S and on T). Counting them as glycans invites the reader to
+            // compare this number with the file and find it wrong.
             GlycanSelectionSummary.Content = selected == 0
-                ? string.Format(CultureInfo.InvariantCulture, "   none checked — the whole selected database will be searched ({0} glycans available)", total)
-                : string.Format(CultureInfo.InvariantCulture, "   {0} of {1} glycans checked", selected, total);
+                ? string.Format(CultureInfo.InvariantCulture, "   none checked — the whole selected database will be searched ({0} entries available)", total)
+                : string.Format(CultureInfo.InvariantCulture, "   {0} of {1} entries checked, across {2} database{3}", selected, total, databases, databases == 1 ? "" : "s");
         }
 
         private void TextChanged_Glycan(object sender, TextChangedEventArgs args)

--- a/MetaMorpheus/GUI/TaskWindows/GlycoSearchTaskWindow.xaml.cs
+++ b/MetaMorpheus/GUI/TaskWindows/GlycoSearchTaskWindow.xaml.cs
@@ -30,6 +30,7 @@ namespace MetaMorpheusGUI
         private readonly ObservableCollection<ModTypeForTreeViewModel> FixedModTypeForTreeViewObservableCollection = new ObservableCollection<ModTypeForTreeViewModel>();
         private readonly ObservableCollection<ModTypeForTreeViewModel> VariableModTypeForTreeViewObservableCollection = new ObservableCollection<ModTypeForTreeViewModel>();
         private readonly ObservableCollection<ModTypeForGrid> ModSelectionGridItems = new ObservableCollection<ModTypeForGrid>();
+        private readonly ObservableCollection<ModTypeForTreeViewModel> GlycanTypeForTreeViewObservableCollection = new ObservableCollection<ModTypeForTreeViewModel>();
         private CustomFragmentationWindow CustomFragmentationWindow;
         private DeconHostViewModel DeconHostViewModel;
 
@@ -76,6 +77,7 @@ namespace MetaMorpheusGUI
 
             CmbOGlycanDatabase.ItemsSource = GlobalVariables.OGlycanDatabasePaths.Select(p=> Path.GetFileName(p));
             CmbNGlycanDatabase.ItemsSource = GlobalVariables.NGlycanDatabasePaths.Select(p => Path.GetFileName(p));
+            PopulateGlycanTree();
 
             foreach (Protease protease in ProteaseDictionary.Dictionary.Values)
             {
@@ -265,6 +267,39 @@ namespace MetaMorpheusGUI
             {
                 ye.VerifyCheckState();
             }
+
+            foreach (var glycan in task._glycoSearchParameters.SelectedGlycans ?? new List<(string, string)>())
+            {
+                var theDatabase = GlycanTypeForTreeViewObservableCollection.FirstOrDefault(b => b.DisplayName.Equals(glycan.Item1));
+                if (theDatabase != null)
+                {
+                    var theGlycan = theDatabase.Children.FirstOrDefault(b => b.ModName.Equals(glycan.Item2));
+                    if (theGlycan != null)
+                    {
+                        theGlycan.Use = true;
+                    }
+                    else
+                    {
+                        // The database is still here but no longer holds this glycan -- surfaced in red,
+                        // the same way the modification trees surface a mod this install does not have.
+                        theDatabase.Children.Add(new ModForTreeViewModel("UNKNOWN GLYCAN!", true, glycan.Item2, true, theDatabase));
+                    }
+                }
+                else
+                {
+                    theDatabase = new ModTypeForTreeViewModel(glycan.Item1, true);
+                    GlycanTypeForTreeViewObservableCollection.Add(theDatabase);
+                    theDatabase.Children.Add(new ModForTreeViewModel("UNKNOWN GLYCAN!", true, glycan.Item2, true, theDatabase));
+                }
+            }
+
+            // Last, and required: the group checkboxes are only pulled into agreement with their children here.
+            foreach (var ye in GlycanTypeForTreeViewObservableCollection)
+            {
+                ye.VerifyCheckState();
+            }
+            UpdateGlycanSelectionSummary();
+
             WritePrunedDBCheckBox.IsChecked = task._glycoSearchParameters.WritePrunedDataBase;
             UpdateModSelectionGrid();
         }
@@ -312,6 +347,15 @@ namespace MetaMorpheusGUI
 
             TheTask._glycoSearchParameters.OGlycanDatabasefile = CmbOGlycanDatabase.SelectedItem.ToString();
             TheTask._glycoSearchParameters.NGlycanDatabasefile = CmbNGlycanDatabase.SelectedItem.ToString();
+
+            // Only the leaves are read back, and always from the master collection rather than the tree's
+            // DataContext -- so a selection made while the search box is filtered is still saved in full.
+            TheTask._glycoSearchParameters.SelectedGlycans = new List<(string, string)>();
+            foreach (var database in GlycanTypeForTreeViewObservableCollection)
+            {
+                TheTask._glycoSearchParameters.SelectedGlycans.AddRange(
+                    database.Children.Where(b => b.Use).Select(b => (b.Parent.DisplayName, b.ModName)));
+            }
             TheTask._glycoSearchParameters.GlycoSearchTopNum = int.Parse(txtTopNum.Text, CultureInfo.InvariantCulture);
             TheTask._glycoSearchParameters.MaximumOGlycanAllowed = int.Parse(TbMaxOGlycanNum.Text, CultureInfo.InvariantCulture);
             TheTask._glycoSearchParameters.OxoniumIonFilt = CkbOxoniumIonFilt.IsChecked.Value;
@@ -513,6 +557,131 @@ namespace MetaMorpheusGUI
             }
         }
 
+        /// <summary>
+        /// Fills the glycan tree: one group per glycan database, its glycans as checkable children.
+        /// </summary>
+        /// <remarks>
+        /// Grouped by DATABASE rather than by ModificationType (which is what the modification trees group
+        /// by, and which would put every O-glycan in one bucket regardless of the file it came from).
+        /// Checking a group is therefore the same statement as picking that database in the combo box above.
+        ///
+        /// Reuses ModTypeForTreeViewModel/ModForTreeViewModel unchanged -- a glycan is a Modification, so
+        /// the existing nodes already fit and no glycan-specific view-model is needed.
+        /// </remarks>
+        private void PopulateGlycanTree()
+        {
+            foreach (var database in GlobalVariables.OGlycansByDatabase.Concat(GlobalVariables.NGlycansByDatabase))
+            {
+                // DisplayName is the bare file name on purpose: it is half of the persisted key
+                // (databaseFileName, IdWithMotif) that the read-back projects and the engine matches on,
+                // so decorating it here -- with a count, say -- would break both.
+                var theDatabase = new ModTypeForTreeViewModel(database.Key, false);
+                GlycanTypeForTreeViewObservableCollection.Add(theDatabase);
+
+                foreach (var glycan in database.Value)
+                {
+                    theDatabase.Children.Add(new ModForTreeViewModel(
+                        GlycanToolTip(glycan), false, glycan.IdWithMotif, false, theDatabase, GlycanLabel(glycan)));
+                }
+            }
+
+            glycanTreeView.DataContext = GlycanTypeForTreeViewObservableCollection;
+            UpdateGlycanSelectionSummary();
+        }
+
+        /// <summary>
+        /// The row label: the identifier, the expanded composition, and the mass.
+        /// </summary>
+        /// <remarks>
+        /// IdWithMotif alone is a composition code ("H5N4A2 on N"), which is unreadable unless you already
+        /// know the letters, and unsearchable in the terms people actually use -- typing "HexNAc" would
+        /// match nothing. Spelling the monosaccharides out and appending the mass makes both work, because
+        /// the tree searches this label.
+        /// </remarks>
+        private static string GlycanLabel(Glycan glycan)
+        {
+            var expanded = ExpandComposition(glycan.Composition);
+            var mass = glycan.Mass / 1E5; // Glycan.Mass is monoisotopic mass scaled by 1e5
+
+            return string.IsNullOrEmpty(expanded)
+                ? string.Format(CultureInfo.InvariantCulture, "{0}   —   {1:F2} Da", glycan.IdWithMotif, mass)
+                : string.Format(CultureInfo.InvariantCulture, "{0}   —   {1}   —   {2:F2} Da", glycan.IdWithMotif, expanded, mass);
+        }
+
+        private static string GlycanToolTip(Glycan glycan)
+        {
+            var lines = new List<string>
+            {
+                "Composition: " + glycan.Composition,
+                "Expanded:    " + ExpandComposition(glycan.Composition),
+                string.Format(CultureInfo.InvariantCulture, "Mass:        {0:F5} Da", glycan.Mass / 1E5),
+                "Type:        " + glycan.Type,
+            };
+
+            // Only structure-format databases carry a structure string; composition databases leave it null.
+            if (!string.IsNullOrEmpty(glycan.Struc))
+            {
+                lines.Add("Structure:   " + glycan.Struc);
+            }
+
+            return string.Join(Environment.NewLine, lines);
+        }
+
+        /// <summary>
+        /// Turns a composition code such as "H5N4A2" into "Hex(5)HexNAc(4)NeuAc(2)".
+        /// </summary>
+        /// <remarks>
+        /// Built from Glycan.NameCharDic so custom monosaccharides registered at startup are spelled out
+        /// too, rather than silently falling back to their letter.
+        /// </remarks>
+        private static string ExpandComposition(string composition)
+        {
+            if (string.IsNullOrWhiteSpace(composition))
+            {
+                return string.Empty;
+            }
+
+            var nameByCode = new Dictionary<char, string>();
+            foreach (var entry in Glycan.NameCharDic)
+            {
+                nameByCode[entry.Value.Item1] = entry.Key;
+            }
+
+            var expanded = new System.Text.StringBuilder();
+            int i = 0;
+            while (i < composition.Length)
+            {
+                char code = composition[i++];
+                int start = i;
+                while (i < composition.Length && char.IsDigit(composition[i]))
+                {
+                    i++;
+                }
+
+                var count = i > start ? composition.Substring(start, i - start) : "1";
+                expanded.Append(nameByCode.TryGetValue(code, out var name) ? name : code.ToString())
+                        .Append('(').Append(count).Append(')');
+            }
+
+            return expanded.ToString();
+        }
+
+        private void UpdateGlycanSelectionSummary()
+        {
+            int selected = GlycanTypeForTreeViewObservableCollection.Sum(db => db.Children.Count(c => c.Use));
+            int total = GlycanTypeForTreeViewObservableCollection.Sum(db => db.Children.Count);
+
+            GlycanSelectionSummary.Content = selected == 0
+                ? string.Format(CultureInfo.InvariantCulture, "   none checked — the whole selected database will be searched ({0} glycans available)", total)
+                : string.Format(CultureInfo.InvariantCulture, "   {0} of {1} glycans checked", selected, total);
+        }
+
+        private void TextChanged_Glycan(object sender, TextChangedEventArgs args)
+        {
+            SearchModifications.SetTimer();
+            SearchModifications.GlycanSearch = true;
+        }
+
         private void TextChanged_Fixed(object sender, TextChangedEventArgs args)
         {
             SearchModifications.SetTimer();
@@ -537,6 +706,13 @@ namespace MetaMorpheusGUI
             {
                 SearchModifications.FilterTree(SearchVarMod, variableModsTreeView, VariableModTypeForTreeViewObservableCollection);
                 SearchModifications.VariableSearch = false;
+            }
+
+            if (SearchModifications.GlycanSearch)
+            {
+                // Searches the row label, not just the identifier, so "HexNAc", "2222" and "H5N4A2" all work.
+                SearchModifications.FilterTree(SearchGlycan, glycanTreeView, GlycanTypeForTreeViewObservableCollection, m => m.DisplayName);
+                SearchModifications.GlycanSearch = false;
             }
         }
 

--- a/MetaMorpheus/GUI/Util/SearchModifications.cs
+++ b/MetaMorpheus/GUI/Util/SearchModifications.cs
@@ -1,6 +1,5 @@
-﻿using System;
+using System;
 using System.Collections.ObjectModel;
-using System.Linq;
 using System.Windows.Controls;
 using System.Windows.Threading;
 using GuiFunctions;
@@ -14,7 +13,7 @@ namespace MetaMorpheusGUI
         public static bool VariableSearch;
         public static bool GptmdSearch;
         public static bool GlycanSearch;
-        
+
         public static void SetUpModSearchBoxes()
         {
             Timer = new DispatcherTimer();
@@ -32,19 +31,13 @@ namespace MetaMorpheusGUI
         // filters and expands tree according to user mod search
         public static void FilterTree(TextBox textbox, TreeView tree, ObservableCollection<ModTypeForTreeViewModel> collection)
         {
-            FilterTree(textbox, tree, collection, m => m.ModName);
+            FilterTree(textbox, tree, collection, null);
         }
 
         /// <summary>
-        /// As <see cref="FilterTree(TextBox,TreeView,ObservableCollection{ModTypeForTreeViewModel})"/>, but
-        /// searching text of the caller's choosing instead of only <see cref="ModForTreeViewModel.ModName"/>.
+        /// As above, but matching text of the caller's choosing instead of only
+        /// <see cref="ModForTreeViewModel.ModName"/> -- see <see cref="ModTreeFilter.Filter"/>.
         /// </summary>
-        /// <remarks>
-        /// Modification names are English words, so matching the identifier is enough -- "ribosyl" finds
-        /// "ADP-ribosylation on S". A glycan's identifier is a composition code, so matching it alone means
-        /// "HexNAc" finds nothing even in a database that spells HexNAc(1) on disk. This lets the glycan tree
-        /// search the expanded name and mass as well, without changing what the other search boxes do.
-        /// </remarks>
         public static void FilterTree(TextBox textbox, TreeView tree, ObservableCollection<ModTypeForTreeViewModel> collection,
             Func<ModForTreeViewModel, string> searchText)
         {
@@ -55,31 +48,7 @@ namespace MetaMorpheusGUI
                 return;
             }
 
-            var modTypesWithMatchingMods = collection.Where(p => p.Children.Any(c => Matches(c, searchText, key))); // parent of child mods that match key
-
-            var modsThatMatchSearchString = new ObservableCollection<ModTypeForTreeViewModel>(); // new collection containing expanded mod types that match key 
-
-            foreach (ModTypeForTreeViewModel modType in modTypesWithMatchingMods)
-            {
-                var textFilteredModType = new ModTypeForTreeViewModel(modType.DisplayName, false);
-                modsThatMatchSearchString.Add(textFilteredModType);
-                textFilteredModType.Expanded = true;
-                textFilteredModType.Use = modType.Use;
-
-                var matchingChildren = modType.Children.Where(p => Matches(p, searchText, key));
-                foreach (ModForTreeViewModel mod in matchingChildren)
-                {
-                    textFilteredModType.Children.Add(mod);
-                }
-            }
-
-            tree.DataContext = modsThatMatchSearchString;
-        }
-
-        private static bool Matches(ModForTreeViewModel mod, Func<ModForTreeViewModel, string> searchText, string key)
-        {
-            var text = searchText(mod);
-            return text != null && text.ToLower().Contains(key);
+            tree.DataContext = ModTreeFilter.Filter(collection, key, searchText);
         }
     }
 }

--- a/MetaMorpheus/GUI/Util/SearchModifications.cs
+++ b/MetaMorpheus/GUI/Util/SearchModifications.cs
@@ -13,6 +13,7 @@ namespace MetaMorpheusGUI
         public static bool FixedSearch;
         public static bool VariableSearch;
         public static bool GptmdSearch;
+        public static bool GlycanSearch;
         
         public static void SetUpModSearchBoxes()
         {
@@ -31,6 +32,22 @@ namespace MetaMorpheusGUI
         // filters and expands tree according to user mod search
         public static void FilterTree(TextBox textbox, TreeView tree, ObservableCollection<ModTypeForTreeViewModel> collection)
         {
+            FilterTree(textbox, tree, collection, m => m.ModName);
+        }
+
+        /// <summary>
+        /// As <see cref="FilterTree(TextBox,TreeView,ObservableCollection{ModTypeForTreeViewModel})"/>, but
+        /// searching text of the caller's choosing instead of only <see cref="ModForTreeViewModel.ModName"/>.
+        /// </summary>
+        /// <remarks>
+        /// Modification names are English words, so matching the identifier is enough -- "ribosyl" finds
+        /// "ADP-ribosylation on S". A glycan's identifier is a composition code, so matching it alone means
+        /// "HexNAc" finds nothing even in a database that spells HexNAc(1) on disk. This lets the glycan tree
+        /// search the expanded name and mass as well, without changing what the other search boxes do.
+        /// </remarks>
+        public static void FilterTree(TextBox textbox, TreeView tree, ObservableCollection<ModTypeForTreeViewModel> collection,
+            Func<ModForTreeViewModel, string> searchText)
+        {
             string key = textbox.Text.ToLower();
             if (string.IsNullOrEmpty(key))
             {
@@ -38,7 +55,7 @@ namespace MetaMorpheusGUI
                 return;
             }
 
-            var modTypesWithMatchingMods = collection.Where(p => p.Children.Any(c => c.ModName.ToLower().Contains(key))); // parent of child mods that match key
+            var modTypesWithMatchingMods = collection.Where(p => p.Children.Any(c => Matches(c, searchText, key))); // parent of child mods that match key
 
             var modsThatMatchSearchString = new ObservableCollection<ModTypeForTreeViewModel>(); // new collection containing expanded mod types that match key 
 
@@ -49,7 +66,7 @@ namespace MetaMorpheusGUI
                 textFilteredModType.Expanded = true;
                 textFilteredModType.Use = modType.Use;
 
-                var matchingChildren = modType.Children.Where(p => p.ModName.ToLower().Contains(key));
+                var matchingChildren = modType.Children.Where(p => Matches(p, searchText, key));
                 foreach (ModForTreeViewModel mod in matchingChildren)
                 {
                     textFilteredModType.Children.Add(mod);
@@ -57,6 +74,12 @@ namespace MetaMorpheusGUI
             }
 
             tree.DataContext = modsThatMatchSearchString;
+        }
+
+        private static bool Matches(ModForTreeViewModel mod, Func<ModForTreeViewModel, string> searchText, string key)
+        {
+            var text = searchText(mod);
+            return text != null && text.ToLower().Contains(key);
         }
     }
 }

--- a/MetaMorpheus/GUI/Views/CustomGlycanWindow.xaml
+++ b/MetaMorpheus/GUI/Views/CustomGlycanWindow.xaml
@@ -1,0 +1,70 @@
+<Window x:Class="MetaMorpheusGUI.CustomGlycanWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:MetaMorpheusGUI"
+        mc:Ignorable="d"
+        Title="Add glycan to custom O-glycan database" Height="300" Width="470" ResizeMode="NoResize" WindowStartupLocation="CenterScreen">
+    <Grid>
+        <StackPanel Orientation="Vertical" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="10,10,10,0">
+
+            <TextBlock TextWrapping="Wrap" Width="430" Margin="0,0,0,8">
+                Adds one glycan to your own O-glycan database. It is offered in the GlycoSearch task beside
+                the databases MetaMorpheus ships, which are never modified.
+            </TextBlock>
+
+            <!-- The glycan itself -->
+            <StackPanel Orientation="Horizontal">
+                <Label Content="Glycan" Width="60"></Label>
+                <Label Content="*" Foreground="Red" FontWeight="Bold"/>
+                <TextBox x:Name="glycanTextBox" Width="330" Height="22" VerticalContentAlignment="Center">
+                    <ToolTipService.ToolTip>
+                        <ToolTip Content="A structure, e.g. (N(H(A))) -- or a composition, e.g. HexNAc(1)Hex(1)NeuAc(1)" />
+                    </ToolTipService.ToolTip>
+                    <TextBox.Style>
+                        <Style TargetType="TextBox" xmlns:sys="clr-namespace:System;assembly=mscorlib">
+                            <Style.Resources>
+                                <VisualBrush x:Key="CueBannerBrush" AlignmentX="Left" AlignmentY="Center" Stretch="None">
+                                    <VisualBrush.Visual>
+                                        <Label Content="ex: '(N(H(A)))'  or  'HexNAc(1)Hex(1)NeuAc(1)'"  Foreground="Gray" />
+                                    </VisualBrush.Visual>
+                                </VisualBrush>
+                            </Style.Resources>
+                            <Style.Triggers>
+                                <Trigger Property="Text" Value="{x:Static sys:String.Empty}">
+                                    <Setter Property="Background" Value="{StaticResource CueBannerBrush}" />
+                                </Trigger>
+                                <Trigger Property="Text" Value="{x:Null}">
+                                    <Setter Property="Background" Value="{StaticResource CueBannerBrush}" />
+                                </Trigger>
+                                <Trigger Property="IsKeyboardFocused" Value="True">
+                                    <Setter Property="Background" Value="White" />
+                                </Trigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBox.Style>
+                </TextBox>
+            </StackPanel>
+
+            <TextBlock TextWrapping="Wrap" Width="430" Margin="0,10,0,0" Foreground="#555555">
+                <Bold>Structure</Bold> format nests single-character codes and is what OGlycan.gdb uses:
+                H Hex, N HexNAc, A NeuAc, G NeuGc, F Fuc, P Phospho, S Sulfo, Y Na, C Ac, X Xylose, K Kdn.<LineBreak/>
+                <Bold>Composition</Bold> format is a name and a count repeated, with no branching.<LineBreak/>
+                A database is read entirely as one format or the other, so a glycan has to match whatever is
+                already in the file.
+            </TextBlock>
+
+            <TextBlock TextWrapping="Wrap" Width="430" Margin="0,8,0,0" Foreground="#555555">
+                To use a monosaccharide MetaMorpheus does not ship with, declare it under
+                "Create new monosaccharide" first.
+            </TextBlock>
+
+        </StackPanel>
+        <!--Save and cancel buttons-->
+        <StackPanel Orientation="Horizontal" Height="35" VerticalAlignment="Bottom" HorizontalAlignment="Center">
+            <Button Name="saveButton" Content="Save Glycan" FontSize="13" Margin="5" Width="140" Click="SaveCustomGlycan_Click"/>
+            <Button Name="cancelButton" Content="Cancel" FontSize="13" Margin="5" Width="100" Click="CancelCustomGlycan_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/MetaMorpheus/GUI/Views/CustomGlycanWindow.xaml
+++ b/MetaMorpheus/GUI/Views/CustomGlycanWindow.xaml
@@ -5,14 +5,27 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:MetaMorpheusGUI"
         mc:Ignorable="d"
-        Title="Add glycan to custom O-glycan database" Height="300" Width="470" ResizeMode="NoResize" WindowStartupLocation="CenterScreen">
+        Title="Add glycan to a custom glycan database" Height="345" Width="470" ResizeMode="NoResize" WindowStartupLocation="CenterScreen">
     <Grid>
         <StackPanel Orientation="Vertical" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="10,10,10,0">
 
             <TextBlock TextWrapping="Wrap" Width="430" Margin="0,0,0,8">
-                Adds one glycan to your own O-glycan database. It is offered in the GlycoSearch task beside
-                the databases MetaMorpheus ships, which are never modified.
+                Adds one glycan to your own glycan database. It is offered in the GlycoSearch task beside the
+                databases MetaMorpheus ships, which are never modified.
             </TextBlock>
+
+            <!-- Which database -->
+            <StackPanel Orientation="Horizontal" Margin="0,0,0,4">
+                <Label Content="Database" Width="60"></Label>
+                <Label Content="*" Foreground="Red" FontWeight="Bold"/>
+                <ComboBox x:Name="databaseComboBox" Width="330" Height="22" SelectedIndex="0">
+                    <ToolTipService.ToolTip>
+                        <ToolTip Content="Which of your custom databases the glycan is added to" />
+                    </ToolTipService.ToolTip>
+                    <ComboBoxItem Content="O-glycan  (OGlycan_Custom.gdb)" />
+                    <ComboBoxItem Content="N-glycan  (NGlycan_Custom.gdb)" />
+                </ComboBox>
+            </StackPanel>
 
             <!-- The glycan itself -->
             <StackPanel Orientation="Horizontal">
@@ -20,14 +33,14 @@
                 <Label Content="*" Foreground="Red" FontWeight="Bold"/>
                 <TextBox x:Name="glycanTextBox" Width="330" Height="22" VerticalContentAlignment="Center">
                     <ToolTipService.ToolTip>
-                        <ToolTip Content="A structure, e.g. (N(H(A))) -- or a composition, e.g. HexNAc(1)Hex(1)NeuAc(1)" />
+                        <ToolTip Content="A structure, e.g. (N(H(A))) -- or a composition, e.g. HexNAc(2)Hex(5)" />
                     </ToolTipService.ToolTip>
                     <TextBox.Style>
                         <Style TargetType="TextBox" xmlns:sys="clr-namespace:System;assembly=mscorlib">
                             <Style.Resources>
                                 <VisualBrush x:Key="CueBannerBrush" AlignmentX="Left" AlignmentY="Center" Stretch="None">
                                     <VisualBrush.Visual>
-                                        <Label Content="ex: '(N(H(A)))'  or  'HexNAc(1)Hex(1)NeuAc(1)'"  Foreground="Gray" />
+                                        <Label Content="ex: '(N(H(A)))'  or  'HexNAc(2)Hex(5)'"  Foreground="Gray" />
                                     </VisualBrush.Visual>
                                 </VisualBrush>
                             </Style.Resources>
@@ -50,7 +63,8 @@
             <TextBlock TextWrapping="Wrap" Width="430" Margin="0,10,0,0" Foreground="#555555">
                 <Bold>Structure</Bold> format nests single-character codes and is what OGlycan.gdb uses:
                 H Hex, N HexNAc, A NeuAc, G NeuGc, F Fuc, P Phospho, S Sulfo, Y Na, C Ac, X Xylose, K Kdn.<LineBreak/>
-                <Bold>Composition</Bold> format is a name and a count repeated, with no branching.<LineBreak/>
+                <Bold>Composition</Bold> format is a name and a count repeated, with no branching, and is what
+                NGlycan.gdb uses.<LineBreak/>
                 A database is read entirely as one format or the other, so a glycan has to match whatever is
                 already in the file.
             </TextBlock>

--- a/MetaMorpheus/GUI/Views/CustomGlycanWindow.xaml.cs
+++ b/MetaMorpheus/GUI/Views/CustomGlycanWindow.xaml.cs
@@ -6,7 +6,8 @@ using System.Windows;
 namespace MetaMorpheusGUI
 {
     /// <summary>
-    /// Interaction logic for CustomGlycanWindow.xaml -- adds one glycan to the user's own O-glycan database.
+    /// Interaction logic for CustomGlycanWindow.xaml -- adds one glycan to the user's own O-glycan or
+    /// N-glycan database.
     /// </summary>
     /// <remarks>
     /// The window collects and sanity-checks; <see cref="GlycanDatabase.PersistCustomGlycan"/> is what
@@ -20,6 +21,13 @@ namespace MetaMorpheusGUI
             InitializeComponent();
         }
 
+        /// <summary>Whether the O-glycan database is the one selected. Index 0 is O, index 1 is N.</summary>
+        private bool IsOGlycanSelected => databaseComboBox.SelectedIndex == 0;
+
+        private string SelectedDatabasePath => IsOGlycanSelected
+            ? GlobalVariables.CustomOGlycanDatabasePath
+            : GlobalVariables.CustomNGlycanDatabasePath;
+
         private void SaveCustomGlycan_Click(object sender, RoutedEventArgs e)
         {
             string glycanText = glycanTextBox.Text.Trim();
@@ -29,10 +37,10 @@ namespace MetaMorpheusGUI
                 return;
             }
 
-            string databasePath = GlobalVariables.CustomOGlycanDatabasePath;
+            string databasePath = SelectedDatabasePath;
             try
             {
-                GlycanDatabase.PersistCustomGlycan(glycanText, databasePath, true);
+                GlycanDatabase.PersistCustomGlycan(glycanText, databasePath, IsOGlycanSelected);
             }
             catch (Exception ex)
             {

--- a/MetaMorpheus/GUI/Views/CustomGlycanWindow.xaml.cs
+++ b/MetaMorpheus/GUI/Views/CustomGlycanWindow.xaml.cs
@@ -1,0 +1,80 @@
+using EngineLayer;
+using System;
+using System.IO;
+using System.Windows;
+
+namespace MetaMorpheusGUI
+{
+    /// <summary>
+    /// Interaction logic for CustomGlycanWindow.xaml -- adds one glycan to the user's own O-glycan database.
+    /// </summary>
+    /// <remarks>
+    /// The window collects and sanity-checks; <see cref="GlycanDatabase.PersistCustomGlycan"/> is what
+    /// decides whether the entry is a glycan and writes it, so the format the file is read in and the format
+    /// it is written in cannot drift apart. Same split as CustomMonosaccharideWindow.
+    /// </remarks>
+    public partial class CustomGlycanWindow : Window
+    {
+        public CustomGlycanWindow()
+        {
+            InitializeComponent();
+        }
+
+        private void SaveCustomGlycan_Click(object sender, RoutedEventArgs e)
+        {
+            string glycanText = glycanTextBox.Text.Trim();
+
+            if (ErrorsDetected(glycanText))
+            {
+                return;
+            }
+
+            string databasePath = GlobalVariables.CustomOGlycanDatabasePath;
+            try
+            {
+                GlycanDatabase.PersistCustomGlycan(glycanText, databasePath, true);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("Error saving glycan: " + ex.Message, "Error", MessageBoxButton.OK, MessageBoxImage.Hand);
+                return;
+            }
+
+            MessageBox.Show(
+                $"The glycan \"{glycanText}\" was added to {Path.GetFileName(databasePath)}. Select that database in a "
+                + "GlycoSearch task to search for it.",
+                "Success", MessageBoxButton.OK, MessageBoxImage.Information);
+
+            DialogResult = true;
+        }
+
+        private void CancelCustomGlycan_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+
+        /// <summary>
+        /// The checks worth answering before the user has left the window. Everything else -- whether the
+        /// glycan parses, whether its format matches the file, whether it is already there -- is the
+        /// engine's call, and its message is shown as-is.
+        /// </summary>
+        private bool ErrorsDetected(string glycanText)
+        {
+            if (string.IsNullOrWhiteSpace(glycanText))
+            {
+                MessageBox.Show("Please enter a glycan.", "Error", MessageBoxButton.OK, MessageBoxImage.Hand);
+                return true;
+            }
+
+            if (glycanText.StartsWith("#", StringComparison.Ordinal))
+            {
+                MessageBox.Show(
+                    "A line beginning with '#' is a comment and would be ignored when the database is read. Enter the glycan itself.",
+                    "Error", MessageBoxButton.OK, MessageBoxImage.Hand);
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
+++ b/MetaMorpheus/GuiFunctions/GuiFunctions.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
@@ -16,7 +16,7 @@
   <ItemGroup>
     <PackageReference Include="itext7" Version="9.7.0" />
     <PackageReference Include="itext7.bouncy-castle-adapter" Version="9.7.0" />
-    <PackageReference Include="mzLib" Version="1.0.588" />
+    <PackageReference Include="mzLib" Version="1.0.589" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.0.0" />
     <PackageReference Include="Svg" Version="3.4.7" />
   </ItemGroup>

--- a/MetaMorpheus/GuiFunctions/ModTreeFilter.cs
+++ b/MetaMorpheus/GuiFunctions/ModTreeFilter.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace GuiFunctions;
+
+/// <summary>
+/// Narrows a modification/glycan tree to the nodes matching what the user typed.
+/// </summary>
+/// <remarks>
+/// Lives here rather than beside the search boxes in the GUI project so it can be tested: the
+/// caller keeps the WPF part (read the TextBox, assign the TreeView's DataContext) and this keeps
+/// the part with the behaviour in it.
+/// </remarks>
+public static class ModTreeFilter
+{
+    /// <summary>
+    /// The text a row is matched on when the caller does not say. Modification identifiers are
+    /// English words, so matching the identifier is enough for the modification trees.
+    /// </summary>
+    public static string DefaultSearchText(ModForTreeViewModel mod) => mod.ModName;
+
+    /// <param name="collection">The master collection. It is not modified.</param>
+    /// <param name="key">What the user typed. Matching is case-insensitive substring.</param>
+    /// <param name="searchText">
+    /// The text of a row to match against, defaulting to <see cref="DefaultSearchText"/>. The glycan
+    /// tree passes the display label instead, because a glycan identifier is a composition code --
+    /// matching only that means "HexNAc" finds nothing, even in a database that spells HexNAc(1) on
+    /// disk but parses to N1.
+    /// </param>
+    /// <returns>
+    /// Groups that contain at least one match, holding only their matching children and expanded.
+    /// </returns>
+    public static ObservableCollection<ModTypeForTreeViewModel> Filter(
+        IEnumerable<ModTypeForTreeViewModel> collection,
+        string key,
+        Func<ModForTreeViewModel, string> searchText = null)
+    {
+        searchText ??= DefaultSearchText;
+        var lowered = (key ?? string.Empty).ToLower();
+
+        var matching = new ObservableCollection<ModTypeForTreeViewModel>();
+
+        foreach (var modType in collection.Where(p => p.Children.Any(c => Matches(c, searchText, lowered))))
+        {
+            var filtered = new ModTypeForTreeViewModel(modType.DisplayName, false);
+            matching.Add(filtered);
+
+            // Order matters. Use is copied while Children is still empty, because the Use setter
+            // cascades to every child -- writing it after the children were added would overwrite
+            // the real check state, and the children below are the SAME instances as the master
+            // collection's, which is what makes filtering non-destructive.
+            filtered.Expanded = true;
+            filtered.Use = modType.Use;
+
+            foreach (var mod in modType.Children.Where(p => Matches(p, searchText, lowered)))
+            {
+                filtered.Children.Add(mod);
+            }
+        }
+
+        return matching;
+    }
+
+    private static bool Matches(ModForTreeViewModel mod, Func<ModForTreeViewModel, string> searchText, string loweredKey)
+    {
+        var text = searchText(mod);
+        return text != null && text.ToLower().Contains(loweredKey);
+    }
+}

--- a/MetaMorpheus/GuiFunctions/ViewModels/GlycanSelectionViewModel.cs
+++ b/MetaMorpheus/GuiFunctions/ViewModels/GlycanSelectionViewModel.cs
@@ -1,0 +1,313 @@
+﻿using EngineLayer;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+
+namespace GuiFunctions;
+
+/// <summary>
+/// The glycan tree in the Glyco Search task window: one group per glycan database, every glycan in
+/// it a checkable row, so a search can be narrowed to individual glycans instead of a whole database.
+/// </summary>
+/// <remarks>
+/// The glycans are handed in rather than read from <c>GlobalVariables</c> so a test can supply its
+/// own, matching how the other task-window view models take the task's parameter objects.
+///
+/// Reuses <see cref="ModTypeForTreeViewModel"/> and <see cref="ModForTreeViewModel"/> unchanged: a
+/// Glycan is a Modification, so the existing nodes already fit and no glycan-specific node type is
+/// needed. What this adds is the wiring those nodes lack -- see <see cref="OnGlycanUseChanged"/>.
+/// </remarks>
+public class GlycanSelectionViewModel : BaseViewModel
+{
+    private bool _syncingCheckState;
+    private string _summary;
+
+    /// <summary>
+    /// One node per glycan database, in the order given. This is the tree's ItemsSource, and the
+    /// master collection the read-back reads -- never a filtered view of it.
+    /// </summary>
+    public ObservableCollection<ModTypeForTreeViewModel> Databases { get; } = new ObservableCollection<ModTypeForTreeViewModel>();
+
+    /// <summary>
+    /// What is checked, in words, for the line beside the search box.
+    /// </summary>
+    public string Summary
+    {
+        get => _summary;
+        private set
+        {
+            _summary = value;
+            OnPropertyChanged(nameof(Summary));
+        }
+    }
+
+    /// <param name="glycansByDatabase">
+    /// Database file name -> the glycans it holds. <c>GlobalVariables.OGlycansByDatabase</c>
+    /// concatenated with <c>NGlycansByDatabase</c> is what the task window passes.
+    /// </param>
+    /// <param name="selectedGlycans">
+    /// A previously saved selection as (database file name, glycan IdWithMotif) pairs. Null or empty
+    /// means nothing is checked, which in turn means the whole database will be searched.
+    /// </param>
+    public GlycanSelectionViewModel(
+        IEnumerable<KeyValuePair<string, List<Glycan>>> glycansByDatabase,
+        IEnumerable<(string, string)> selectedGlycans = null)
+    {
+        foreach (var database in glycansByDatabase ?? Enumerable.Empty<KeyValuePair<string, List<Glycan>>>())
+        {
+            // DisplayName is the bare file name on purpose: it is half of the persisted key that
+            // ToSelectedGlycans projects and the engine matches on, so decorating it -- with a count,
+            // say -- would break both.
+            var theDatabase = new ModTypeForTreeViewModel(database.Key, false);
+            Databases.Add(theDatabase);
+
+            foreach (var glycan in database.Value ?? new List<Glycan>())
+            {
+                AddGlycan(theDatabase, GlycanToolTip(glycan), glycan.IdWithMotif, GlycanLabel(glycan), bad: false);
+            }
+
+            SettleCheckState(theDatabase);
+        }
+
+        Restore(selectedGlycans);
+        UpdateSummary();
+    }
+
+    /// <summary>
+    /// Re-checks the glycans a saved task named, and marks in red any it names that are no longer
+    /// there -- the same way the modification trees surface a mod this install does not have.
+    /// </summary>
+    private void Restore(IEnumerable<(string, string)> selectedGlycans)
+    {
+        foreach (var (databaseName, glycanId) in selectedGlycans ?? Enumerable.Empty<(string, string)>())
+        {
+            var theDatabase = Databases.FirstOrDefault(b => b.DisplayName.Equals(databaseName));
+            if (theDatabase == null)
+            {
+                // The database itself is gone, so the group has to be invented to hang the row on.
+                theDatabase = new ModTypeForTreeViewModel(databaseName, true);
+                Databases.Add(theDatabase);
+                AddGlycan(theDatabase, UnknownGlycan, glycanId, glycanId, bad: true);
+            }
+            else
+            {
+                var theGlycan = theDatabase.Children.FirstOrDefault(b => b.ModName.Equals(glycanId));
+                if (theGlycan != null)
+                {
+                    theGlycan.Use = true;
+                }
+                else
+                {
+                    AddGlycan(theDatabase, UnknownGlycan, glycanId, glycanId, bad: true);
+                }
+            }
+
+            SettleCheckState(theDatabase);
+        }
+    }
+
+    private void AddGlycan(ModTypeForTreeViewModel database, string toolTip, string modName, string displayName, bool bad)
+    {
+        var node = new ModForTreeViewModel(toolTip, bad, modName, bad, database, displayName);
+        node.PropertyChanged += OnGlycanUseChanged;
+        database.Children.Add(node);
+    }
+
+    /// <summary>
+    /// Keeps the database checkbox and <see cref="Summary"/> in step with the glycans underneath them.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ModForTreeViewModel.Use"/> notifies only itself; nothing tells the parent a child
+    /// changed, and <c>VerifyCheckState</c> is a manual pull the owner has to make. The modification
+    /// trees only ever make it while restoring a saved task, which is why a group there still reads
+    /// as fully checked right after you uncheck something inside it.
+    ///
+    /// The re-entrancy guard is required, not defensive: VerifyCheckState assigns the parent's Use,
+    /// and a non-null assignment cascades back down to every child, each of which raises
+    /// PropertyChanged again. Checking the last box in a group would otherwise recurse forever.
+    /// </remarks>
+    private void OnGlycanUseChanged(object sender, PropertyChangedEventArgs e)
+    {
+        if (_syncingCheckState || e.PropertyName != nameof(ModForTreeViewModel.Use))
+        {
+            return;
+        }
+
+        _syncingCheckState = true;
+        try
+        {
+            if (sender is ModForTreeViewModel glycan)
+            {
+                SettleCheckState(glycan.Parent);
+            }
+
+            UpdateSummary();
+        }
+        finally
+        {
+            _syncingCheckState = false;
+        }
+    }
+
+    /// <summary>
+    /// Brings one database checkbox into agreement with its children.
+    /// </summary>
+    /// <remarks>
+    /// The empty case has to be said outright. <see cref="ModTypeForTreeViewModel"/> takes <c>bad</c>
+    /// as its second constructor argument, not <c>use</c>, so Use is never initialized and a bool?
+    /// defaults to null -- which is the indeterminate box. VerifyCheckState over no children leaves
+    /// it there, so a database holding no glycans would be the only one that looked partly selected.
+    /// </remarks>
+    private static void SettleCheckState(ModTypeForTreeViewModel database)
+    {
+        if (database == null)
+        {
+            return;
+        }
+
+        if (database.Children.Count == 0)
+        {
+            database.Use = false;
+        }
+        else
+        {
+            database.VerifyCheckState();
+        }
+    }
+
+    private void UpdateSummary()
+    {
+        int selected = Databases.Sum(db => db.Children.Count(c => c.Use));
+        int total = Databases.Sum(db => db.Children.Count);
+        int databases = Databases.Count(db => db.Children.Any(c => c.Use));
+
+        // "entries", not "glycans": a glycan is listed once per attachment site, so the 12 lines of
+        // OGlycan.gdb are 24 rows here. Calling them glycans invites the reader to compare the number
+        // with the file and find it wrong.
+        Summary = selected == 0
+            ? string.Format(CultureInfo.InvariantCulture,
+                "   none checked â€” the whole selected database will be searched ({0} entries available)", total)
+            : string.Format(CultureInfo.InvariantCulture,
+                "   {0} of {1} entries checked, across {2} database{3}", selected, total, databases, databases == 1 ? "" : "s");
+    }
+
+    /// <summary>
+    /// The checked glycans as (database file name, glycan IdWithMotif) pairs, for
+    /// <c>GlycoSearchParameters.SelectedGlycans</c>. Empty means the whole database.
+    /// </summary>
+    /// <remarks>
+    /// Only leaves are read, and always from <see cref="Databases"/> rather than from whatever the
+    /// tree is currently displaying -- so a selection made while the search box is filtered is still
+    /// returned in full.
+    ///
+    /// Keyed by composition string rather than by Glycan.GlyId, which is a positional index into the
+    /// loaded array: a saved index would quietly point at a different glycan if the .gdb were edited.
+    /// </remarks>
+    public List<(string, string)> ToSelectedGlycans()
+    {
+        return Databases
+            .SelectMany(database => database.Children.Where(b => b.Use).Select(b => (b.Parent.DisplayName, b.ModName)))
+            .ToList();
+    }
+
+    /// <summary>
+    /// The row label: identifier, expanded composition, and mass.
+    /// </summary>
+    /// <remarks>
+    /// IdWithMotif alone is a composition code ("H5N4A2 on N"), unreadable unless you already know
+    /// the letters and unsearchable in the terms people use -- typing "HexNAc" would match nothing.
+    /// Spelling the monosaccharides out and appending the mass makes both work, because the tree
+    /// searches this label.
+    /// </remarks>
+    public static string GlycanLabel(Glycan glycan)
+    {
+        var expanded = ExpandComposition(glycan.Composition);
+        var mass = glycan.Mass / 1E5; // Glycan.Mass is the monoisotopic mass scaled by 1e5
+
+        return string.IsNullOrEmpty(expanded)
+            ? string.Format(CultureInfo.InvariantCulture, "{0}   â€”   {1:F2} Da", glycan.IdWithMotif, mass)
+            : string.Format(CultureInfo.InvariantCulture, "{0}   â€”   {1}   â€”   {2:F2} Da", glycan.IdWithMotif, expanded, mass);
+    }
+
+    public static string GlycanToolTip(Glycan glycan)
+    {
+        var lines = new List<string>
+        {
+            "Composition: " + glycan.Composition,
+            "Expanded:    " + ExpandComposition(glycan.Composition),
+            string.Format(CultureInfo.InvariantCulture, "Mass:        {0:F5} Da", glycan.Mass / 1E5),
+            "Type:        " + glycan.Type,
+        };
+
+        // Only structure-format databases carry a structure string; composition databases leave it null.
+        if (!string.IsNullOrEmpty(glycan.Struc))
+        {
+            lines.Add("Structure:   " + glycan.Struc);
+        }
+
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    /// <summary>
+    /// Turns a composition code such as "H5N4A2" into "Hex(5)HexNAc(4)NeuAc(2)".
+    /// </summary>
+    /// <remarks>
+    /// Built from Glycan.NameCharDic so custom monosaccharides registered at start-up are spelled out
+    /// too, rather than silently falling back to their letter. A code with no count means one, and an
+    /// unrecognized code is passed through as itself.
+    /// </remarks>
+    public static string ExpandComposition(string composition)
+    {
+        if (string.IsNullOrWhiteSpace(composition))
+        {
+            return string.Empty;
+        }
+
+        // NameCharDic holds aliases as well as canonical names -- "dHex" and "Fuc" share a code and a
+        // slot -- so an inversion has to choose, and must not choose by dictionary order. Ordering by
+        // slot then ordinally by name is deterministic and picks the canonical name, which is also the
+        // spelling the shipped databases use on disk.
+        var nameByCode = Glycan.NameCharDic
+            .GroupBy(entry => entry.Value.Item1)
+            .ToDictionary(
+                group => group.Key,
+                group => group.OrderBy(entry => entry.Value.Item2)
+                              .ThenBy(entry => entry.Key, StringComparer.Ordinal)
+                              .First().Key);
+
+        var expanded = new StringBuilder();
+        int i = 0;
+        while (i < composition.Length)
+        {
+            char code = composition[i++];
+            int start = i;
+            while (i < composition.Length && char.IsDigit(composition[i]))
+            {
+                i++;
+            }
+
+            var count = i > start ? composition.Substring(start, i - start) : "1";
+            expanded.Append(nameByCode.TryGetValue(code, out var name) ? name : code.ToString())
+                    .Append('(').Append(count).Append(')');
+        }
+
+        return expanded.ToString();
+    }
+
+    private const string UnknownGlycan = "UNKNOWN GLYCAN!";
+}
+
+[ExcludeFromCodeCoverage] // For design time gui display only
+public class GlycanSelectionModel : GlycanSelectionViewModel
+{
+    public static GlycanSelectionModel Instance => new GlycanSelectionModel();
+
+    public GlycanSelectionModel() : base(new Dictionary<string, List<Glycan>>())
+    {
+    }
+}

--- a/MetaMorpheus/GuiFunctions/ViewModels/ModForTreeViewModel.cs
+++ b/MetaMorpheus/GuiFunctions/ViewModels/ModForTreeViewModel.cs
@@ -99,6 +99,24 @@ namespace GuiFunctions
                 Background = new SolidColorBrush(Colors.Transparent);
         }
 
+        /// <summary>
+        /// As the constructor above, but with an explicit <see cref="DisplayName"/>.
+        /// </summary>
+        /// <remarks>
+        /// The other constructor derives DisplayName from modName, which is right when the identifier is
+        /// already readable ("Oxidation on M"). A glycan's identifier is a composition code -- "H5N4A2 on N"
+        /// -- so its row needs a label the reader can actually use, while ModName stays the key the task
+        /// parameters persist and the tree restores by.
+        /// </remarks>
+        public ModForTreeViewModel(string toolTip, bool use, string modName, bool bad, ModTypeForTreeViewModel parent, string displayName)
+            : this(toolTip, use, modName, bad, parent)
+        {
+            if (!string.IsNullOrWhiteSpace(displayName))
+            {
+                DisplayName = displayName;
+            }
+        }
+
         #endregion
 
         /// <summary>

--- a/MetaMorpheus/TaskLayer/GlycoSearchTask/GlycoSearchParameters.cs
+++ b/MetaMorpheus/TaskLayer/GlycoSearchTask/GlycoSearchParameters.cs
@@ -1,4 +1,4 @@
-using EngineLayer.GlycoSearch;
+﻿using EngineLayer.GlycoSearch;
 using System.Collections.Generic;
 using UsefulProteomicsDatabases;
 
@@ -10,6 +10,7 @@ namespace TaskLayer
         {
             OGlycanDatabasefile = "OGlycan.gdb";
             NGlycanDatabasefile = "NGlycan.gdb";
+            SelectedGlycans = new List<(string, string)>();
             GlycoSearchType = GlycoSearchType.OGlycanSearch;
             OxoniumIonFilt = true;
             DecoyType = DecoyType.Reverse;
@@ -37,6 +38,20 @@ namespace TaskLayer
         }
         public string OGlycanDatabasefile { get; set; }
         public string NGlycanDatabasefile { get; set; }
+
+        /// <summary>
+        /// The individual glycans the user checked, as (database file name, glycan IdWithMotif) pairs.
+        /// EMPTY MEANS THE WHOLE DATABASE -- which is what every task written before this existed says, so
+        /// old TOMLs and users who never open the tree keep today's behaviour exactly.
+        /// </summary>
+        /// <remarks>
+        /// Stored by composition string, never by Glycan.GlyId: GlyId is a positional index into the loaded
+        /// array, so a saved index would quietly point at a different glycan if the .gdb were edited.
+        ///
+        /// List&lt;(string, string)&gt; is deliberate -- MetaMorpheusTask.tomlConfig already registers a
+        /// converter for exactly this type, so it round-trips with no new serialization code.
+        /// </remarks>
+        public List<(string, string)> SelectedGlycans { get; set; }
         public GlycoSearchType GlycoSearchType { get; set; }
         public bool OxoniumIonFilt { get; set; }
         public DecoyType DecoyType { get; set; }

--- a/MetaMorpheus/TaskLayer/GlycoSearchTask/GlycoSearchTask.cs
+++ b/MetaMorpheus/TaskLayer/GlycoSearchTask/GlycoSearchTask.cs
@@ -132,7 +132,7 @@ namespace TaskLayer
 
                     Status("Searching files...", taskId);
                     new GlycoSearchEngine(newCsmsPerMS2ScanPerFile, arrayOfMs2ScansSortedByMass, peptideIndex, fragmentIndex, secondFragmentIndex, currentPartition, combinedParams, this.FileSpecificParameters,
-                        _glycoSearchParameters.OGlycanDatabasefile, _glycoSearchParameters.NGlycanDatabasefile, _glycoSearchParameters.GlycoSearchType, _glycoSearchParameters.GlycoSearchTopNum, _glycoSearchParameters.MaximumOGlycanAllowed, _glycoSearchParameters.OxoniumIonFilt, thisId).Run();
+                        _glycoSearchParameters.OGlycanDatabasefile, _glycoSearchParameters.NGlycanDatabasefile, _glycoSearchParameters.GlycoSearchType, _glycoSearchParameters.GlycoSearchTopNum, _glycoSearchParameters.MaximumOGlycanAllowed, _glycoSearchParameters.OxoniumIonFilt, thisId, _glycoSearchParameters.SelectedGlycans).Run();
 
                     ReportProgress(new ProgressEventArgs(100, "Done with search " + (currentPartition + 1) + "/" + CommonParameters.TotalPartitions + "!", thisId));
                     if (GlobalVariables.StopLoops) { break; }

--- a/MetaMorpheus/TaskLayer/TaskLayer.csproj
+++ b/MetaMorpheus/TaskLayer/TaskLayer.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.588" />
+    <PackageReference Include="mzLib" Version="1.0.589" />
     <PackageReference Include="NetSerializer" Version="4.1.2" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="SQLite.Interop.dll" Version="1.0.103" />

--- a/MetaMorpheus/Test/CustomDataFileTests.cs
+++ b/MetaMorpheus/Test/CustomDataFileTests.cs
@@ -180,6 +180,7 @@ namespace Test
                 ["custom rnases"] = GlobalVariables.CustomRnasePath,
                 ["custom monosaccharides"] = GlobalVariables.CustomMonosaccharidePath,
                 ["custom O-glycan database"] = GlobalVariables.CustomOGlycanDatabasePath,
+                ["custom N-glycan database"] = GlobalVariables.CustomNGlycanDatabasePath,
                 ["custom crosslinkers"] = Path.Combine(d, "Data", "CustomCrosslinkers.tsv"),
                 ["custom modifications"] = Path.Combine(d, "Mods", "CustomModifications.txt"),
                 ["custom RNA modifications"] = Path.Combine(d, "Mods", "RnaCustomModifications.txt"),

--- a/MetaMorpheus/Test/CustomDataFileTests.cs
+++ b/MetaMorpheus/Test/CustomDataFileTests.cs
@@ -1,4 +1,4 @@
-using EngineLayer;
+﻿using EngineLayer;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -179,6 +179,7 @@ namespace Test
                 ["custom proteases"] = GlobalVariables.CustomProteasePath,
                 ["custom rnases"] = GlobalVariables.CustomRnasePath,
                 ["custom monosaccharides"] = GlobalVariables.CustomMonosaccharidePath,
+                ["custom O-glycan database"] = GlobalVariables.CustomOGlycanDatabasePath,
                 ["custom crosslinkers"] = Path.Combine(d, "Data", "CustomCrosslinkers.tsv"),
                 ["custom modifications"] = Path.Combine(d, "Mods", "CustomModifications.txt"),
                 ["custom RNA modifications"] = Path.Combine(d, "Mods", "RnaCustomModifications.txt"),

--- a/MetaMorpheus/Test/CustomDataFileTests.cs
+++ b/MetaMorpheus/Test/CustomDataFileTests.cs
@@ -161,9 +161,18 @@ namespace Test
         /// Every custom file is seeded by startup, and none of them is a file the installer or the build
         /// also writes -- so listing them here is the inventory that a new custom file has to join.
         /// </summary>
+        /// <remarks>
+        /// Runs the startup itself rather than reading whatever the process happens to have lying around.
+        /// Test order is not fixed, and CustomAminoAcidsTest deletes CustomAminoAcids.txt when it finishes
+        /// ("Delete so it doesn't crash the next time") without seeding it again -- so asserting on ambient
+        /// state passes or fails depending on what ran first. Re-running SetUpGlobalVariables is what the
+        /// application does on launch, and is the pattern LoadDigestionAgentTest already uses to put the
+        /// globals back.
+        /// </remarks>
         [Test]
         public static void EveryKnownCustomFileIsSeededByStartup()
         {
+            GlobalVariables.SetUpGlobalVariables();
             string d = GlobalVariables.DataDir;
             var expected = new Dictionary<string, string>
             {

--- a/MetaMorpheus/Test/CustomDataFileTests.cs
+++ b/MetaMorpheus/Test/CustomDataFileTests.cs
@@ -1,0 +1,230 @@
+using EngineLayer;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Test
+{
+    /// <summary>
+    /// The custom-file contract, enforced. Every file a user is expected to edit must be seeded with a
+    /// template when it is absent and left strictly alone when it is present -- that second half is the
+    /// one that matters, and the one #2752 broke.
+    /// </summary>
+    [TestFixture]
+    public static class CustomDataFileTests
+    {
+        private static string _dir;
+
+        [SetUp]
+        public static void SetUp()
+        {
+            _dir = Path.Combine(TestContext.CurrentContext.TestDirectory, "CustomDataFileTests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+        }
+
+        [TearDown]
+        public static void TearDown()
+        {
+            if (Directory.Exists(_dir)) Directory.Delete(_dir, true);
+        }
+
+        /// <summary>
+        /// The rule the whole class exists for: an existing file is never touched, whatever is in it --
+        /// including content the template would never have produced.
+        /// </summary>
+        [Test]
+        public static void EnsureExists_NeverRewritesAnExistingFile()
+        {
+            string path = Path.Combine(_dir, "already_here.tsv");
+            const string userContent = "the user typed this\tand meant it\n";
+            File.WriteAllText(path, userContent);
+
+            CustomDataFile.EnsureExists(path, () => "TEMPLATE THAT MUST NOT APPEAR", "test");
+
+            Assert.That(File.ReadAllText(path), Is.EqualTo(userContent));
+        }
+
+        /// <summary>
+        /// An empty file is still the user's file. Seeding it would silently replace a file someone had
+        /// truncated on purpose, and "it was empty so I overwrote it" is exactly the reasoning that loses
+        /// data.
+        /// </summary>
+        [Test]
+        public static void EnsureExists_TreatsAnEmptyExistingFileAsTheUsers()
+        {
+            string path = Path.Combine(_dir, "empty.tsv");
+            File.WriteAllText(path, string.Empty);
+
+            CustomDataFile.EnsureExists(path, () => "TEMPLATE", "test");
+
+            Assert.That(File.ReadAllText(path), Is.Empty);
+        }
+
+        [Test]
+        public static void EnsureExists_SeedsWhenAbsent_AndCreatesTheDirectory()
+        {
+            string path = Path.Combine(_dir, "nested", "seeded.tsv");
+            Assert.That(File.Exists(path), Is.False, "precondition");
+
+            CustomDataFile.EnsureExists(path, () => "Name\tValue", "test");
+
+            Assert.That(File.ReadAllText(path), Is.EqualTo("Name\tValue"));
+        }
+
+        /// <summary>
+        /// The template must not be built when the file already exists -- reading an embedded resource on
+        /// every startup for a file that is already there is waste, and the deferred Func is the only
+        /// thing preventing it.
+        /// </summary>
+        [Test]
+        public static void EnsureExists_DoesNotBuildTheTemplateWhenTheFileExists()
+        {
+            string path = Path.Combine(_dir, "present.tsv");
+            File.WriteAllText(path, "x");
+            bool built = false;
+
+            CustomDataFile.EnsureExists(path, () => { built = true; return "y"; }, "test");
+
+            Assert.That(built, Is.False);
+        }
+
+        [Test]
+        public static void EnsureExists_ReportsAFailureRatherThanLeavingTheFileMissing()
+        {
+            string path = Path.Combine(_dir, "boom.tsv");
+
+            var ex = Assert.Throws<MetaMorpheusException>(() =>
+                CustomDataFile.EnsureExists(path, () => throw new InvalidOperationException("no template"), "test thing"));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.Message, Does.Contain("test thing"), "the message has to say which file");
+                Assert.That(ex.Message, Does.Contain(path));
+                Assert.That(File.Exists(path), Is.False);
+            });
+        }
+
+        /// <summary>
+        /// The template is the shipped file's banner and header with the data dropped. Keeping the banner
+        /// is the point: the user opens a file that documents its own format, which is what makes the
+        /// custom-protease template worth copying everywhere else.
+        /// </summary>
+        [Test]
+        public static void BannerAndHeader_KeepsCommentsAndHeader_AndDropsEveryDataRow()
+        {
+            string shipped = Path.Combine(_dir, "shipped.tsv");
+            File.WriteAllLines(shipped, new[]
+            {
+                "# what this file is",
+                "# how to edit it",
+                "Name\tSites\tMass",
+                "Trypsin\tKR\t0",
+                "LysC\tK\t0",
+            });
+
+            string template = CustomDataFile.BannerAndHeaderFromFile(shipped, "Name\t");
+
+            var lines = template.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
+            Assert.Multiple(() =>
+            {
+                Assert.That(lines, Is.EqualTo(new[] { "# what this file is", "# how to edit it", "Name\tSites\tMass" }));
+                Assert.That(template, Does.Not.Contain("Trypsin"), "a data row would become a fake custom entry");
+                Assert.That(template, Does.Not.Contain("LysC"));
+            });
+        }
+
+        /// <summary>
+        /// Every shipped file whose custom counterpart we seed must actually contain the header we look
+        /// for. If a header is renamed upstream this silently produces a data-row-free but header-free
+        /// template, and the user's first custom entry lands in a file the parser rejects.
+        /// </summary>
+        [Test]
+        public static void BannerAndHeader_FindsTheHeaderInTheRealShippedCrosslinkerFile()
+        {
+            string shipped = Path.Combine(GlobalVariables.DataDir, "Data", "Crosslinkers.tsv");
+            Assume.That(File.Exists(shipped), "shipped crosslinker file is required for this test");
+
+            string template = CustomDataFile.BannerAndHeaderFromFile(shipped, "Name\t");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(template, Does.StartWith("Name\t"));
+                Assert.That(template.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries).Length,
+                    Is.EqualTo(1), "LoadCrosslinkers skips only line 1, so this template must be exactly the header");
+                Assert.That(template, Does.Not.Contain("DSSO"), "no shipped crosslinker may leak into the custom file");
+            });
+        }
+
+        /// <summary>
+        /// Every custom file is seeded by startup, and none of them is a file the installer or the build
+        /// also writes -- so listing them here is the inventory that a new custom file has to join.
+        /// </summary>
+        [Test]
+        public static void EveryKnownCustomFileIsSeededByStartup()
+        {
+            string d = GlobalVariables.DataDir;
+            var expected = new Dictionary<string, string>
+            {
+                ["custom proteases"] = GlobalVariables.CustomProteasePath,
+                ["custom rnases"] = GlobalVariables.CustomRnasePath,
+                ["custom monosaccharides"] = GlobalVariables.CustomMonosaccharidePath,
+                ["custom crosslinkers"] = Path.Combine(d, "Data", "CustomCrosslinkers.tsv"),
+                ["custom modifications"] = Path.Combine(d, "Mods", "CustomModifications.txt"),
+                ["custom RNA modifications"] = Path.Combine(d, "Mods", "RnaCustomModifications.txt"),
+                ["custom amino acids"] = Path.Combine(d, "CustomAminoAcids", "CustomAminoAcids.txt"),
+            };
+
+            var missing = expected.Where(p => !File.Exists(p.Value)).Select(p => p.Key).ToList();
+            Assert.That(missing, Is.Empty, "not seeded by SetUpGlobalVariables: " + string.Join(", ", missing));
+        }
+
+        /// <summary>
+        /// A hand-edited crosslinker file picks up blank lines and notes. Both used to reach
+        /// ParseCrosslinkerFromString and surface as an unhandled IndexOutOfRangeException during startup,
+        /// before any window opened, with nothing naming the file.
+        /// </summary>
+        [Test]
+        public static void LoadCrosslinkers_SkipsBlankAndCommentLines()
+        {
+            string path = Path.Combine(_dir, "CustomCrosslinkers.tsv");
+            File.WriteAllLines(path, new[]
+            {
+                "Name\tCrosslinkAminoAcid\tCrosslinkerAminoAcid2\tCleavable\tDissociationType\tCrosslinkerTotalMass\tCrosslinkerShortMass\tCrosslinkerLongMass\tQuenchMassH2O\tQuenchMassNH2\tQuenchMassTris",
+                "# a note the user left themselves",
+                "",
+                "MyLinker\tK\tK\tT\tCID|HCD\t158.0038\t54.01056\t85.982635\t176.0143\t175.0303\t279.0777",
+                "   ",
+            });
+
+            var loaded = Crosslinker.LoadCrosslinkers(path).ToList();
+
+            Assert.That(loaded.Select(p => p.CrosslinkerName), Is.EqualTo(new[] { "MyLinker" }));
+        }
+
+        /// <summary>
+        /// A genuinely malformed row still has to fail -- but as a message naming the file and the line,
+        /// not as IndexOutOfRangeException from inside a LINQ iterator.
+        /// </summary>
+        [Test]
+        public static void LoadCrosslinkers_NamesTheFileAndLineForAShortRow()
+        {
+            string path = Path.Combine(_dir, "CustomCrosslinkers.tsv");
+            File.WriteAllLines(path, new[]
+            {
+                "Name\tCrosslinkAminoAcid\tCrosslinkerAminoAcid2\tCleavable\tDissociationType\tCrosslinkerTotalMass\tCrosslinkerShortMass\tCrosslinkerLongMass\tQuenchMassH2O\tQuenchMassNH2\tQuenchMassTris",
+                "OopsOnlyThree\tK\tK",
+            });
+
+            var ex = Assert.Throws<MetaMorpheusException>(() => Crosslinker.LoadCrosslinkers(path).ToList());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.Message, Does.Contain("CustomCrosslinkers.tsv"));
+                Assert.That(ex.Message, Does.Contain("Line 2"));
+                Assert.That(ex.Message, Does.Contain("OopsOnlyThree"), "the offending line is what the user has to fix");
+            });
+        }
+    }
+}

--- a/MetaMorpheus/Test/CustomFileCollisionTests.cs
+++ b/MetaMorpheus/Test/CustomFileCollisionTests.cs
@@ -1,0 +1,131 @@
+using EngineLayer;
+using NUnit.Framework;
+using Proteomics.ProteolyticDigestion;
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace Test
+{
+    /// <summary>
+    /// mzLib refuses to let a custom digestion agent shadow one of its own and reports it through
+    /// CustomDigestionAgentLoadResult.Skipped rather than throwing, so that the caller can tell the user.
+    /// Nothing consumed that before, so a user who named a custom protease after a built-in got silence
+    /// and a protease that was not theirs. These cover the reporting, and the embedded-resource half of
+    /// the template builder.
+    /// </summary>
+    [TestFixture]
+    public static class CustomFileCollisionTests
+    {
+        private static string _backup;
+        private static bool _hadFile;
+
+        [SetUp]
+        public static void SetUp()
+        {
+            _hadFile = File.Exists(GlobalVariables.CustomProteasePath);
+            if (_hadFile)
+            {
+                _backup = GlobalVariables.CustomProteasePath + ".bak";
+                File.Copy(GlobalVariables.CustomProteasePath, _backup, true);
+            }
+        }
+
+        [TearDown]
+        public static void TearDown()
+        {
+            if (_hadFile && _backup != null && File.Exists(_backup))
+            {
+                File.Copy(_backup, GlobalVariables.CustomProteasePath, true);
+                File.Delete(_backup);
+            }
+            else if (!_hadFile && File.Exists(GlobalVariables.CustomProteasePath))
+            {
+                File.Delete(GlobalVariables.CustomProteasePath);
+            }
+
+            _backup = null;
+            GlobalVariables.SetUpGlobalVariables();
+        }
+
+        /// <summary>
+        /// A custom protease that reuses a built-in's name is refused by mzLib -- silently, until now. The
+        /// user has to be told, because the protease they get is not the one they wrote.
+        /// </summary>
+        [Test]
+        public static void ACustomProteaseThatShadowsABuiltInIsReportedToTheUser()
+        {
+            string shadowed = ProteaseDictionary.Dictionary.Keys.First();
+
+            File.WriteAllLines(GlobalVariables.CustomProteasePath, new[]
+            {
+                "Name\tMotif\tSpecificity\tPSI-MS Accession\tPSI-MS Name\tCleavage Modification",
+                $"{shadowed}\tX|\tfull\t\t\t",
+            });
+
+            GlobalVariables.SetUpGlobalVariables();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(GlobalVariables.StartupWarnings.Any(w => w.Contains(shadowed)),
+                    Is.True, "the shadowed name has to be named: " + string.Join(" | ", GlobalVariables.StartupWarnings));
+                Assert.That(GlobalVariables.StartupWarnings.Any(w => w.Contains("proteases_custom.tsv")),
+                    Is.True, "and the file to fix it in");
+                // the built-in definition is the one that survives, which is the reason to warn at all
+                Assert.That(ProteaseDictionary.Dictionary[shadowed].DigestionMotifs.Any(m => m.InducingCleavage == "X"),
+                    Is.False, "the custom entry must not have replaced the built-in");
+            });
+        }
+
+        /// <summary>
+        /// The counterpart: a custom protease with a name of its own is not reported. Without this, the
+        /// assertion above would be satisfied by warning unconditionally, which is worse than silence.
+        /// </summary>
+        [Test]
+        public static void ACustomProteaseWithItsOwnNameIsNotReported()
+        {
+            File.WriteAllLines(GlobalVariables.CustomProteasePath, new[]
+            {
+                "Name\tMotif\tSpecificity\tPSI-MS Accession\tPSI-MS Name\tCleavage Modification",
+                "NotAShadowingName_ForTest\tX|\tfull\t\t\t",
+            });
+
+            GlobalVariables.SetUpGlobalVariables();
+
+            Assert.That(GlobalVariables.StartupWarnings.Any(w => w.Contains("could not be") || w.Contains("ignored")),
+                Is.False, "nothing to report: " + string.Join(" | ", GlobalVariables.StartupWarnings));
+        }
+
+        /// <summary>
+        /// The seeded custom-protease template is derived from mzLib's embedded proteases.tsv, which is
+        /// where the "banner plus header, no data rows" shape this whole policy copies comes from.
+        /// </summary>
+        [Test]
+        public static void TheProteaseTemplateComesFromMzLibsEmbeddedFile_AndCarriesNoProteases()
+        {
+            string template = CustomDataFile.BannerAndHeaderFrom(typeof(ProteaseDictionary).Assembly,
+                "Proteomics.ProteolyticDigestion.proteases.tsv", "Name\t");
+
+            var lines = template.Split(new[] { "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries);
+            Assert.Multiple(() =>
+            {
+                Assert.That(lines.Last(), Does.StartWith("Name\t"), "the header is the last line kept");
+                Assert.That(lines.Count(l => l.StartsWith("#")), Is.GreaterThan(0),
+                    "the banner is the part that makes the template worth seeding");
+                Assert.That(lines.Any(l => l.StartsWith("Arg-C\t")), Is.False,
+                    "a shipped protease in the custom file would look like the user's own");
+            });
+        }
+
+        [Test]
+        public static void AMissingEmbeddedTemplateIsReportedByName()
+        {
+            var ex = Assert.Throws<MetaMorpheusException>(() =>
+                CustomDataFile.BannerAndHeaderFrom(typeof(ProteaseDictionary).Assembly,
+                    "Proteomics.ProteolyticDigestion.this.resource.does.not.exist.tsv", "Name\t"));
+
+            Assert.That(ex!.Message, Does.Contain("this.resource.does.not.exist.tsv"));
+        }
+    }
+}

--- a/MetaMorpheus/Test/CustomGlycanDatabaseTests.cs
+++ b/MetaMorpheus/Test/CustomGlycanDatabaseTests.cs
@@ -1,0 +1,423 @@
+using EngineLayer;
+using EngineLayer.GlycoSearch;
+using MassSpectrometry;
+using NUnit.Framework;
+using Omics.Modifications;
+using Proteomics.ProteolyticDigestion;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace Test
+{
+    /// <summary>
+    /// The custom O-glycan database: the template a user is handed, the loader tolerance that lets a
+    /// documented database be read at all, and the validation that stands between what they type and
+    /// what the search will later have to parse.
+    /// </summary>
+    [TestFixture]
+    [NonParallelizable] // registers custom monosaccharides, which is process-wide state
+    public static class CustomGlycanDatabaseTests
+    {
+        private static string _dir;
+
+        [SetUp]
+        public static void SetUp()
+        {
+            _dir = Path.Combine(TestContext.CurrentContext.TestDirectory, "CustomGlycanDatabaseTests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+        }
+
+        [TearDown]
+        public static void TearDown()
+        {
+            Glycan.ResetCustomMonosaccharides();
+            if (Directory.Exists(_dir))
+            {
+                Directory.Delete(_dir, true);
+            }
+        }
+
+        private static string Path_(string name) => Path.Combine(_dir, name);
+
+        private static string EmbeddedTemplate() => CustomDataFile.EmbeddedText(
+            typeof(GlobalVariables).Assembly, "EngineLayer.Glycan_Mods.OGlycan_Custom.gdb");
+
+        // ---------------------------------------------------------------------------------------------
+        // The template
+        // ---------------------------------------------------------------------------------------------
+
+        /// <summary>
+        /// The template is embedded under the name the seeding code asks for. If the EmbeddedResource entry
+        /// in EngineLayer.csproj is dropped or the file is renamed, this is what says so.
+        /// </summary>
+        [Test]
+        public static void TheOGlycanTemplateIsEmbeddedUnderTheExpectedName()
+        {
+            var names = typeof(GlobalVariables).Assembly.GetManifestResourceNames();
+            Assert.That(names, Does.Contain("EngineLayer.Glycan_Mods.OGlycan_Custom.gdb"),
+                "the <EmbeddedResource Include=\"Glycan_Mods\\OGlycan_Custom.gdb\" /> entry in EngineLayer.csproj is missing");
+        }
+
+        /// <summary>
+        /// Every line of the shipped template is a comment or blank -- it documents the format and
+        /// contributes no glycans. A data row slipped into it would be silently searched by every user who
+        /// never opened the file.
+        /// </summary>
+        [Test]
+        public static void TheOGlycanTemplateHasNoDataRows()
+        {
+            string[] lines = EmbeddedTemplate().Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+
+            for (int i = 0; i < lines.Length; i++)
+            {
+                string line = lines[i];
+                Assert.That(string.IsNullOrWhiteSpace(line) || line.TrimStart().StartsWith("#"), Is.True,
+                    $"line {i + 1} of the embedded O-glycan template is a data row: \"{line}\"");
+            }
+        }
+
+        /// <summary>
+        /// A freshly seeded database loads, and loads to nothing. This is the case that runs on every user's
+        /// first launch: GlobalVariables.LoadGlycans reads every database in the list eagerly, so a template
+        /// the loaders could not read would throw inside SetUpGlobalVariables, before any window opened.
+        /// </summary>
+        [Test]
+        public static void TheSeededTemplateLoadsToZeroGlycansWithoutThrowing()
+        {
+            string path = Path_("OGlycan_Custom.gdb");
+            CustomDataFile.EnsureExists(path, EmbeddedTemplate, "custom O-glycan database");
+
+            Assert.That(File.Exists(path), Is.True);
+            Assert.That(GlycanDatabase.LoadGlycan(path, false, true).ToList(), Is.Empty);
+        }
+
+        // ---------------------------------------------------------------------------------------------
+        // Loader tolerance
+        // ---------------------------------------------------------------------------------------------
+
+        /// <summary>
+        /// A composition database that opens with a banner is still read as a composition database. The
+        /// format is sniffed from the first line, so before this the banner decided the format and the whole
+        /// file went to the structure parser.
+        /// </summary>
+        [Test]
+        public static void ACommentBannerDoesNotChangeWhichParserReadsTheFile()
+        {
+            string path = Path_("commented_composition.gdb");
+            File.WriteAllLines(path, new[]
+            {
+                "# my N-glycans",
+                "#",
+                "",
+                "HexNAc(2)Hex(5)",
+                "HexNAc(2)Hex(3)Fuc(1)",
+            });
+
+            var glycans = GlycanDatabase.LoadGlycan(path, false, false).ToList();
+
+            // two motifs (Nxs, Nxt) per composition
+            Assert.That(glycans.Count, Is.EqualTo(4));
+            Assert.That(glycans.Select(g => Glycan.GetKindString(g.Kind)).Distinct().Count(), Is.EqualTo(2));
+        }
+
+        /// <summary>
+        /// A comment that quotes a composition -- which the template does, to show the format -- is a comment.
+        /// LoadKindGlycan used to skip only lines that lacked "Hex", so this line reached String2Kind and
+        /// threw a KeyNotFoundException naming neither the file nor the line.
+        /// </summary>
+        [Test]
+        public static void ACommentThatQuotesACompositionIsNotReadAsAGlycan()
+        {
+            string path = Path_("comment_quotes_composition.gdb");
+            File.WriteAllLines(path, new[]
+            {
+                "HexNAc(2)Hex(5)",
+                "# for example HexNAc(2)Hex(3)Fuc(1)",
+            });
+
+            var glycans = GlycanDatabase.LoadGlycan(path, false, false).ToList();
+
+            Assert.That(glycans.Count, Is.EqualTo(2), "the commented composition was read as a glycan");
+        }
+
+        /// <summary>
+        /// The structure parser skips comments and blanks too. Before this it ran ValidateStructureLine over
+        /// the '#' and threw.
+        /// </summary>
+        [Test]
+        public static void TheStructureParserSkipsCommentsAndBlankLines()
+        {
+            string path = Path_("commented_structure.gdb");
+            File.WriteAllLines(path, new[]
+            {
+                "# my O-glycans",
+                "",
+                "(N)",
+                "   # indented comment",
+                "(N(H))",
+            });
+
+            var glycans = GlycanDatabase.LoadGlycan(path, false, true).ToList();
+
+            Assert.That(glycans.Count, Is.EqualTo(4)); // two motifs (S, T) per structure
+        }
+
+        /// <summary>
+        /// A structure with a character no monosaccharide claims is refused by name, naming the file and the
+        /// line -- it used to be a bare FormatException that said neither.
+        /// </summary>
+        [Test]
+        public static void AnUnknownMonosaccharideCodeNamesTheFileAndTheLine()
+        {
+            string path = Path_("bad_structure.gdb");
+            File.WriteAllLines(path, new[] { "# banner", "(N(H))", "(N(Q))" });
+
+            var ex = Assert.Throws<MetaMorpheusException>(() => GlycanDatabase.LoadGlycan(path, false, true).ToList());
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.Message, Does.Contain("bad_structure.gdb"));
+                Assert.That(ex.Message, Does.Contain("line 3"));
+                Assert.That(ex.Message, Does.Contain("'Q'"));
+            });
+        }
+
+        // ---------------------------------------------------------------------------------------------
+        // Adding a glycan
+        // ---------------------------------------------------------------------------------------------
+
+        [Test]
+        public static void AStructureIsAppendedAndReadsBack()
+        {
+            string path = Path_("OGlycan_Custom.gdb");
+            CustomDataFile.EnsureExists(path, EmbeddedTemplate, "custom O-glycan database");
+
+            GlycanDatabase.PersistCustomGlycan("(N(H(A)))", path, true);
+
+            var glycans = GlycanDatabase.LoadGlycan(path, false, true).ToList();
+            Assert.That(glycans.Count, Is.EqualTo(2)); // S and T
+            Assert.That(File.ReadAllText(path), Does.Contain("(N(H(A)))"));
+        }
+
+        [Test]
+        public static void ACompositionIsAppendedAndReadsBack()
+        {
+            string path = Path_("composition.gdb");
+            GlycanDatabase.PersistCustomGlycan("HexNAc(2)Hex(5)", path, false);
+
+            var glycans = GlycanDatabase.LoadGlycan(path, false, false).ToList();
+            Assert.That(glycans.Count, Is.EqualTo(2)); // Nxs and Nxt
+        }
+
+        /// <summary>
+        /// A database is read entirely as one format, so an entry in the other one would change how every
+        /// line already in the file is interpreted. It is refused rather than mixed in.
+        /// </summary>
+        [Test]
+        public static void AnEntryInTheOtherFormatIsRefused()
+        {
+            string path = Path_("structure_db.gdb");
+            File.WriteAllLines(path, new[] { "# banner", "(N(H))" });
+
+            var ex = Assert.Throws<MetaMorpheusException>(
+                () => GlycanDatabase.PersistCustomGlycan("HexNAc(2)Hex(5)", path, true));
+
+            Assert.That(ex.Message, Does.Contain("structure"));
+            Assert.That(ex.Message, Does.Contain("composition"));
+        }
+
+        /// <summary>
+        /// The format of a database that holds only a banner is undecided, so the first glycan added to a
+        /// freshly seeded file may be in either format.
+        /// </summary>
+        [Test]
+        public static void AFreshlySeededDatabaseAcceptsEitherFormat()
+        {
+            string structurePath = Path_("seeded_structure.gdb");
+            string compositionPath = Path_("seeded_composition.gdb");
+            CustomDataFile.EnsureExists(structurePath, EmbeddedTemplate, "custom O-glycan database");
+            CustomDataFile.EnsureExists(compositionPath, EmbeddedTemplate, "custom O-glycan database");
+
+            Assert.DoesNotThrow(() => GlycanDatabase.PersistCustomGlycan("(N(H))", structurePath, true));
+            Assert.DoesNotThrow(() => GlycanDatabase.PersistCustomGlycan("HexNAc(2)Hex(5)", compositionPath, true));
+        }
+
+        [Test]
+        public static void TheSameGlycanIsNotAddedTwice()
+        {
+            string path = Path_("dupe.gdb");
+            GlycanDatabase.PersistCustomGlycan("(N(H))", path, true);
+
+            var ex = Assert.Throws<MetaMorpheusException>(() => GlycanDatabase.PersistCustomGlycan("(N(H))", path, true));
+            Assert.That(ex.Message, Does.Contain("already contains"));
+        }
+
+        /// <summary>
+        /// A hand-edited .gdb very often has no final newline -- the shipped NGlycan_ForNoSearch.gdb test
+        /// fixture does not. Without the guard the new glycan is glued onto the end of the last one and both
+        /// are lost.
+        /// </summary>
+        [Test]
+        public static void AppendingToAFileWithNoTrailingNewlineDoesNotCorruptTheLastEntry()
+        {
+            string path = Path_("no_trailing_newline.gdb");
+            File.WriteAllText(path, "(N)\r\n(N(H))"); // deliberately unterminated
+
+            GlycanDatabase.PersistCustomGlycan("(N(A))", path, true);
+
+            var entries = File.ReadAllLines(path).Where(l => l.Trim().Length > 0).ToList();
+            Assert.That(entries, Is.EqualTo(new List<string> { "(N)", "(N(H))", "(N(A))" }));
+        }
+
+        [Test]
+        public static void AnUnknownMonosaccharideNameIsRefusedBeforeItReachesTheFile()
+        {
+            string path = Path_("unknown_name.gdb");
+
+            var ex = Assert.Throws<MetaMorpheusException>(
+                () => GlycanDatabase.PersistCustomGlycan("HexA(1)Hex(1)", path, false));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.Message, Does.Contain("HexA"));
+                Assert.That(ex.Message, Does.Contain("MonosaccharidesCustom.tsv"));
+                Assert.That(File.Exists(path), Is.False, "the file was written despite the entry being refused");
+            });
+        }
+
+        /// <summary>
+        /// Once a monosaccharide is declared, it is legal in both formats -- which is the promise the
+        /// MonosaccharidesCustom.tsv banner already makes about this file.
+        /// </summary>
+        [Test]
+        public static void ADeclaredCustomMonosaccharideIsAcceptedInBothFormats()
+        {
+            Glycan.ResetCustomMonosaccharides();
+            Glycan.RegisterCustomMonosaccharide("HexA", 'U', (int)Math.Round(176.03209 * 1E5), null);
+
+            string compositionPath = Path_("custom_sugar_composition.gdb");
+            string structurePath = Path_("custom_sugar_structure.gdb");
+
+            Assert.DoesNotThrow(() => GlycanDatabase.PersistCustomGlycan("HexNAc(1)HexA(1)", compositionPath, true));
+            Assert.DoesNotThrow(() => GlycanDatabase.PersistCustomGlycan("(N(U))", structurePath, true));
+
+            Assert.That(GlycanDatabase.LoadGlycan(structurePath, false, true).ToList(), Is.Not.Empty);
+        }
+
+        [Test]
+        public static void UnbalancedParenthesesAreRefused()
+        {
+            string path = Path_("unbalanced.gdb");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(Assert.Throws<MetaMorpheusException>(
+                    () => GlycanDatabase.PersistCustomGlycan("(N(H)", path, true)).Message, Does.Contain("balance"));
+                Assert.That(Assert.Throws<MetaMorpheusException>(
+                    () => GlycanDatabase.PersistCustomGlycan("(N(H)))", path, true)).Message, Does.Contain("balance"));
+            });
+        }
+
+        [Test]
+        public static void TextThatIsNeitherFormatIsRefused()
+        {
+            string path = Path_("nonsense.gdb");
+
+            var ex = Assert.Throws<MetaMorpheusException>(
+                () => GlycanDatabase.PersistCustomGlycan("a nice glycan please", path, true));
+            Assert.That(ex.Message, Does.Contain("neither a structure"));
+        }
+
+        [Test]
+        public static void ACommentIsRefusedRatherThanSilentlyIgnored()
+        {
+            string path = Path_("comment_entry.gdb");
+
+            var ex = Assert.Throws<MetaMorpheusException>(
+                () => GlycanDatabase.PersistCustomGlycan("# (N(H))", path, true));
+            Assert.That(ex.Message, Does.Contain("comment"));
+        }
+
+        [Test]
+        public static void ARepeatedMonosaccharideInOneCompositionIsRefused()
+        {
+            string path = Path_("repeated.gdb");
+
+            var ex = Assert.Throws<MetaMorpheusException>(
+                () => GlycanDatabase.PersistCustomGlycan("Hex(1)Hex(2)", path, false));
+            Assert.That(ex.Message, Does.Contain("more than once"));
+        }
+
+        // ---------------------------------------------------------------------------------------------
+        // Startup wiring, and the guard on an empty database
+        // ---------------------------------------------------------------------------------------------
+
+        /// <summary>
+        /// The custom database sits at the DataDir root, so unlike the shipped ones it is not found by the
+        /// directory sweep. If it is not added to the list by name it exists but is never offered.
+        /// </summary>
+        [Test]
+        public static void StartupOffersTheCustomOGlycanDatabase()
+        {
+            GlobalVariables.SetUpGlobalVariables();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(File.Exists(GlobalVariables.CustomOGlycanDatabasePath), Is.True);
+                Assert.That(GlobalVariables.OGlycanDatabasePaths, Does.Contain(GlobalVariables.CustomOGlycanDatabasePath));
+            });
+        }
+
+        /// <summary>
+        /// Searching a database with no glycans in it used to build an empty box array without complaint and
+        /// then throw "Sequence contains no elements" from inside the parallel search loop -- or, if no scan
+        /// reached that branch, quietly return nothing. It matters more now that a user can be handed an
+        /// empty database: a freshly seeded one is all banner until they add a glycan.
+        /// </summary>
+        [Test]
+        public static void SearchingAnEmptyGlycanDatabaseIsRefusedByName()
+        {
+            string path = Path_("OGlycan_Empty.gdb");
+            CustomDataFile.EnsureExists(path, EmbeddedTemplate, "custom O-glycan database");
+            GlobalVariables.OGlycanDatabasePaths.Add(path);
+
+            try
+            {
+                var ex = Assert.Throws<MetaMorpheusException>(() => new GlycoSearchEngine(
+                    new List<GlycoSpectralMatch>[0], new Ms2ScanWithSpecificMass[0],
+                    new List<PeptideWithSetModifications>(), null, null, 0,
+                    new CommonParameters(), null, "OGlycan_Empty.gdb", "NGlycan.gdb",
+                    GlycoSearchType.OGlycanSearch, 30, 3, false, null));
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(ex.Message, Does.Contain("OGlycan_Empty.gdb"));
+                    Assert.That(ex.Message, Does.Contain("no glycans"));
+                });
+            }
+            finally
+            {
+                GlobalVariables.OGlycanDatabasePaths.Remove(path);
+            }
+        }
+
+        /// <summary>
+        /// A database that is selected but no longer in the folder threw the same unhelpful
+        /// "Sequence contains no elements" from the path lookup. It now says which one is missing.
+        /// </summary>
+        [Test]
+        public static void SelectingAGlycanDatabaseThatIsNotThereIsRefusedByName()
+        {
+            var ex = Assert.Throws<MetaMorpheusException>(() => new GlycoSearchEngine(
+                new List<GlycoSpectralMatch>[0], new Ms2ScanWithSpecificMass[0],
+                new List<PeptideWithSetModifications>(), null, null, 0,
+                new CommonParameters(), null, "NoSuchDatabase.gdb", "NGlycan.gdb",
+                GlycoSearchType.OGlycanSearch, 30, 3, false, null));
+
+            Assert.That(ex.Message, Does.Contain("NoSuchDatabase.gdb"));
+        }
+    }
+}

--- a/MetaMorpheus/Test/CustomGlycanDatabaseTests.cs
+++ b/MetaMorpheus/Test/CustomGlycanDatabaseTests.cs
@@ -1,4 +1,4 @@
-using EngineLayer;
+﻿using EngineLayer;
 using EngineLayer.GlycoSearch;
 using MassSpectrometry;
 using NUnit.Framework;
@@ -349,6 +349,152 @@ namespace Test
             var ex = Assert.Throws<MetaMorpheusException>(
                 () => GlycanDatabase.PersistCustomGlycan("Hex(1)Hex(2)", path, false));
             Assert.That(ex.Message, Does.Contain("more than once"));
+        }
+
+
+        /// <summary>
+        /// Nothing at all, whitespace, and null are the same refusal. The window blocks the first two, but
+        /// the engine is what a CLI or a later caller reaches.
+        /// </summary>
+        [Test]
+        public static void AnEmptyOrNullGlycanIsRefused()
+        {
+            string path = Path_("empty_entry.gdb");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(Assert.Throws<MetaMorpheusException>(
+                    () => GlycanDatabase.PersistCustomGlycan(null, path, true)).Message, Does.Contain("no glycan was given"));
+                Assert.That(Assert.Throws<MetaMorpheusException>(
+                    () => GlycanDatabase.PersistCustomGlycan("   ", path, true)).Message, Does.Contain("no glycan was given"));
+                Assert.That(File.Exists(path), Is.False);
+            });
+        }
+
+        /// <summary>
+        /// One glycan per line. A tab would be read as the start of the name/mass columns the shipped .txt
+        /// databases carry, and a newline would smuggle in a second entry that never passed validation.
+        /// </summary>
+        [Test]
+        public static void AGlycanCarryingATabOrANewlineIsRefused()
+        {
+            string path = Path_("tabbed.gdb");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(Assert.Throws<MetaMorpheusException>(
+                    () => GlycanDatabase.PersistCustomGlycan("(N(H))\tN1H1", path, true)).Message, Does.Contain("one glycan per line"));
+                Assert.That(Assert.Throws<MetaMorpheusException>(
+                    () => GlycanDatabase.PersistCustomGlycan("(N(H))\r\n(N(A))", path, true)).Message, Does.Contain("one glycan per line"));
+                Assert.That(File.Exists(path), Is.False);
+            });
+        }
+
+        /// <summary>
+        /// A glycan that validates but cannot be written is reported naming the file, rather than leaving
+        /// the user believing it was saved. Forced portably by putting a directory where the file goes.
+        /// </summary>
+        [Test]
+        public static void AGlycanThatCannotBeWrittenIsReportedByName()
+        {
+            string path = Path_("unwritable.gdb");
+            Directory.CreateDirectory(path); // a directory where the database should be
+
+            var ex = Assert.Throws<MetaMorpheusException>(() => GlycanDatabase.PersistCustomGlycan("(N(H))", path, true));
+
+            Assert.That(ex.Message, Does.Contain("unwritable.gdb"));
+        }
+
+        /// <summary>
+        /// Counts are stored in a byte, so one above 255 cannot be represented. It is refused rather than
+        /// silently wrapping to a different glycan.
+        /// </summary>
+        [Test]
+        public static void ACountTooLargeToStoreIsRefused()
+        {
+            string path = Path_("big_count.gdb");
+
+            var ex = Assert.Throws<MetaMorpheusException>(
+                () => GlycanDatabase.PersistCustomGlycan("Hex(300)", path, false));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.Message, Does.Contain("between 0 and 255"));
+                Assert.That(File.Exists(path), Is.False);
+            });
+        }
+
+        /// <summary>
+        /// "()" balances, uses only legal characters, and parses -- into a glycan of nothing, whose mass is
+        /// zero. Searching for it is meaningless and it would widen every box it landed in. Same for a
+        /// composition that totals nothing.
+        /// </summary>
+        [Test]
+        public static void AGlycanWithNoMonosaccharidesIsRefused()
+        {
+            string path = Path_("empty_glycan.gdb");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(Assert.Throws<MetaMorpheusException>(
+                    () => GlycanDatabase.PersistCustomGlycan("()", path, true)).Message, Does.Contain("no monosaccharides"));
+                Assert.That(Assert.Throws<MetaMorpheusException>(
+                    () => GlycanDatabase.PersistCustomGlycan("Hex(0)", path, false)).Message, Does.Contain("no monosaccharides"));
+                Assert.That(File.Exists(path), Is.False);
+            });
+        }
+
+        /// <summary>
+        /// A structure whose nesting the tree builder cannot follow comes back as a NullReferenceException
+        /// from Struct2Glycan. It is reported as a refusal naming the entry, not raised at the user as a
+        /// null reference.
+        /// </summary>
+        [Test]
+        public static void AStructureTheTreeBuilderCannotFollowIsRefusedNotThrownRaw()
+        {
+            string path = Path_("bad_nesting.gdb");
+
+            var ex = Assert.Throws<MetaMorpheusException>(
+                () => GlycanDatabase.PersistCustomGlycan("(N())", path, true));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.Message, Does.Contain("(N())"));
+                Assert.That(File.Exists(path), Is.False);
+            });
+        }
+
+        /// <summary>
+        /// The format guard works in both directions -- a structure is refused by a composition database
+        /// just as a composition is refused by a structure one.
+        /// </summary>
+        [Test]
+        public static void AStructureIsRefusedByACompositionDatabase()
+        {
+            string path = Path_("composition_db.gdb");
+            File.WriteAllLines(path, new[] { "# banner", "HexNAc(2)Hex(5)" });
+
+            var ex = Assert.Throws<MetaMorpheusException>(
+                () => GlycanDatabase.PersistCustomGlycan("(N(H))", path, false));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(ex.Message, Does.Contain("composition"));
+                Assert.That(ex.Message, Does.Contain("structure"));
+            });
+        }
+
+        /// <summary>
+        /// A template that is not embedded is reported by the name that was asked for, so a dropped
+        /// EmbeddedResource entry says which one rather than failing as a null stream somewhere later.
+        /// </summary>
+        [Test]
+        public static void AMissingEmbeddedTemplateIsReportedByName()
+        {
+            var ex = Assert.Throws<MetaMorpheusException>(
+                () => CustomDataFile.EmbeddedText(typeof(GlobalVariables).Assembly, "EngineLayer.Glycan_Mods.NotAThing.gdb"));
+
+            Assert.That(ex.Message, Does.Contain("EngineLayer.Glycan_Mods.NotAThing.gdb"));
         }
 
         // ---------------------------------------------------------------------------------------------

--- a/MetaMorpheus/Test/CustomNGlycanDatabaseTests.cs
+++ b/MetaMorpheus/Test/CustomNGlycanDatabaseTests.cs
@@ -1,0 +1,177 @@
+using EngineLayer;
+using EngineLayer.GlycoSearch;
+using MassSpectrometry;
+using NUnit.Framework;
+using Proteomics.ProteolyticDigestion;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Test
+{
+    /// <summary>
+    /// The custom N-glycan database. The loader tolerance and the validate-and-append it rests on are
+    /// covered by <see cref="CustomGlycanDatabaseTests"/> and shared; what is N-specific is the template,
+    /// the seeding, and that a glycan added to it is read back on the N-glycan motifs.
+    /// </summary>
+    [TestFixture]
+    [NonParallelizable] // registers custom monosaccharides, which is process-wide state
+    public static class CustomNGlycanDatabaseTests
+    {
+        private static string _dir;
+
+        [SetUp]
+        public static void SetUp()
+        {
+            _dir = Path.Combine(TestContext.CurrentContext.TestDirectory, "CustomNGlycanDatabaseTests", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_dir);
+        }
+
+        [TearDown]
+        public static void TearDown()
+        {
+            Glycan.ResetCustomMonosaccharides();
+            if (Directory.Exists(_dir))
+            {
+                Directory.Delete(_dir, true);
+            }
+        }
+
+        private static string Path_(string name) => Path.Combine(_dir, name);
+
+        private static string EmbeddedTemplate() => CustomDataFile.EmbeddedText(
+            typeof(GlobalVariables).Assembly, "EngineLayer.Glycan_Mods.NGlycan_Custom.gdb");
+
+        /// <summary>
+        /// The template is embedded under the name the seeding code asks for. If the EmbeddedResource entry
+        /// in EngineLayer.csproj is dropped or the file is renamed, this is what says so.
+        /// </summary>
+        [Test]
+        public static void TheNGlycanTemplateIsEmbeddedUnderTheExpectedName()
+        {
+            var names = typeof(GlobalVariables).Assembly.GetManifestResourceNames();
+            Assert.That(names, Does.Contain("EngineLayer.Glycan_Mods.NGlycan_Custom.gdb"),
+                "the <EmbeddedResource Include=\"Glycan_Mods\\NGlycan_Custom.gdb\" /> entry in EngineLayer.csproj is missing");
+        }
+
+        /// <summary>
+        /// Every line of the shipped template is a comment or blank -- it documents the format and
+        /// contributes no glycans. A data row slipped into it would be silently searched by every user who
+        /// never opened the file.
+        /// </summary>
+        [Test]
+        public static void TheNGlycanTemplateHasNoDataRows()
+        {
+            string[] lines = EmbeddedTemplate().Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+
+            for (int i = 0; i < lines.Length; i++)
+            {
+                string line = lines[i];
+                Assert.That(string.IsNullOrWhiteSpace(line) || line.TrimStart().StartsWith("#"), Is.True,
+                    $"line {i + 1} of the embedded N-glycan template is a data row: \"{line}\"");
+            }
+        }
+
+        /// <summary>
+        /// A freshly seeded database loads, and loads to nothing. GlobalVariables.LoadGlycans reads every
+        /// database in the list eagerly, so a template the loaders could not read would throw inside
+        /// SetUpGlobalVariables, before any window opened.
+        /// </summary>
+        [Test]
+        public static void TheSeededTemplateLoadsToZeroGlycansWithoutThrowing()
+        {
+            string path = Path_("NGlycan_Custom.gdb");
+            CustomDataFile.EnsureExists(path, EmbeddedTemplate, "custom N-glycan database");
+
+            Assert.That(File.Exists(path), Is.True);
+            Assert.That(GlycanDatabase.LoadGlycan(path, false, false).ToList(), Is.Empty);
+        }
+
+        /// <summary>
+        /// A composition added to the seeded template reads back on both N-glycan sequons, with the
+        /// composition it was written with.
+        /// </summary>
+        [Test]
+        public static void ACompositionAddedToTheSeededTemplateReadsBackOnBothSequons()
+        {
+            string path = Path_("NGlycan_Custom.gdb");
+            CustomDataFile.EnsureExists(path, EmbeddedTemplate, "custom N-glycan database");
+
+            GlycanDatabase.PersistCustomGlycan("HexNAc(4)Hex(5)Fuc(1)NeuAc(1)", path, false);
+
+            var glycans = GlycanDatabase.LoadGlycan(path, false, false).ToList();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(glycans.Count, Is.EqualTo(2));
+                Assert.That(glycans.Select(g => g.Target.ToString()), Is.EquivalentTo(new[] { "Nxs", "Nxt" }));
+                Assert.That(glycans.Select(g => Glycan.GetKindString(g.Kind)).Distinct().Single(),
+                    Is.EqualTo(Glycan.GetKindString(GlycanDatabase.String2Kind("HexNAc(4)Hex(5)Fuc(1)NeuAc(1)"))));
+            });
+        }
+
+        /// <summary>
+        /// The N-glycan template invites composition format, but structure format is legal in it too -- the
+        /// loader picks the parser from the first data line, not from which database it is.
+        /// </summary>
+        [Test]
+        public static void AStructureIsAlsoLegalInAnNGlycanDatabase()
+        {
+            string path = Path_("NGlycan_structure.gdb");
+            CustomDataFile.EnsureExists(path, EmbeddedTemplate, "custom N-glycan database");
+
+            GlycanDatabase.PersistCustomGlycan("(N(N(H(H)(H))))", path, false);
+
+            var glycans = GlycanDatabase.LoadGlycan(path, false, false).ToList();
+            Assert.That(glycans, Is.Not.Empty);
+        }
+
+        /// <summary>
+        /// The custom database sits at the DataDir root, so unlike the shipped ones it is not found by the
+        /// directory sweep. If it is not added to the list by name it exists but is never offered.
+        /// </summary>
+        [Test]
+        public static void StartupOffersTheCustomNGlycanDatabase()
+        {
+            GlobalVariables.SetUpGlobalVariables();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(File.Exists(GlobalVariables.CustomNGlycanDatabasePath), Is.True);
+                Assert.That(GlobalVariables.NGlycanDatabasePaths, Does.Contain(GlobalVariables.CustomNGlycanDatabasePath));
+            });
+        }
+
+        /// <summary>
+        /// The empty-database guard covers the N-glycan search too -- that branch loads its database through
+        /// a separate call, and a freshly seeded N-glycan database is exactly the empty case.
+        /// </summary>
+        [Test]
+        public static void SearchingAnEmptyNGlycanDatabaseIsRefusedByName()
+        {
+            string path = Path_("NGlycan_Empty.gdb");
+            CustomDataFile.EnsureExists(path, EmbeddedTemplate, "custom N-glycan database");
+            GlobalVariables.NGlycanDatabasePaths.Add(path);
+
+            try
+            {
+                var ex = Assert.Throws<MetaMorpheusException>(() => new GlycoSearchEngine(
+                    new List<GlycoSpectralMatch>[0], new Ms2ScanWithSpecificMass[0],
+                    new List<PeptideWithSetModifications>(), null, null, 0,
+                    new CommonParameters(), null, "OGlycan.gdb", "NGlycan_Empty.gdb",
+                    GlycoSearchType.NGlycanSearch, 30, 3, false, null));
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(ex.Message, Does.Contain("NGlycan_Empty.gdb"));
+                    Assert.That(ex.Message, Does.Contain("no glycans"));
+                });
+            }
+            finally
+            {
+                GlobalVariables.NGlycanDatabasePaths.Remove(path);
+            }
+        }
+    }
+}

--- a/MetaMorpheus/Test/GlycoSearchEngineSelectedGlycansTests.cs
+++ b/MetaMorpheus/Test/GlycoSearchEngineSelectedGlycansTests.cs
@@ -1,0 +1,201 @@
+﻿using EngineLayer;
+using EngineLayer.GlycoSearch;
+using MassSpectrometry;
+using NUnit.Framework;
+using Proteomics.ProteolyticDigestion;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Test
+{
+    /// <summary>
+    /// GlycoSearchEngine narrowing a glycan database to the individual glycans the user checked.
+    /// </summary>
+    /// <remarks>
+    /// Marked NonParallelizable because the subset lands on GlycanBox's static GlobalOGlycans, which
+    /// GlobalVariables never resets between fixtures. TearDown puts the whole database back so a
+    /// later fixture asserting a baked-in glycan count does not fail on this one's leftovers.
+    /// </remarks>
+    [TestFixture]
+    [NonParallelizable]
+    public class GlycoSearchEngineSelectedGlycansTests
+    {
+        private const string OGlycanDatabase = "OGlycan.gdb";
+        private const string NGlycanDatabase = "NGlycan.gdb";
+
+        private static string PathOf(string databaseFileName)
+        {
+            return GlobalVariables.OGlycanDatabasePaths.Concat(GlobalVariables.NGlycanDatabasePaths)
+                .First(p => Path.GetFileName(p) == databaseFileName);
+        }
+
+        private static Glycan[] WholeODatabase()
+        {
+            return GlycanDatabase.LoadGlycan(PathOf(OGlycanDatabase), true, true).ToArray();
+        }
+
+        /// <summary>
+        /// Builds the engine and returns nothing: everything under test is the effect its constructor
+        /// has on GlycanBox's statics, which is where the subset has to be applied. It is applied
+        /// before the array is assigned and before any box is built, because a box identifies a
+        /// glycan by its POSITION in that array.
+        /// </summary>
+        private static void RunEngineConstructor(GlycoSearchType searchType, List<(string, string)> selectedGlycans, int maxOGlycanNum = 2)
+        {
+            var commonParameters = new CommonParameters(dissociationType: DissociationType.HCD, trimMsMsPeaks: false);
+
+            _ = new GlycoSearchEngine(
+                new List<GlycoSpectralMatch>[0],
+                new Ms2ScanWithSpecificMass[0],
+                new List<PeptideWithSetModifications>(),
+                null,
+                null,
+                0,
+                commonParameters,
+                null,
+                OGlycanDatabase,
+                NGlycanDatabase,
+                searchType,
+                glycoSearchTopNum: 30,
+                maxOGlycanNum: maxOGlycanNum,
+                oxoniumIonFilter: false,
+                nestedIds: null,
+                selectedGlycans: selectedGlycans);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            // Leave the statics holding the whole databases, the way start-up and every other fixture
+            // expect to find them. N_O_GlycanSearch settles both sides plus the box arrays.
+            RunEngineConstructor(GlycoSearchType.N_O_GlycanSearch, null);
+            RunEngineConstructor(GlycoSearchType.OGlycanSearch, null);
+        }
+
+        [Test]
+        public void NoSelection_SearchesTheWholeDatabase()
+        {
+            RunEngineConstructor(GlycoSearchType.OGlycanSearch, null);
+
+            Assert.That(GlycanBox.GlobalOGlycans.Length, Is.EqualTo(WholeODatabase().Length));
+        }
+
+        [Test]
+        public void EmptySelection_SearchesTheWholeDatabase()
+        {
+            // This is the compatibility case: it is what every task written before the feature says.
+            RunEngineConstructor(GlycoSearchType.OGlycanSearch, new List<(string, string)>());
+
+            Assert.That(GlycanBox.GlobalOGlycans.Length, Is.EqualTo(WholeODatabase().Length));
+        }
+
+        [Test]
+        public void ASelection_NarrowsTheDatabaseToTheChosenGlycans()
+        {
+            var chosen = WholeODatabase().Select(g => g.IdWithMotif).Distinct().Take(3).ToList();
+            var selection = chosen.Select(id => (OGlycanDatabase, id)).ToList();
+
+            RunEngineConstructor(GlycoSearchType.OGlycanSearch, selection);
+
+            Assert.That(GlycanBox.GlobalOGlycans.Length, Is.LessThan(WholeODatabase().Length));
+            Assert.That(GlycanBox.GlobalOGlycans.Select(g => g.IdWithMotif).Distinct(), Is.EquivalentTo(chosen));
+        }
+
+        [Test]
+        public void ASelectionNamingNothingThatExists_FallsBackToTheWholeDatabase()
+        {
+            // Better than handing BuildOGlycanBoxes an empty array, whose failure surfaces much later
+            // and elsewhere -- GlycanBoxes.First().Mass inside the parallel search loop.
+            var selection = new List<(string, string)> { (OGlycanDatabase, "H99N99 on S") };
+
+            RunEngineConstructor(GlycoSearchType.OGlycanSearch, selection);
+
+            Assert.That(GlycanBox.GlobalOGlycans.Length, Is.EqualTo(WholeODatabase().Length));
+        }
+
+        [Test]
+        public void ASelectionNamingOnlyTheOtherDatabase_LeavesThisOneWhole()
+        {
+            // Choosing individual N-glycans must not silently narrow the O-glycan side too.
+            var selection = new List<(string, string)> { (NGlycanDatabase, "H5N2 on Nxs") };
+
+            RunEngineConstructor(GlycoSearchType.OGlycanSearch, selection);
+
+            Assert.That(GlycanBox.GlobalOGlycans.Length, Is.EqualTo(WholeODatabase().Length));
+        }
+
+        [Test]
+        public void ANarrowedDatabase_BuildsFewerBoxes()
+        {
+            // The point of the feature. BuildOGlycanBoxes is combinations-with-repetition over the
+            // whole array, so the box count is what a selection actually collapses.
+            RunEngineConstructor(GlycoSearchType.OGlycanSearch, null);
+            int boxesForTheWholeDatabase = GlycanBox.OGlycanBoxes.Length;
+
+            var chosen = WholeODatabase().Select(g => g.IdWithMotif).Distinct().Take(2).ToList();
+            RunEngineConstructor(GlycoSearchType.OGlycanSearch, chosen.Select(id => (OGlycanDatabase, id)).ToList());
+
+            Assert.That(GlycanBox.OGlycanBoxes.Length, Is.LessThan(boxesForTheWholeDatabase));
+        }
+
+        [Test]
+        public void ANarrowedDatabase_BuildsBoxesThatPointOnlyAtChosenGlycans()
+        {
+            // The reason the filter is applied before GlobalOGlycans is assigned. A box identifies a
+            // glycan by its index into that array, so filtering after the assignment would leave every
+            // box pointing at a different glycan than the one the user picked -- silently.
+            var chosen = WholeODatabase().Select(g => g.IdWithMotif).Distinct().Take(3).ToList();
+
+            RunEngineConstructor(GlycoSearchType.OGlycanSearch, chosen.Select(id => (OGlycanDatabase, id)).ToList());
+
+            Assert.That(GlycanBox.OGlycanBoxes, Is.Not.Empty);
+            foreach (var box in GlycanBox.OGlycanBoxes)
+            {
+                foreach (var id in box.ModIds)
+                {
+                    Assert.That(id, Is.InRange(0, GlycanBox.GlobalOGlycans.Length - 1));
+                    Assert.That(chosen, Does.Contain(GlycanBox.GlobalOGlycans[id].IdWithMotif));
+                }
+            }
+        }
+
+        [Test]
+        public void NOGlycanSearch_NarrowsTheNGlycanSideToo()
+        {
+            var wholeN = GlycanDatabase.LoadGlycan(PathOf(NGlycanDatabase), true, false).ToArray();
+            var chosen = wholeN.Select(g => g.IdWithMotif).Distinct().Take(4).ToList();
+
+            RunEngineConstructor(GlycoSearchType.N_O_GlycanSearch, chosen.Select(id => (NGlycanDatabase, id)).ToList());
+
+            Assert.That(GlycanBox.GlobalNGlycans.Values.Select(g => g.IdWithMotif).Distinct(), Is.EquivalentTo(chosen));
+            Assert.That(GlycanBox.GlobalNGlycans.Count, Is.LessThan(wholeN.Length));
+        }
+
+        [Test]
+        public void NOGlycanSearch_ReIndexesTheNarrowedNGlycansDenselyAndNegatively()
+        {
+            // N-glycans are keyed by negative index to tell them apart from O-glycans, and the keys
+            // are handed out in load order. Narrowing has to produce -1..-m with no gaps, or a box
+            // referring to a key that was skipped resolves to nothing.
+            var wholeN = GlycanDatabase.LoadGlycan(PathOf(NGlycanDatabase), true, false).ToArray();
+            var chosen = wholeN.Select(g => g.IdWithMotif).Distinct().Take(4).ToList();
+
+            RunEngineConstructor(GlycoSearchType.N_O_GlycanSearch, chosen.Select(id => (NGlycanDatabase, id)).ToList());
+
+            var keys = GlycanBox.GlobalNGlycans.Keys.OrderByDescending(k => k).ToList();
+            Assert.That(keys, Is.EqualTo(Enumerable.Range(1, keys.Count).Select(i => -i).ToList()));
+        }
+
+        [Test]
+        public void NOGlycanSearch_NarrowingOnlyTheNSideLeavesTheOSideWhole()
+        {
+            var wholeN = GlycanDatabase.LoadGlycan(PathOf(NGlycanDatabase), true, false).ToArray();
+            var chosen = wholeN.Select(g => g.IdWithMotif).Distinct().Take(2).ToList();
+
+            RunEngineConstructor(GlycoSearchType.N_O_GlycanSearch, chosen.Select(id => (NGlycanDatabase, id)).ToList());
+
+            Assert.That(GlycanBox.GlobalOGlycans.Length, Is.EqualTo(WholeODatabase().Length));
+        }
+    }
+}

--- a/MetaMorpheus/Test/GlycoSearchParametersTomlTests.cs
+++ b/MetaMorpheus/Test/GlycoSearchParametersTomlTests.cs
@@ -1,0 +1,140 @@
+using Nett;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using TaskLayer;
+
+namespace Test
+{
+    /// <summary>
+    /// The individual-glycan selection has to survive a task being saved and reopened, and a task
+    /// saved before the selection existed has to keep behaving as it did.
+    /// </summary>
+    [TestFixture]
+    public class GlycoSearchParametersTomlTests
+    {
+        private string _tomlPath;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _tomlPath = Path.Combine(TestContext.CurrentContext.TestDirectory, "GlycoSelectedGlycans.toml");
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            if (File.Exists(_tomlPath))
+            {
+                File.Delete(_tomlPath);
+            }
+        }
+
+        private GlycoSearchTask WriteAndReadBack(GlycoSearchTask task)
+        {
+            Toml.WriteFile(task, _tomlPath, MetaMorpheusTask.tomlConfig);
+            return Toml.ReadFile<GlycoSearchTask>(_tomlPath, MetaMorpheusTask.tomlConfig);
+        }
+
+        [Test]
+        public void SelectedGlycans_DefaultsToEmptyMeaningTheWholeDatabase()
+        {
+            var task = new GlycoSearchTask();
+
+            Assert.That(task._glycoSearchParameters.SelectedGlycans, Is.Not.Null);
+            Assert.That(task._glycoSearchParameters.SelectedGlycans, Is.Empty);
+        }
+
+        [Test]
+        public void SelectedGlycans_RoundTripsThroughToml()
+        {
+            var task = new GlycoSearchTask();
+            task._glycoSearchParameters.SelectedGlycans = new List<(string, string)>
+            {
+                ("OGlycan.gdb", "N1 on S"),
+                ("OGlycan.gdb", "H1N1 on T"),
+                ("NGlycan.gdb", "H5N2 on Nxs"),
+            };
+
+            var loaded = WriteAndReadBack(task);
+
+            Assert.That(loaded._glycoSearchParameters.SelectedGlycans,
+                Is.EqualTo(task._glycoSearchParameters.SelectedGlycans));
+        }
+
+        [Test]
+        public void SelectedGlycans_RoundTripsASelectionSpanningTwoDatabases()
+        {
+            var task = new GlycoSearchTask();
+            task._glycoSearchParameters.SelectedGlycans = new List<(string, string)>
+            {
+                ("OGlycan.gdb", "N1 on S"),
+                ("NGlycan.gdb", "H5N2 on Nxs"),
+            };
+
+            var loaded = WriteAndReadBack(task);
+
+            // The database name is half the key, and it is what the engine matches on to decide which
+            // database a chosen glycan belongs to -- so it has to survive, not just the glycan id.
+            Assert.That(loaded._glycoSearchParameters.SelectedGlycans.Select(s => s.Item1),
+                Is.EquivalentTo(new[] { "OGlycan.gdb", "NGlycan.gdb" }));
+            Assert.That(loaded._glycoSearchParameters.SelectedGlycans.Select(s => s.Item2),
+                Is.EquivalentTo(new[] { "N1 on S", "H5N2 on Nxs" }));
+        }
+
+        [Test]
+        public void SelectedGlycans_RoundTripsAnEmptySelection()
+        {
+            var task = new GlycoSearchTask();
+            task._glycoSearchParameters.SelectedGlycans = new List<(string, string)>();
+
+            var loaded = WriteAndReadBack(task);
+
+            Assert.That(loaded._glycoSearchParameters.SelectedGlycans, Is.Empty);
+        }
+
+        [Test]
+        public void SelectedGlycans_KeepsTheDatabaseFileNamesAlongsideIt()
+        {
+            // The tree narrows a database; it does not replace choosing one. Both have to persist.
+            var task = new GlycoSearchTask();
+            task._glycoSearchParameters.OGlycanDatabasefile = "OGlycan_withIsobaric.gdb";
+            task._glycoSearchParameters.SelectedGlycans = new List<(string, string)>
+            {
+                ("OGlycan_withIsobaric.gdb", "N1 on S"),
+            };
+
+            var loaded = WriteAndReadBack(task);
+
+            Assert.That(loaded._glycoSearchParameters.OGlycanDatabasefile, Is.EqualTo("OGlycan_withIsobaric.gdb"));
+            Assert.That(loaded._glycoSearchParameters.SelectedGlycans.Single().Item1, Is.EqualTo("OGlycan_withIsobaric.gdb"));
+        }
+
+        [Test]
+        public void ATaskFileWrittenBeforeSelectedGlycansExistedStillLoads()
+        {
+            // The compatibility guarantee, tested the way it will actually be met: every GlycoSearch
+            // toml already on a user's disk has no SelectedGlycans line at all. It must load, and it
+            // must load as "nothing selected", which the engine reads as the whole database.
+            var task = new GlycoSearchTask();
+            task._glycoSearchParameters.SelectedGlycans = new List<(string, string)>
+            {
+                ("OGlycan.gdb", "N1 on S"),
+            };
+            Toml.WriteFile(task, _tomlPath, MetaMorpheusTask.tomlConfig);
+
+            var withoutTheLine = File.ReadAllLines(_tomlPath)
+                .Where(line => !line.TrimStart().StartsWith("SelectedGlycans"))
+                .ToArray();
+            Assert.That(withoutTheLine.Length, Is.LessThan(File.ReadAllLines(_tomlPath).Length),
+                "the property should have been written, otherwise this test proves nothing");
+            File.WriteAllLines(_tomlPath, withoutTheLine);
+
+            var loaded = Toml.ReadFile<GlycoSearchTask>(_tomlPath, MetaMorpheusTask.tomlConfig);
+
+            Assert.That(loaded._glycoSearchParameters.SelectedGlycans, Is.Not.Null);
+            Assert.That(loaded._glycoSearchParameters.SelectedGlycans, Is.Empty);
+        }
+    }
+}

--- a/MetaMorpheus/Test/GuiTests/GlycanSelectionViewModelTests.cs
+++ b/MetaMorpheus/Test/GuiTests/GlycanSelectionViewModelTests.cs
@@ -1,0 +1,311 @@
+﻿using EngineLayer;
+using EngineLayer.GlycoSearch;
+using GuiFunctions;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Test.GuiTests
+{
+    [TestFixture]
+    public class GlycanSelectionViewModelTests
+    {
+        /// <summary>
+        /// A composition-format glycan, built the way GlycanDatabase builds one from a .gdb line.
+        /// </summary>
+        private static Glycan MakeGlycan(string composition, string motif, GlycanType type = GlycanType.O_glycan)
+        {
+            return new Glycan(GlycanDatabase.String2Kind(composition), motif, type);
+        }
+
+        private static Dictionary<string, List<Glycan>> TwoDatabases()
+        {
+            return new Dictionary<string, List<Glycan>>
+            {
+                ["OGlycan.gdb"] = new List<Glycan>
+                {
+                    MakeGlycan("HexNAc(1)", "S"),
+                    MakeGlycan("HexNAc(1)Hex(1)", "S"),
+                    MakeGlycan("HexNAc(1)Hex(1)NeuAc(1)", "T"),
+                },
+                ["NGlycan.gdb"] = new List<Glycan>
+                {
+                    MakeGlycan("HexNAc(2)Hex(5)", "Nxs", GlycanType.N_glycan),
+                    MakeGlycan("HexNAc(2)Hex(6)", "Nxt", GlycanType.N_glycan),
+                },
+            };
+        }
+
+        [Test]
+        public void Constructor_GroupsGlycansByDatabase()
+        {
+            var viewModel = new GlycanSelectionViewModel(TwoDatabases());
+
+            Assert.That(viewModel.Databases.Count, Is.EqualTo(2));
+            Assert.That(viewModel.Databases.Select(d => d.DisplayName), Is.EqualTo(new[] { "OGlycan.gdb", "NGlycan.gdb" }));
+            Assert.That(viewModel.Databases[0].Children.Count, Is.EqualTo(3));
+            Assert.That(viewModel.Databases[1].Children.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Constructor_NothingIsCheckedByDefault()
+        {
+            var viewModel = new GlycanSelectionViewModel(TwoDatabases());
+
+            Assert.That(viewModel.Databases.SelectMany(d => d.Children).Any(c => c.Use), Is.False);
+            Assert.That(viewModel.ToSelectedGlycans(), Is.Empty);
+        }
+
+        [Test]
+        public void Constructor_DatabaseWithNoGlycansIsUncheckedNotIndeterminate()
+        {
+            // ModTypeForTreeViewModel takes `bad` as its second argument, not `use`, so Use is never
+            // initialised and a bool? defaults to null -- which renders as the indeterminate box. An
+            // empty database would otherwise be the only group that looked partly selected.
+            var databases = new Dictionary<string, List<Glycan>>
+            {
+                ["OGlycan_Custom.gdb"] = new List<Glycan>(),
+            };
+
+            var viewModel = new GlycanSelectionViewModel(databases);
+
+            Assert.That(viewModel.Databases.Single().Use, Is.False);
+        }
+
+        [Test]
+        public void CheckingAGlycan_MakesItsDatabaseIndeterminate()
+        {
+            var viewModel = new GlycanSelectionViewModel(TwoDatabases());
+            var database = viewModel.Databases.First(d => d.DisplayName == "OGlycan.gdb");
+
+            database.Children[0].Use = true;
+
+            Assert.That(database.Use, Is.Null);
+        }
+
+        [Test]
+        public void CheckingEveryGlycan_MakesItsDatabaseChecked()
+        {
+            var viewModel = new GlycanSelectionViewModel(TwoDatabases());
+            var database = viewModel.Databases.First(d => d.DisplayName == "OGlycan.gdb");
+
+            foreach (var child in database.Children)
+            {
+                child.Use = true;
+            }
+
+            // Also the re-entrancy case: settling the parent to true cascades back down to every
+            // child, each raising PropertyChanged again. Without the guard this never returns.
+            Assert.That(database.Use, Is.True);
+        }
+
+        [Test]
+        public void UncheckingTheLastGlycan_ReturnsItsDatabaseToUnchecked()
+        {
+            var viewModel = new GlycanSelectionViewModel(TwoDatabases());
+            var database = viewModel.Databases.First(d => d.DisplayName == "OGlycan.gdb");
+
+            database.Children[0].Use = true;
+            database.Children[0].Use = false;
+
+            Assert.That(database.Use, Is.False);
+        }
+
+        [Test]
+        public void Summary_ReportsNothingCheckedWithTheTotalAvailable()
+        {
+            var viewModel = new GlycanSelectionViewModel(TwoDatabases());
+
+            Assert.That(viewModel.Summary, Does.Contain("none checked"));
+            Assert.That(viewModel.Summary, Does.Contain("5 entries available"));
+        }
+
+        [Test]
+        public void Summary_CountsCheckedEntriesAndDatabases()
+        {
+            var viewModel = new GlycanSelectionViewModel(TwoDatabases());
+
+            viewModel.Databases[0].Children[0].Use = true;
+            Assert.That(viewModel.Summary, Does.Contain("1 of 5 entries checked, across 1 database"));
+
+            viewModel.Databases[1].Children[0].Use = true;
+            Assert.That(viewModel.Summary, Does.Contain("2 of 5 entries checked, across 2 databases"));
+        }
+
+        [Test]
+        public void Summary_RaisesPropertyChanged()
+        {
+            var viewModel = new GlycanSelectionViewModel(TwoDatabases());
+            bool propertyChangedFired = false;
+            viewModel.PropertyChanged += (s, e) => { if (e.PropertyName == nameof(viewModel.Summary)) propertyChangedFired = true; };
+
+            viewModel.Databases[0].Children[0].Use = true;
+
+            Assert.That(propertyChangedFired, Is.True);
+        }
+
+        [Test]
+        public void ToSelectedGlycans_ProjectsDatabaseNameAndIdWithMotif()
+        {
+            var viewModel = new GlycanSelectionViewModel(TwoDatabases());
+            var glycan = viewModel.Databases[0].Children[1];
+            glycan.Use = true;
+
+            var selected = viewModel.ToSelectedGlycans();
+
+            Assert.That(selected.Count, Is.EqualTo(1));
+            Assert.That(selected[0].Item1, Is.EqualTo("OGlycan.gdb"));
+            Assert.That(selected[0].Item2, Is.EqualTo(glycan.ModName));
+        }
+
+        [Test]
+        public void ToSelectedGlycans_SpansMultipleDatabases()
+        {
+            var viewModel = new GlycanSelectionViewModel(TwoDatabases());
+            viewModel.Databases[0].Children[0].Use = true;
+            viewModel.Databases[1].Children[1].Use = true;
+
+            var selected = viewModel.ToSelectedGlycans();
+
+            Assert.That(selected.Select(s => s.Item1), Is.EquivalentTo(new[] { "OGlycan.gdb", "NGlycan.gdb" }));
+        }
+
+        [Test]
+        public void Constructor_RestoresASavedSelection()
+        {
+            var databases = TwoDatabases();
+            var wanted = databases["NGlycan.gdb"][1].IdWithMotif;
+
+            var viewModel = new GlycanSelectionViewModel(databases, new[] { ("NGlycan.gdb", wanted) });
+
+            var restored = viewModel.Databases.First(d => d.DisplayName == "NGlycan.gdb");
+            Assert.That(restored.Children.Single(c => c.Use).ModName, Is.EqualTo(wanted));
+            Assert.That(restored.Use, Is.Null, "one of two checked should read as indeterminate");
+        }
+
+        [Test]
+        public void Constructor_RestoredSelectionRoundTripsThroughToSelectedGlycans()
+        {
+            var databases = TwoDatabases();
+            var saved = new List<(string, string)>
+            {
+                ("OGlycan.gdb", databases["OGlycan.gdb"][0].IdWithMotif),
+                ("NGlycan.gdb", databases["NGlycan.gdb"][0].IdWithMotif),
+            };
+
+            var viewModel = new GlycanSelectionViewModel(databases, saved);
+
+            Assert.That(viewModel.ToSelectedGlycans(), Is.EquivalentTo(saved));
+        }
+
+        [Test]
+        public void Constructor_MarksAGlycanTheDatabaseNoLongerHasAsBad()
+        {
+            var databases = TwoDatabases();
+
+            var viewModel = new GlycanSelectionViewModel(databases, new[] { ("OGlycan.gdb", "H9N9 on S") });
+
+            var database = viewModel.Databases.First(d => d.DisplayName == "OGlycan.gdb");
+            var unknown = database.Children.Single(c => c.ModName == "H9N9 on S");
+            Assert.That(unknown.Use, Is.True);
+            Assert.That(unknown.ToolTipStuff, Is.EqualTo("UNKNOWN GLYCAN!"));
+        }
+
+        [Test]
+        public void Constructor_InventsTheGroupWhenTheWholeDatabaseIsGone()
+        {
+            var viewModel = new GlycanSelectionViewModel(TwoDatabases(), new[] { ("Retired.gdb", "H9N9 on S") });
+
+            var invented = viewModel.Databases.Single(d => d.DisplayName == "Retired.gdb");
+            Assert.That(invented.Children.Single().ModName, Is.EqualTo("H9N9 on S"));
+            Assert.That(invented.Use, Is.True);
+        }
+
+        [Test]
+        public void Constructor_AcceptsNoGlycansAndNoSelection()
+        {
+            var viewModel = new GlycanSelectionViewModel(null, null);
+
+            Assert.That(viewModel.Databases, Is.Empty);
+            Assert.That(viewModel.ToSelectedGlycans(), Is.Empty);
+            Assert.That(viewModel.Summary, Does.Contain("0 entries available"));
+        }
+
+        [Test]
+        [TestCase("H5N4A2", "Hex(5)HexNAc(4)NeuAc(2)")]
+        [TestCase("N1", "HexNAc(1)")]
+        [TestCase("N1F1", "HexNAc(1)Fuc(1)")]
+        public void ExpandComposition_SpellsOutTheMonosaccharides(string composition, string expected)
+        {
+            Assert.That(GlycanSelectionViewModel.ExpandComposition(composition), Is.EqualTo(expected));
+        }
+
+        [Test]
+        public void ExpandComposition_TreatsAMissingCountAsOne()
+        {
+            Assert.That(GlycanSelectionViewModel.ExpandComposition("N"), Is.EqualTo("HexNAc(1)"));
+        }
+
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("   ")]
+        public void ExpandComposition_ReturnsEmptyForNothing(string composition)
+        {
+            Assert.That(GlycanSelectionViewModel.ExpandComposition(composition), Is.Empty);
+        }
+
+        [Test]
+        public void ExpandComposition_PassesAnUnknownCodeThrough()
+        {
+            Assert.That(GlycanSelectionViewModel.ExpandComposition("Z2"), Is.EqualTo("Z(2)"));
+        }
+
+        [Test]
+        public void GlycanLabel_CarriesIdentifierExpandedCompositionAndMass()
+        {
+            var glycan = MakeGlycan("HexNAc(1)", "S");
+
+            var label = GlycanSelectionViewModel.GlycanLabel(glycan);
+
+            // The whole point of the label: the identifier alone is a composition code, so searching
+            // "HexNAc" would find nothing without the expansion.
+            Assert.That(label, Does.Contain(glycan.IdWithMotif));
+            Assert.That(label, Does.Contain("HexNAc(1)"));
+            Assert.That(label, Does.Contain("Da"));
+        }
+
+        [Test]
+        public void GlycanLabel_ShowsMassDividedOutOfItsScaledInteger()
+        {
+            var glycan = MakeGlycan("HexNAc(1)", "S");
+
+            Assert.That(GlycanSelectionViewModel.GlycanLabel(glycan),
+                Does.Contain((glycan.Mass / 1E5).ToString("F2", System.Globalization.CultureInfo.InvariantCulture)));
+        }
+
+        [Test]
+        public void GlycanToolTip_ReportsCompositionExpansionMassAndType()
+        {
+            var glycan = MakeGlycan("HexNAc(2)Hex(5)", "Nxs", GlycanType.N_glycan);
+
+            var toolTip = GlycanSelectionViewModel.GlycanToolTip(glycan);
+
+            Assert.That(toolTip, Does.Contain("Composition: " + glycan.Composition));
+            // Expansion follows the Kind[] slot order (Hex, HexNAc, ...), not the order the .gdb line
+            // happens to write the monosaccharides in.
+            Assert.That(toolTip, Does.Contain("Hex(5)HexNAc(2)"));
+            Assert.That(toolTip, Does.Contain("Mass:"));
+            Assert.That(toolTip, Does.Contain(GlycanType.N_glycan.ToString()));
+        }
+
+        [Test]
+        public void GlycanToolTip_OmitsTheStructureLineForACompositionGlycan()
+        {
+            // Struc is only populated for structure-format databases.
+            var glycan = MakeGlycan("HexNAc(1)", "S");
+
+            Assert.That(GlycanSelectionViewModel.GlycanToolTip(glycan), Does.Not.Contain("Structure:"));
+        }
+    }
+}

--- a/MetaMorpheus/Test/GuiTests/LoadDigestionAgentTest.cs
+++ b/MetaMorpheus/Test/GuiTests/LoadDigestionAgentTest.cs
@@ -408,7 +408,10 @@ namespace Test.GuiTests
 
                 var ex = Assert.Throws<MetaMorpheusException>(() => InvokeLoadDigestionAgents());
 
-                Assert.That(ex!.Message, Does.Contain("Error creating default custom protease file with error message:"));
+                // Seeding moved to CustomDataFile.EnsureExists, which names the file it could not create.
+                // The old message said only "custom protease file", which did not tell the user where to look.
+                Assert.That(ex!.Message, Does.Contain("custom protease"));
+                Assert.That(ex.Message, Does.Contain(customPath), "the message has to name the file that failed");
                 Assert.That(ex.InnerException, Is.Not.Null);
             }
             finally
@@ -453,7 +456,10 @@ namespace Test.GuiTests
 
                 var ex = Assert.Throws<MetaMorpheusException>(() => InvokeLoadDigestionAgents());
 
-                Assert.That(ex!.Message, Does.Contain("Error creating default custom rnase file with error message:"));
+                // Seeding moved to CustomDataFile.EnsureExists, which names the file it could not create.
+                // The old message said only "custom rnase file", which did not tell the user where to look.
+                Assert.That(ex!.Message, Does.Contain("custom rnase"));
+                Assert.That(ex.Message, Does.Contain(customPath), "the message has to name the file that failed");
                 Assert.That(ex.InnerException, Is.Not.Null);
             }
             finally

--- a/MetaMorpheus/Test/GuiTests/ModTreeFilterTests.cs
+++ b/MetaMorpheus/Test/GuiTests/ModTreeFilterTests.cs
@@ -1,0 +1,156 @@
+using GuiFunctions;
+using NUnit.Framework;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace Test.GuiTests
+{
+    [TestFixture]
+    public class ModTreeFilterTests
+    {
+        private static ObservableCollection<ModTypeForTreeViewModel> TwoGroups()
+        {
+            var collection = new ObservableCollection<ModTypeForTreeViewModel>();
+
+            var biological = new ModTypeForTreeViewModel("Common Biological", false);
+            biological.Children.Add(new ModForTreeViewModel("tip", false, "Acetylation on K", false, biological));
+            biological.Children.Add(new ModForTreeViewModel("tip", false, "ADP-ribosylation on S", false, biological));
+            collection.Add(biological);
+
+            var glycans = new ModTypeForTreeViewModel("OGlycan.gdb", false);
+            glycans.Children.Add(new ModForTreeViewModel("tip", false, "N1 on S", false, glycans, "N1 on S — HexNAc(1) — 203.08 Da"));
+            glycans.Children.Add(new ModForTreeViewModel("tip", false, "H1N1 on T", false, glycans, "H1N1 on T — Hex(1)HexNAc(1) — 365.13 Da"));
+            collection.Add(glycans);
+
+            return collection;
+        }
+
+        [Test]
+        public void Filter_KeepsOnlyGroupsHoldingAMatch()
+        {
+            var filtered = ModTreeFilter.Filter(TwoGroups(), "ribosyl");
+
+            Assert.That(filtered.Count, Is.EqualTo(1));
+            Assert.That(filtered.Single().DisplayName, Is.EqualTo("Common Biological"));
+        }
+
+        [Test]
+        public void Filter_KeepsOnlyMatchingChildren()
+        {
+            var filtered = ModTreeFilter.Filter(TwoGroups(), "ribosyl");
+
+            Assert.That(filtered.Single().Children.Count, Is.EqualTo(1));
+            Assert.That(filtered.Single().Children.Single().ModName, Is.EqualTo("ADP-ribosylation on S"));
+        }
+
+        [Test]
+        public void Filter_IsCaseInsensitive()
+        {
+            Assert.That(ModTreeFilter.Filter(TwoGroups(), "ACETYL").Single().Children.Single().ModName,
+                Is.EqualTo("Acetylation on K"));
+        }
+
+        [Test]
+        public void Filter_MatchesModNameByDefault()
+        {
+            // The default search text is the identifier, which is what the modification trees rely on.
+            var filtered = ModTreeFilter.Filter(TwoGroups(), "H1N1");
+
+            Assert.That(filtered.Single().DisplayName, Is.EqualTo("OGlycan.gdb"));
+        }
+
+        [Test]
+        public void Filter_ByDefaultCannotFindTextThatIsOnlyInTheDisplayName()
+        {
+            // This is exactly why the overload exists: a glycan identifier is a composition code, so
+            // "HexNAc" is absent from ModName even though the row displays it.
+            Assert.That(ModTreeFilter.Filter(TwoGroups(), "HexNAc"), Is.Empty);
+        }
+
+        [Test]
+        public void Filter_WithADisplayNameSelectorFindsTheExpandedComposition()
+        {
+            var filtered = ModTreeFilter.Filter(TwoGroups(), "HexNAc", m => m.DisplayName);
+
+            Assert.That(filtered.Single().DisplayName, Is.EqualTo("OGlycan.gdb"));
+            Assert.That(filtered.Single().Children.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Filter_WithADisplayNameSelectorFindsAMass()
+        {
+            var filtered = ModTreeFilter.Filter(TwoGroups(), "203.08", m => m.DisplayName);
+
+            Assert.That(filtered.Single().Children.Single().ModName, Is.EqualTo("N1 on S"));
+        }
+
+        [Test]
+        public void Filter_ExpandsTheGroupsItReturns()
+        {
+            Assert.That(ModTreeFilter.Filter(TwoGroups(), "ribosyl").Single().Expanded, Is.True);
+        }
+
+        [Test]
+        public void Filter_SharesChildInstancesWithTheMasterCollection()
+        {
+            // What makes filtering non-destructive: ticking a row while filtered has to be visible in
+            // the master collection, because that is what the read-back reads.
+            var master = TwoGroups();
+
+            var filtered = ModTreeFilter.Filter(master, "ribosyl");
+            filtered.Single().Children.Single().Use = true;
+
+            Assert.That(master[0].Children.Single(c => c.ModName == "ADP-ribosylation on S").Use, Is.True);
+        }
+
+        [Test]
+        public void Filter_DoesNotMutateTheMasterCollection()
+        {
+            var master = TwoGroups();
+
+            ModTreeFilter.Filter(master, "ribosyl");
+
+            Assert.That(master.Count, Is.EqualTo(2));
+            Assert.That(master[0].Children.Count, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void Filter_CopiesGroupCheckStateWithoutClobberingTheChildren()
+        {
+            // The clone's Use is written while its Children is still empty, because the Use setter
+            // cascades. Writing it after the children were added would set every visible row to true.
+            var master = TwoGroups();
+            master[0].Use = true;
+
+            var filtered = ModTreeFilter.Filter(master, "acetyl");
+
+            Assert.That(filtered.Single().Use, Is.True);
+            Assert.That(master[0].Children.Single(c => c.ModName == "ADP-ribosylation on S").Use, Is.True,
+                "cascade from the master group, not from the filtered clone");
+        }
+
+        [Test]
+        public void Filter_ReturnsNothingWhenNothingMatches()
+        {
+            Assert.That(ModTreeFilter.Filter(TwoGroups(), "no such modification"), Is.Empty);
+        }
+
+        [Test]
+        public void Filter_WithAnEmptyKeyKeepsEverything()
+        {
+            var filtered = ModTreeFilter.Filter(TwoGroups(), "");
+
+            Assert.That(filtered.Count, Is.EqualTo(2));
+            Assert.That(filtered.Sum(g => g.Children.Count), Is.EqualTo(4));
+        }
+
+        [Test]
+        public void DefaultSearchText_IsTheModName()
+        {
+            var parent = new ModTypeForTreeViewModel("group", false);
+            var mod = new ModForTreeViewModel("tip", false, "Oxidation on M", false, parent, "a different label");
+
+            Assert.That(ModTreeFilter.DefaultSearchText(mod), Is.EqualTo("Oxidation on M"));
+        }
+    }
+}

--- a/MetaMorpheus/Test/Test.csproj
+++ b/MetaMorpheus/Test/Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.CpuMath" Version="3.0.1" />
     <PackageReference Include="Microsoft.ML.FastTree" Version="3.0.1" />
-    <PackageReference Include="mzLib" Version="1.0.588" />
+    <PackageReference Include="mzLib" Version="1.0.589" />
     <PackageReference Include="NUnit" Version="4.1.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />


### PR DESCRIPTION
<!-- project-of-origin -->
> **Project of origin:** `glycanGui`

🤖 **Stacked on #2792** — which stacks on #2791 and #2787. Those must merge first, and this diff shows their commits until they do.

The Glyco Search task offers a whole glycan database and nothing smaller. This adds a tree beside the two database combo boxes: one group per database file, every glycan in it as a checkable row.

Checking nothing means the whole database, so every task written before this behaves exactly as it did, and a user who never opens the section sees no change.

## Why it is not only convenience

`BuildOGlycanBoxes` is combinations-with-repetition over the whole array, so box count grows as C(n+k-1, k), and `BuildNOGlycanBoxes` multiplies that by `GlobalNGlycans.Count + 1`. The default `MaximumOGlycanAllowed` is 4. Picking six glycans out of twenty-four collapses the search space rather than trimming it.

## The control is not new

`GlycoSearchTaskWindow` already hosts two filter-box + checkbox trees, for fixed and variable mods. A `Glycan` **is** a `Modification`, so this is a third instance of a pattern already in the file: `ModTypeForTreeViewModel` and `ModForTreeViewModel` are reused as they are, and there is no glycan-specific view-model.

Two things had to be added rather than reused.

**`GlobalVariables` knew every glycan but not where it came from.** `LoadGlycans` flattens all databases into `AllModsKnown` and discards the file each glycan was read from — which is exactly the grouping this needs. It now also records the glycans per database, ordered by mass.

**`FilterTree` matched only `ModName`.** That is enough for modifications, whose identifiers are English words: `ribosyl` finds `ADP-ribosylation on S`. A glycan's identifier is a composition code, so `HexNAc` would match **nothing** — even in `NGlycan.gdb`, which spells `HexNAc(1)` on disk but parses to `N1`. `FilterTree` gains an overload taking the text to search, defaulting to today's behaviour so the five existing search boxes are untouched, and each glycan row carries an expanded label the tree searches:

```
H5N4A2 on Nxs   —   Hex(5)HexNAc(4)NeuAc(2)   —   2204.77 Da
```

`HexNAc`, `NeuAc`, `2204` and `H5N4A2` all find that row.

## Two decisions worth stating

**The selection is stored as (database file name, `IdWithMotif`), never by `GlyId`.** `GlyId` is a positional index into the loaded array, so a saved index would quietly point at a different glycan if the `.gdb` were edited. The property is typed `List<(string, string)>` deliberately: `MetaMorpheusTask.tomlConfig` already registers a converter for that type, so it round-trips with no new serialization code.

**The subset is applied before the glycans reach `GlycanBox.GlobalOGlycans`**, and before any box is built, because `GlycanBox` identifies a glycan by its position in that array — `BuildOGlycanBoxes` enumerates `Range(0, GlobalOGlycans.Length)`. Filtering later would re-point every box at a different glycan; filtering here means the dense re-index falls out for free. It is deliberately **not** applied inside `GlycanDatabase.LoadGlycan`, which `GlobalVariables` shares to populate `AllModsKnown` for MetaDraw and which must keep seeing every glycan.

A selection naming none of a given database means that whole database, so choosing individual O-glycans does not silently narrow the N-glycan side too.

## What driving the window turned up

The tree was exercised through UI automation — ticking glycans across two databases, running the search box, saving the task. It reported its own state wrongly in three ways, all now fixed.

| | Before | After |
|---|---|---|
| Summary line | permanently "none checked", even after ticking a whole 24-glycan group | `6 of 830 entries checked, across 2 databases`, live |
| Database checkbox | stayed `Off` with children ticked | `Off` → `Indeterminate` → `On` |
| Expand 830 entries | ~4 s, UI blocked | 0.06 s |

The first two share a cause: `ModForTreeViewModel.Use` notifies only itself, and `VerifyCheckState` is a manual pull the window has to make. The modification trees only ever make it while **restoring** a saved task, which is why a group there still reads as fully checked right after you uncheck something inside it. Subscribing to the children fixes both, and does it in the window rather than in the shared view-model, which MetaDraw also uses.

The re-entrancy guard on that handler is load-bearing, not defensive: `VerifyCheckState` assigns the parent's `Use`, and a non-null assignment cascades back down to every child, each raising `PropertyChanged` again. Ticking the last box in a group would otherwise recurse forever.

The third was the odd one. The two custom databases hold no glycans, and they were the only groups rendering as partly selected — exactly backwards. `ModTypeForTreeViewModel` takes `bad` as its second constructor argument, **not** `use`, so `Use` is never initialized and a `bool?` defaults to `null`, which is the indeterminate box. A group with children is corrected by the `VerifyCheckState` pass; an empty one has nothing to inspect, so it has to be said outright.

Also from that run: the tree virtualizes now, and `AutomationProperties.Name` is set on the item container rather than on controls inside the header — a `TreeViewItem` takes its automation name from the container, so every row had been announcing `GuiFunctions.ModForTreeViewModel` to a screen reader.

The count is described as **entries** rather than glycans because a glycan is listed once per attachment site: the 12 lines of `OGlycan.gdb` are 24 rows here, and calling them glycans invites the reader to compare the number with the file and find it wrong.

## Where the code lives

`Test.csproj` references CMD, EngineLayer, GuiFunctions and TaskLayer — **not GUI** — so the test assembly cannot see `MetaMorpheusGUI` types and coverlet emits no rows for that project. Code left in a `.xaml.cs` is neither covered nor uncovered; it is absent from the report. So the logic is in **GuiFunctions**, where it can be tested, and the window keeps the WPF.

- **`GuiFunctions/ViewModels/GlycanSelectionViewModel.cs`** — builds the tree, settles the database checkboxes, maintains the summary, restores a saved selection, and reads one back through `ToSelectedGlycans()`. It takes its glycans as a constructor argument rather than reading `GlobalVariables`, so a test can supply its own. This follows `FragmentationParamsViewModel`, which takes the task's parameter objects in and gives a domain object back, and whose control code-behind is 38 lines.
- **`GuiFunctions/ModTreeFilter.cs`** — the filtering itself. `SearchModifications` keeps only the WPF: read the `TextBox`, assign the `TreeView`'s `DataContext`.
- **`GlycoSearchTaskWindow.xaml.cs`** grows by **27 lines**: one field, one `new GlycanSelectionViewModel(...)`, two `DataContext` assignments, one read-back, one filter call.

## Tests

`Test/GuiTests/GlycanSelectionViewModelTests.cs` (28) and `Test/GuiTests/ModTreeFilterTests.cs` (14) — 42 tests, `[TestFixture]`, instance methods, `Assert.That`, hand-written fixtures, no `GlobalVariables` dependency and so no static-state hazard.

They pin the two behaviours previously confirmed only by driving the window: that a database checkbox goes `Off` → `Indeterminate` → `On` as its children are ticked, and that ticking the last box in a group **terminates at all** — settling the parent cascades back down and re-raises `PropertyChanged`, so without the guard it recurses forever.

They also caught a bug the GUI had been showing. `Glycan.NameCharDic` carries aliases as well as canonical names — `dHex` and `Fuc` share a code and a slot — so inverting it has to choose between them, and it was choosing by enumeration order and landing on the alias. Ordering by slot then ordinally by name is deterministic and picks the canonical spelling, which is also what the shipped databases write on disk and therefore what a user is likely to type.

Two more fixtures cover the other side of the boundary, which is EngineLayer and TaskLayer rather than GUI:

- **`Test/GlycoSearchParametersTomlTests.cs`** (6) — the selection surviving save-and-reopen. The one that matters is the compatibility case, tested the way it will actually be met: every GlycoSearch toml already on a user''s disk has no `SelectedGlycans` line at all, so the test writes a task with a selection, strips the line back out, and reads it again. It asserts first that the line was there to remove, because a test that strips nothing would pass for the wrong reason.
- **`Test/GlycoSearchEngineSelectedGlycansTests.cs`** (10) — the engine honouring a selection. That no selection, an empty one, and one naming only the *other* database each leave this database whole; that a selection matching nothing falls back rather than handing `BuildOGlycanBoxes` an empty array; that narrowing collapses the box count; and — the reason the filter runs before `GlobalOGlycans` is assigned — that every box resolves to a glycan the selection actually named. The N side gets the same through `GlobalNGlycans`, whose negative keys must come out `-1..-m` with no gaps. `[NonParallelizable]`, and TearDown restores both databases, because `GlobalVariables` is static and never reset between fixtures and other glyco fixtures assert baked-in counts.

**58 tests for this feature; 500 pass** across the glyco, GUI and toml suites.

## Also here

`mzLib` bumped to **1.0.589** in all six projects (its own commit).

## Not in this PR

**The same stale-parent-checkbox behaviour in the modification trees.** It is fixed here for the glycan tree without touching `ModForTreeViewModel`. Fixing it at the source would improve the Search and GPTMD windows too, but it is a hot type MetaDraw shares and `MetaDrawSettingsAndViewsTest.cs` pins its semantics, so it wants its own PR.

**Known conflict:** #2541 deletes `GlycanBox.cs` and rewrites `GlycoSearchEngine.cs:63-95`. Whichever lands first, the other needs rework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYPSBFRWvhAPXaR6RktVuR

