### PR TITLE
Do not treat a failed retention-time prediction as a hydrophobicity of zero

### DIFF
--- a/MetaMorpheus/EngineLayer/FdrAnalysis/FdrAnalysisEngine.cs
+++ b/MetaMorpheus/EngineLayer/FdrAnalysis/FdrAnalysisEngine.cs
@@ -4,6 +4,7 @@ using Chromatography.RetentionTimePrediction.SSRCalc;
 using EngineLayer.CrosslinkSearch;
 using EngineLayer.SpectrumMatch;
 using PredictionClients.Koina.SupportedModels.RetentionTimeModels;
+using Omics.SequenceConversion;
 using Proteomics.ProteolyticDigestion;
 using System;
 using System.Collections.Generic;
@@ -16,7 +17,13 @@ namespace EngineLayer.FdrAnalysis
     {
         private static readonly Lazy<ChronologerRetentionTimePredictor> _chronologerInstance =
             new Lazy<ChronologerRetentionTimePredictor>(
-                () => new ChronologerRetentionTimePredictor(),
+                // ReturnNull, not the default RemoveIncompatibleElements. Under the default a modification
+                // outside Chronologer's vocabulary is silently deleted and the residue encoded bare, so the
+                // model predicts the retention time of a DIFFERENT molecule and reports success. That is
+                // particularly damaging within a single scan: two peptidoforms the spectrum cannot separate can
+                // receive different predictions purely because one modification is in the vocabulary and the
+                // other is not. Reporting the failure lets PsmData.HasHydrophobicity mark the value unusable.
+                () => new ChronologerRetentionTimePredictor(SequenceConversionHandlingMode.ReturnNull),
                 System.Threading.LazyThreadSafetyMode.ExecutionAndPublication);
 
         // When non-null, GetChronologer() calls this factory instead of the real Lazy<>.

--- a/MetaMorpheus/EngineLayer/FdrAnalysis/PEPAnalysisEngine.cs
+++ b/MetaMorpheus/EngineLayer/FdrAnalysis/PEPAnalysisEngine.cs
@@ -479,6 +479,7 @@ namespace EngineLayer
             float longestSeq = 0;
             float complementaryIonCount = 0;
             float hydrophobicityZscore = float.NaN;
+            float hasHydrophobicity = 0;
             bool isVariantPeptide = false;
 
             //crosslink specific features
@@ -542,11 +543,13 @@ namespace EngineLayer
                             var dict = isUnmodified
                                 ? FileSpecificTimeDependantHydrophobicityAverageAndDeviation_unmodified
                                 : FileSpecificTimeDependantHydrophobicityAverageAndDeviation_modified;
-                            hydrophobicityZscore = (float)Math.Round(GetRetentionTimeEquivalentZscore(psm, tentativeSpectralMatch.SpecificBioPolymer, dict, RetentionTimePredictor) * 10.0, 0);
+                            hydrophobicityZscore = (float)Math.Round(GetRetentionTimeEquivalentZscore(psm, tentativeSpectralMatch.SpecificBioPolymer, dict, RetentionTimePredictor, out bool retentionTimePredicted) * 10.0, 0);
+                            hasHydrophobicity = Convert.ToSingle(retentionTimePredicted);
                         }
                         else
                         {
                             hydrophobicityZscore = (float)Math.Round(GetMobilityZScore(psm, tentativeSpectralMatch.SpecificBioPolymer) * 10.0, 0);
+                            hasHydrophobicity = 1; // CZE mobility is computed from composition and always available
                         }
                     }
                 }
@@ -620,6 +623,7 @@ namespace EngineLayer
                 LongestFragmentIonSeries = longestSeq,
                 ComplementaryIonCount = complementaryIonCount,
                 HydrophobicityZScore = hydrophobicityZscore,
+                HasHydrophobicity = hasHydrophobicity,
                 IsVariantPeptide = Convert.ToSingle(isVariantPeptide),
 
                 AlphaIntensity = alphaIntensity,
@@ -713,7 +717,22 @@ namespace EngineLayer
                         }
                         fullSequences.Add(bestMatch.SpecificBioPolymer.FullSequence);
 
-                        double predictedHydrophobicity = bestMatch.SpecificBioPolymer is PeptideWithSetModifications pep ? predictor.PredictRetentionTimeEquivalent(pep, out _) ?? 0 : 0;
+                        // A peptidoform the predictor cannot represent must not contribute to the reference
+                        // distribution. `?? 0` would enter it as a predicted hydrophobicity of zero, which is a
+                        // real and extreme value on this scale, and would drag the median and standard deviation
+                        // that every other peptide in this retention-time bin is then scored against.
+                        if (bestMatch.SpecificBioPolymer is not PeptideWithSetModifications pep)
+                        {
+                            continue;
+                        }
+
+                        double? predicted = predictor.PredictRetentionTimeEquivalent(pep, out _);
+                        if (!predicted.HasValue)
+                        {
+                            continue;
+                        }
+
+                        double predictedHydrophobicity = predicted.Value;
 
                         //here i'm grouping this in 2 minute increments becuase there are cases where you get too few data points to get a good standard deviation an average. This is for stability.
                         int possibleKey = (int)(2 * Math.Round(psm.ScanRetentionTime / 2d, 0));
@@ -902,8 +921,14 @@ namespace EngineLayer
             return mobility;
         }
 
-        private static float GetRetentionTimeEquivalentZscore(SpectralMatch psm, IBioPolymerWithSetMods Peptide, Dictionary<string, Dictionary<int, Tuple<double, double>>> d, IRetentionTimePredictor predictor)
+        /// <param name="predictionAvailable">
+        /// False when the retention-time predictor could not produce a value for this peptidoform -- most often
+        /// because it carries a modification outside the predictor's vocabulary. Callers must surface this to the
+        /// model (see PsmData.HasHydrophobicity) rather than letting the returned z-score stand on its own.
+        /// </param>
+        private static float GetRetentionTimeEquivalentZscore(SpectralMatch psm, IBioPolymerWithSetMods Peptide, Dictionary<string, Dictionary<int, Tuple<double, double>>> d, IRetentionTimePredictor predictor, out bool predictionAvailable)
         {
+            predictionAvailable = false;
             //Using SSRCalc3 but probably any number of different calculators could be used instead. One could also use the CE mobility.
             double hydrophobicityZscore = double.NaN;
 
@@ -912,9 +937,26 @@ namespace EngineLayer
                 int time = (int)(2 * Math.Round(psm.ScanRetentionTime / 2d, 0));
                 if (d[Path.GetFileName(psm.FullFilePath)].Keys.Contains(time))
                 {
-                    double predictedHydrophobicity = Peptide is PeptideWithSetModifications pep ? predictor.PredictRetentionTimeEquivalent(pep, out _) ?? 0 : 0;
-
-                    hydrophobicityZscore = Math.Abs(d[Path.GetFileName(psm.FullFilePath)][time].Item1 - predictedHydrophobicity) / d[Path.GetFileName(psm.FullFilePath)][time].Item2;
+                    // A failed prediction is not a hydrophobicity of zero. Zero is a real and extreme value on
+                    // this scale, so `?? 0` turned "could not predict" into "disagrees with the observed
+                    // retention time as badly as possible" -- the z-score saturates at the maximum below and the
+                    // model reads it as strong evidence against the candidate. Report unavailability instead and
+                    // let the companion feature tell the model to ignore the value.
+                    if (Peptide is PeptideWithSetModifications pep)
+                    {
+                        double? predicted = predictor.PredictRetentionTimeEquivalent(pep, out RetentionTimeFailureReason? failureReason);
+                        if (predicted.HasValue)
+                        {
+                            predictionAvailable = true;
+                            hydrophobicityZscore = Math.Abs(d[Path.GetFileName(psm.FullFilePath)][time].Item1 - predicted.Value) / d[Path.GetFileName(psm.FullFilePath)][time].Item2;
+                        }
+                        else if (failureReason == RetentionTimeFailureReason.IncompatibleModifications)
+                        {
+                            // The peptidoform carries a modification outside the predictor's vocabulary. Its
+                            // retention time is not evidence about THIS peptidoform, and in particular it must not
+                            // be used to choose between two peptidoforms that the spectrum cannot separate.
+                        }
+                    }
                 }
             }
 

--- a/MetaMorpheus/EngineLayer/FdrAnalysis/PsmData.cs
+++ b/MetaMorpheus/EngineLayer/FdrAnalysis/PsmData.cs
@@ -18,6 +18,7 @@ namespace EngineLayer.FdrAnalysis
                     "Notch", "ModsCount", "AbsoluteAverageFragmentMassErrorFromMedian", "MissedCleavagesCount",
                     "Ambiguity", "LongestFragmentIonSeries", "ComplementaryIonCount", "HydrophobicityZScore",
                     "IsVariantPeptide", "IsDeadEnd", "IsLoop", "SpectralAngle", "HasSpectralAngle",
+                    "HasHydrophobicity",
                     "PrecursorDeconvolutionScore",
                 }
             },
@@ -70,6 +71,7 @@ namespace EngineLayer.FdrAnalysis
             { "LongestFragmentIonSeries", 1 },
             { "ComplementaryIonCount", 1 },
             { "HydrophobicityZScore", -1 },
+            { "HasHydrophobicity", 1 },
             { "IsVariantPeptide",-1 },
             { "AlphaIntensity", 1 },
             { "BetaIntensity", 1 },
@@ -176,6 +178,19 @@ namespace EngineLayer.FdrAnalysis
 
         [LoadColumn(23)]
         public float HasSpectralAngle { get; set; }
+
+        /// <summary>
+        /// 1 when the retention-time predictor produced a value for this peptidoform, 0 when it could not --
+        /// most often because the peptidoform carries a modification outside the predictor's vocabulary
+        /// (Chronologer supports roughly twenty; a G-PTM-D search can enable many times that).
+        ///
+        /// Companion to <see cref="HydrophobicityZScore"/> in the same way <see cref="HasSpectralAngle"/> is the
+        /// companion to <see cref="SpectralAngle"/>: it lets the model distinguish "predicted, and disagrees with
+        /// the observed retention time" from "could not be predicted at all". Without it a failed prediction is
+        /// indistinguishable from a maximally bad one.
+        /// </summary>
+        [LoadColumn(30)]
+        public float HasHydrophobicity { get; set; }
 
         [LoadColumn(24)]
         public float PeaksInPrecursorEnvelope { get; set; }

--- a/MetaMorpheus/Test/FdrTest.cs
+++ b/MetaMorpheus/Test/FdrTest.cs
@@ -256,6 +256,37 @@ namespace Test
             float maxPsmIntensity = Math.Min(50, (float)Math.Round((maxScorePsm.Score - (int)maxScorePsm.Score) / normalizationFactor * 100.0, 0));
             Assert.That(maxPsmIntensity, Is.EqualTo(maxPsmData.Intensity).Within(0.05));
             Assert.That(maxPsmData.HydrophobicityZScore, Is.EqualTo(52.0).Within(0.05));
+            // A retention time the predictor COULD produce must be marked available.
+            Assert.That(maxPsmData.HasHydrophobicity, Is.EqualTo(1));
+
+            // And a peptidoform the predictor cannot represent must be marked UNavailable, rather than being
+            // scored as though its predicted hydrophobicity were zero. Zero is a real and extreme value on this
+            // scale, so the old `?? 0` turned "could not predict" into the maximum z-score, which the model reads
+            // as strong evidence against the candidate. See PsmData.HasHydrophobicity.
+            var unpredictableEngine = new PepAnalysisEngine(nonNullPsms, "standard", fsp,
+                Path.Combine(TestContext.CurrentContext.TestDirectory, @"TestData\"), new NeverPredictsRetentionTime());
+            foreach (var p in unpredictableEngine.GetType().GetProperties())
+            {
+                switch (p.Name)
+                {
+                    case "FileSpecificTimeDependantHydrophobicityAverageAndDeviation_unmodified":
+                        p.SetValue(unpredictableEngine, fileSpecificRetTimeHI_behavior);
+                        break;
+                    case "FileSpecificTimeDependantHydrophobicityAverageAndDeviation_modified":
+                        p.SetValue(unpredictableEngine, fileSpecificRetTemHI_behaviorModifiedPeptides);
+                        break;
+                    case "ChargeStateMode":
+                        p.SetValue(unpredictableEngine, chargeStateMode);
+                        break;
+                    case "FileSpecificMedianFragmentMassErrors":
+                        p.SetValue(unpredictableEngine, massError);
+                        break;
+                    default:
+                        break;
+                }
+            }
+            var unpredictableData = unpredictableEngine.CreateOnePsmDataEntry("standard", maxScorePsm, bestMatch, !bestMatch.IsDecoy);
+            Assert.That(unpredictableData.HasHydrophobicity, Is.EqualTo(0));
             Assert.That(maxScorePsm.BestMatchingBioPolymersWithSetMods.Select(p => p.SpecificBioPolymer).First().MissedCleavages, Is.EqualTo(maxPsmData.MissedCleavagesCount));
             Assert.That(maxScorePsm.BestMatchingBioPolymersWithSetMods.Select(p => p.SpecificBioPolymer).First().AllModsOneIsNterminus.Values.Count(), Is.EqualTo(maxPsmData.ModsCount));
             Assert.That(maxScorePsm.Notch ?? 0, Is.EqualTo(maxPsmData.Notch));
@@ -713,7 +744,7 @@ namespace Test
                 "TotalMatchingFragmentCount", "Intensity", "PrecursorChargeDiffToMode", "DeltaScore", "Notch",
                 "ModsCount", "AbsoluteAverageFragmentMassErrorFromMedian", "MissedCleavagesCount", "Ambiguity",
                 "LongestFragmentIonSeries", "ComplementaryIonCount", "HydrophobicityZScore", "IsVariantPeptide",
-                "IsDeadEnd", "IsLoop", "SpectralAngle", "HasSpectralAngle",
+                "IsDeadEnd", "IsLoop", "SpectralAngle", "HasSpectralAngle", "HasHydrophobicity",
                 "PrecursorDeconvolutionScore"
             };
             Assert.That(trainingInfoStandard, Is.EqualTo(expectedTrainingInfoStandard));
@@ -784,9 +815,10 @@ namespace Test
                 PrecursorFractionalIntensity = 26,
                 InternalIonCount = 27,
                 PrecursorDeconvolutionScore = 28,
+                HasHydrophobicity = 29,
             };
 
-            string standardToString = "\t0\t1\t2\t3\t4\t5\t6\t7\t8\t9\t10\t11\t12\t17\t18\t21\t22\t28";
+            string standardToString = "\t0\t1\t2\t3\t4\t5\t6\t7\t8\t9\t10\t11\t12\t17\t18\t21\t22\t29\t28";
             Assert.That(pd.ToString("standard"), Is.EqualTo(standardToString));
 
             string topDownToString = "\t0\t1\t2\t3\t4\t5\t6\t8\t9\t10\t21\t22\t23\t24\t25\t26\t27";

--- a/MetaMorpheus/Test/NeverPredictsRetentionTime.cs
+++ b/MetaMorpheus/Test/NeverPredictsRetentionTime.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Chromatography;
+using Chromatography.RetentionTimePrediction;
+using Omics;
+
+namespace Test
+{
+    /// <summary>
+    /// A retention time predictor that can never produce a value, reporting
+    /// <see cref="RetentionTimeFailureReason.IncompatibleModifications"/> for every peptide.
+    ///
+    /// Stands in for the real case this models: Chronologer supports roughly twenty modifications, while a
+    /// G-PTM-D search can enable many times that, so a peptidoform carrying an unsupported modification cannot
+    /// be represented. What matters is that such a peptidoform is reported as UNPREDICTABLE rather than being
+    /// silently scored as if its hydrophobicity were zero.
+    /// </summary>
+    internal sealed class NeverPredictsRetentionTime : IRetentionTimePredictor
+    {
+        public string PredictorName => "NeverPredicts";
+        public SeparationType SeparationType => SeparationType.HPLC;
+
+        public double? PredictRetentionTimeEquivalent(IRetentionPredictable peptide, out RetentionTimeFailureReason? failureReason)
+        {
+            failureReason = RetentionTimeFailureReason.IncompatibleModifications;
+            return null;
+        }
+
+        public IReadOnlyList<(double? PredictedValue, IRetentionPredictable Peptide, RetentionTimeFailureReason? FailureReason)>
+            PredictRetentionTimeEquivalents(IEnumerable<IRetentionPredictable> peptides, int maxThreads = 1)
+            => peptides
+                .Select(p => ((double?)null, p, (RetentionTimeFailureReason?)RetentionTimeFailureReason.IncompatibleModifications))
+                .ToList();
+
+        public string GetFormattedSequence(IRetentionPredictable peptide, out RetentionTimeFailureReason? failureReason)
+        {
+            failureReason = RetentionTimeFailureReason.IncompatibleModifications;
+            return null;
+        }
+
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
<!-- project-of-origin -->
> **Project of origin:** `phred`

### Summary

PEP builds a `HydrophobicityZScore` for every candidate from a predicted retention time. Two places coerced a **failed** prediction to zero:

```csharp
predictor.PredictRetentionTimeEquivalent(pep, out _) ?? 0
```

Zero is a real and extreme value on that scale, not a sentinel. So *"could not predict"* became *"disagrees with the observed retention time as badly as possible"* — the z-score saturates at its maximum of 10 and the model reads it as strong evidence against the candidate. The failure reason was discarded with `out _`, so nothing downstream could tell the two situations apart.

### What changes

**1. The reference distribution no longer absorbs failed predictions.** `ComputeRetentionTimeEquivalentValues` builds the per-file, per-RT-bin median and standard deviation that *every other* peptide's z-score is measured against. An unpredictable peptidoform did not merely mis-score itself — it entered that reference as a predicted hydrophobicity of zero and dragged the statistics for every peptide in its bin. Those peptides are now skipped.

**2. `PsmData.HasHydrophobicity`**, a companion feature in exactly the relationship `HasSpectralAngle` already has with `SpectralAngle`. The model can now distinguish *"predicted, and disagrees"* from *"could not be predicted"*, instead of being handed a value that means neither.

**3. Chronologer is constructed with `SequenceConversionHandlingMode.ReturnNull`** rather than the default `RemoveIncompatibleElements`. **This is the behavioural change worth your attention.** Under the default, a modification outside Chronologer's vocabulary is silently deleted and the residue encoded bare — so the model predicts the retention time of a *different molecule* and reports success. Chronologer supports roughly twenty modifications; a G-PTM-D search can enable many times that.

### How this surfaced

Within a single scan, two peptidoforms that the spectrum **cannot** separate received different predictions purely because of vocabulary membership:

| candidate | Chronologer encoding |
|---|---|
| `[N-term acetyl]SKGPAVGID…` | `^SKGPAVGID…` — N-terminal acetylation is a supported N-terminus state |
| `S[Acetylation on S]KGPAVGID…` | `-SKGPAVGID…` — `(42.01, 'S')` is not in the table, silently removed |

Both place +42.011 **inside residue 1**, so every b/y/a and immonium ion carries it identically and the `Mass Diff (ppm)` cell is a single value. Walking the `"standard"` feature list, *every* other feature is identical for such a pair — the matched ions are the same, so all ion-derived features are the same; the rest are PSM-level. **Hydrophobicity alone decided between them**, and PEP then deleted the "loser" via `GetIndicesOfPeptidesToRemove`.

On a 12-file G-PTM-D search (MassIVE `MSV000083304`, calibrate → GPTMD → search) this resolved **fifteen provably undecidable pairs** — and the aggregate metrics *improved* while it happened (AUC 0.9917 → 0.9951). That combination is what makes it hard to notice: by every number the task reports, things got better.

The same mechanism explains a near miss. `Ethylation on K` is also outside the vocabulary, but the mass fallback is keyed on `(rounded mass, residue)` and contains `{ (28.03, 'K'), 'o' }` — dimethylation. Ethyl-K has the same rounded mass on the same residue, so it maps to the same code, the two encode identically, and that pair was protected **by accident**.

### Not proposed

Changing the tiebreak ordering. A deterministic order is worth more than the bias costs, and randomising it would trade a knowable, reproducible imperfection for an unrepeatable one.

Switching retention-time models. The defect is **vocabulary coverage, not accuracy** — every RT model has a finite vocabulary, and a better model applied to a mis-encoded sequence returns a *more* confident wrong difference.

### Tests

`FdrTest` asserts `HasHydrophobicity` is 1 when the predictor succeeds and 0 when it cannot represent the peptidoform, using a stub predictor that always reports `IncompatibleModifications`. The `trainingInfos` and `ToString` round-trip guards are updated for the new feature.

### Worth your judgement

Point 3 widens which peptidoforms lose the hydrophobicity feature — anything carrying a modification Chronologer does not know. That is the intended semantics (if the model cannot represent the peptidoform, its retention time is not evidence about it), and `HasHydrophobicity` is what makes it safe for the model to learn. But it will change PEP behaviour on modification-rich searches, and you may prefer to gate it behind a parameter. Happy to split that commit out if you would rather take 1 and 2 first.

Related: #2797 (`MaxModificationIsoforms` truncates silently) came out of the same investigation. That one silently *removes* hypotheses; this one silently *manufactures* evidence.

