### PR TITLE
Archive the TMT design only once it parses, and name the reason a copy failed

### DIFF
--- a/MetaMorpheus/TaskLayer/SearchTask/PostSearchAnalysisTask.cs
+++ b/MetaMorpheus/TaskLayer/SearchTask/PostSearchAnalysisTask.cs
@@ -336,21 +336,35 @@ namespace TaskLayer
             // the PSM and peptide levels but not the protein level: with the box unticked, contaminant
             // peptides appeared in RawQuantification.tsv and PeptideQuantification.tsv while their
             // groups were absent from ProteinGroupQuantification.tsv.
-            var filteredPsms = FilteredPsms.Filter(Parameters.AllSpectralMatches,
+            FilteredPsms FilterMatches(bool includeContaminants) => FilteredPsms.Filter(
+                Parameters.AllSpectralMatches,
                 CommonParameters,
                 includeDecoys: false,
-                includeContaminants: Parameters.SearchParameters.WriteContaminants,
+                includeContaminants: includeContaminants,
                 includeAmbiguous: false,
                 includeAmbiguousMods: false,
                 includeHighQValuePsms: false);
 
-            var quantifiablePsms = filteredPsms
-                .Where(psm => psm.IsobaricMassTagReporterIonIntensities is { Length: > 0 })
-                .ToList();
+            static bool CarriesReporterIons(SpectralMatch psm) =>
+                psm.IsobaricMassTagReporterIonIntensities is { Length: > 0 };
+
+            var filteredPsms = FilterMatches(Parameters.SearchParameters.WriteContaminants);
+
+            var quantifiablePsms = filteredPsms.Where(CarriesReporterIons).ToList();
 
             if (quantifiablePsms.Count == 0)
             {
-                Warn("No spectral matches carried reporter ion intensities. Skipping multiplex quantification");
+                // Name the filter that emptied the set. With the contaminant box unticked, every
+                // reporter-bearing match in a run can be a contaminant, and the plain wording then
+                // blames the data for what the filter above removed. Asked only on the way out, so a
+                // run that quantifies never pays for the second filter.
+                bool contaminantsCarriedThemAll = !Parameters.SearchParameters.WriteContaminants
+                    && FilterMatches(includeContaminants: true).Any(CarriesReporterIons);
+
+                Warn(contaminantsCarriedThemAll
+                    ? "Every spectral match that carried reporter ion intensities was a contaminant, and " +
+                      "contaminants are not being written. Skipping multiplex quantification"
+                    : "No spectral matches carried reporter ion intensities. Skipping multiplex quantification");
                 return;
             }
 

--- a/MetaMorpheus/TaskLayer/SearchTask/PostSearchAnalysisTask.cs
+++ b/MetaMorpheus/TaskLayer/SearchTask/PostSearchAnalysisTask.cs
@@ -292,24 +292,30 @@ namespace TaskLayer
 
             Status("Quantifying multiplex channels...", Parameters.SearchTaskId);
 
+            var tmtFiles = TmtExperimentalDesign.Read(tmtDesignPath, Parameters.CurrentRawFileList, out var designErrors);
+            if (designErrors.Any())
+            {
+                Warn("Error reading TMT design file: " + designErrors.First() + ". Skipping multiplex quantification");
+                return;
+            }
+
             // Copy the design into the output folder, as the label-free path does for ExperimentalDesign,
-            // so a result folder records the design it was quantified under.
+            // so a result folder records the design it was quantified under. AFTER the read, not before:
+            // a design that could not be parsed was not quantified under anything, and archiving it
+            // anyway left it in the results folder and announced it through FinishedWritingFile while
+            // this method was on its way out.
             try
             {
                 string copiedDesign = Path.Combine(Parameters.OutputFolder, Path.GetFileName(tmtDesignPath));
                 File.Copy(tmtDesignPath, copiedDesign, overwrite: true);
                 FinishedWritingFile(copiedDesign, new List<string> { Parameters.SearchTaskId });
             }
-            catch
+            catch (Exception e)
             {
-                Warn("Could not copy the TMT design file to the search task output. That's ok, the search will continue");
-            }
-
-            var tmtFiles = TmtExperimentalDesign.Read(tmtDesignPath, Parameters.CurrentRawFileList, out var designErrors);
-            if (designErrors.Any())
-            {
-                Warn("Error reading TMT design file: " + designErrors.First() + ". Skipping multiplex quantification");
-                return;
+                // Named, not swallowed: a user whose archive failed can act on "access is denied" and
+                // can do nothing with "could not copy".
+                Warn("Could not copy the TMT design file to the search task output: " + e.Message +
+                     ". That's ok, the search will continue");
             }
 
             var tag = IsobaricMassTag.GetIsobaricMassTag(Parameters.SearchParameters.MultiplexModId);
@@ -324,10 +330,16 @@ namespace TaskLayer
             // includeAmbiguous: false is the unambiguous filter the design calls for. A PSM that could be
             // more than one peptide would otherwise have its channel intensities credited to whichever
             // candidate happened to sort first.
+            //
+            // includeContaminants follows WriteContaminants, the same switch ProteinGroupIsWritten reads
+            // below. Passing true unconditionally made the quantified set wider than the written set at
+            // the PSM and peptide levels but not the protein level: with the box unticked, contaminant
+            // peptides appeared in RawQuantification.tsv and PeptideQuantification.tsv while their
+            // groups were absent from ProteinGroupQuantification.tsv.
             var filteredPsms = FilteredPsms.Filter(Parameters.AllSpectralMatches,
                 CommonParameters,
                 includeDecoys: false,
-                includeContaminants: true,
+                includeContaminants: Parameters.SearchParameters.WriteContaminants,
                 includeAmbiguous: false,
                 includeAmbiguousMods: false,
                 includeHighQValuePsms: false);

--- a/MetaMorpheus/Test/MultiplexQuantificationTests.cs
+++ b/MetaMorpheus/Test/MultiplexQuantificationTests.cs
@@ -504,6 +504,13 @@ namespace Test
                 Assert.That(warnings, Has.Exactly(1).Contains("Error reading TMT design file"));
                 Assert.That(warnings, Has.Exactly(1).Contains("Biological Replicate"));
                 Assert.That(parameters.MultiplexQuantificationResults, Is.Null);
+
+                // The mirror of NoPsmCarriesReporterIons_WarnsAndSkips, which asserts the positive: a
+                // design the search could READ is archived even when it then declines to quantify. One
+                // it could not read is not, because the results folder would then advertise a design
+                // nothing was quantified under.
+                Assert.That(File.Exists(Path.Combine(StageOutput(folder), GlobalVariables.TmtExperimentalDesignFileName)),
+                    Is.False, "a design that could not be read must not be archived beside the results");
             }
             finally
             {

--- a/MetaMorpheus/Test/MultiplexQuantificationTests.cs
+++ b/MetaMorpheus/Test/MultiplexQuantificationTests.cs
@@ -436,6 +436,7 @@ namespace Test
             List<ProteinGroup> proteinGroups = null,
             string multiplexModId = "TMT11",
             bool writeDecoys = true,
+            bool writeContaminants = true,
             bool writeHighQValuePsms = true)
         {
             var task = new PostSearchAnalysisTask { CommonParameters = new CommonParameters() };
@@ -445,6 +446,7 @@ namespace Test
                 {
                     MultiplexModId = multiplexModId,
                     WriteDecoys = writeDecoys,
+                    WriteContaminants = writeContaminants,
                     WriteHighQValuePsms = writeHighQValuePsms
                 },
                 CurrentRawFileList = currentRawFileList,
@@ -896,6 +898,105 @@ namespace Test
                         Has.Length.EqualTo(group.GetTabSeparatedHeader().Split('\t').Length),
                         "every row must carry the columns its own header advertises");
                 }
+            }
+            finally
+            {
+                Directory.Delete(folder, true);
+            }
+        }
+
+        /// <summary>
+        /// The contaminant switch has to reach the PSM filter and the protein-group filter together. It
+        /// governs what AllProteinGroups.tsv shows, and quantifying a wider set than that wrote
+        /// contaminant peptides into RawQuantification.tsv and PeptideQuantification.tsv while their
+        /// groups were missing from ProteinGroupQuantification.tsv -- three tables disagreeing about
+        /// whether contaminants are part of this search.
+        /// </summary>
+        /// <remarks>
+        /// Both directions are asserted because the default is on: with the box ticked a contaminant is
+        /// quantified like anything else, and only the unticked run may drop it. Neither TMT fixture can
+        /// reach either case -- no contaminant is in the fixture databases -- so this is the only place
+        /// the behaviour is pinned.
+        /// </remarks>
+        [TestCase(true)]
+        [TestCase(false)]
+        public static void ContaminantMatches_AreQuantifiedOnlyWhenTheirGroupsAreWritten(bool writeContaminants)
+        {
+            string folder = StageFolder("TmtGuardContaminants" + writeContaminants);
+            try
+            {
+                string rawPath = RawPathIn(folder);
+                WriteDesign(folder, ValidDesignRows(rawPath));
+
+                var target = new Protein("PEPTIDEK", "PROTEINA", "ORGANISM");
+                var targetPeptide = FirstPeptideOf(target);
+                var targetPsm = ReporterIonPsm(rawPath, targetPeptide);
+                var targetGroup = GroupOf(target, new[] { targetPeptide }, new[] { targetPsm });
+
+                var contaminant = new Protein("PEPTIDERPEPTIDEK", "CONTAMINANTA", "ORGANISM", isContaminant: true);
+                var contaminantPeptide = FirstPeptideOf(contaminant);
+                var contaminantPsm = ReporterIonPsm(rawPath, contaminantPeptide, scanNumber: 2);
+                var contaminantGroup = GroupOf(contaminant, new[] { contaminantPeptide }, new[] { contaminantPsm });
+
+                Assert.That(contaminantPsm.IsContaminant, Is.True, "the fixture only means anything if the match is flagged");
+                Assert.That(contaminantGroup.IsContaminant, Is.True, "and so is the group the writer filters on");
+
+                var (_, parameters) = RunMultiplexAnalysis(
+                    new List<string> { rawPath }, StageOutput(folder),
+                    allSpectralMatches: new List<SpectralMatch> { targetPsm, contaminantPsm },
+                    proteinGroups: new List<ProteinGroup> { targetGroup, contaminantGroup },
+                    writeContaminants: writeContaminants);
+
+                var results = parameters.MultiplexQuantificationResults;
+                Assert.That(results, Is.Not.Null, "the target group is quantifiable either way, so the run must succeed");
+
+                Assert.That(results.ProteinIntensities.Keys, Is.EquivalentTo(writeContaminants
+                        ? new[] { targetGroup, contaminantGroup }
+                        : new[] { targetGroup }),
+                    "the groups quantified must be exactly the groups AllProteinGroups.tsv will show");
+                Assert.That(results.PeptideIntensities.Keys.Contains(contaminantPeptide), Is.EqualTo(writeContaminants),
+                    "the peptide table has to agree with the protein table about contaminants");
+
+                Assert.That(results.ProteinIntensities.Keys, Does.Contain(targetGroup),
+                    "the contaminant switch must not touch the target half of the search");
+                Assert.That(results.PeptideIntensities.Keys, Does.Contain(targetPeptide));
+            }
+            finally
+            {
+                Directory.Delete(folder, true);
+            }
+        }
+
+        /// <summary>
+        /// The guard that reports an empty quantifiable set has to name the filter that emptied it. With
+        /// contaminants excluded and every reporter-bearing match a contaminant, "no spectral matches
+        /// carried reporter ion intensities" blames the data for what a setting one line above removed --
+        /// and the user's fix is a checkbox, not another search.
+        /// </summary>
+        [Test]
+        public static void EveryReporterIonMatchIsAContaminant_NamesTheFilterRatherThanTheData()
+        {
+            string folder = StageFolder("TmtGuardAllContaminant");
+            try
+            {
+                string rawPath = RawPathIn(folder);
+                WriteDesign(folder, ValidDesignRows(rawPath));
+
+                var contaminant = new Protein("PEPTIDEK", "CONTAMINANTA", "ORGANISM", isContaminant: true);
+                var peptide = FirstPeptideOf(contaminant);
+                var psm = ReporterIonPsm(rawPath, peptide);
+                var group = GroupOf(contaminant, new[] { peptide }, new[] { psm });
+
+                var (warnings, parameters) = RunMultiplexAnalysis(
+                    new List<string> { rawPath }, StageOutput(folder),
+                    allSpectralMatches: new List<SpectralMatch> { psm },
+                    proteinGroups: new List<ProteinGroup> { group },
+                    writeContaminants: false);
+
+                Assert.That(warnings, Has.Exactly(1).Contains("was a contaminant"));
+                Assert.That(warnings, Has.None.Contains("No spectral matches carried reporter ion intensities"),
+                    "the matches did carry them; the contaminant filter is what removed them");
+                Assert.That(parameters.MultiplexQuantificationResults, Is.Null);
             }
             finally
             {

--- a/MetaMorpheus/Test/MultiplexQuantificationTests.cs
+++ b/MetaMorpheus/Test/MultiplexQuantificationTests.cs
@@ -566,11 +566,17 @@ namespace Test
                     new List<string> { RawPathIn(folder) }, StageOutput(folder));
 
                 Assert.That(warnings, Has.Count.EqualTo(1),
-                    "the design itself archived cleanly, so declining is the only thing to report");
+                    "the read fails before anything is copied, so declining is the only thing to report");
                 Assert.That(warnings, Has.Exactly(1).Contains("Error reading TMT design file"));
                 Assert.That(warnings, Has.Exactly(1).Contains("name a file in this run"),
                     "the user has to be told the design is pointed at the wrong place");
                 Assert.That(parameters.MultiplexQuantificationResults, Is.Null);
+
+                // This reports through designErrors like an unparseable design does, so the copy is
+                // skipped here too. Said out loud because the reason above stopped being that the
+                // design archived cleanly the moment the copy moved below the read.
+                Assert.That(File.Exists(Path.Combine(StageOutput(folder), GlobalVariables.TmtExperimentalDesignFileName)),
+                    Is.False, "a design that names no file in this run is not archived either");
             }
             finally
             {


### PR DESCRIPTION
Three defects on the multiplex quantification path #2755 added, and the guard wording one of the
three then made wrong. Every one of them needs a non-default setting or a bad design file to reach,
so a stock run is unchanged.

## What changes

### An unreadable design was still archived beside the results

The copy into the output folder, and its `FinishedWritingFile` announcement, ran **before**
`TmtExperimentalDesign.Read`. A design that did not parse therefore landed in the results folder and
was announced as an output — under a comment saying the folder "records the design it was quantified
under", when nothing had been quantified under anything.

The copy now sits below the read guard. The sibling case is deliberately unchanged: a design that
*reads* is still archived even when a later guard declines to quantify.

### A bare `catch` discarded the reason the archive failed

`catch { Warn("Could not copy the TMT design file…") }` told a user whose copy failed nothing they
could act on. It now reports `e.Message` — the difference between "access is denied" and a shrug.

### Contaminants were filtered asymmetrically, and the guard then misreported it

PSMs went into quantification with `includeContaminants: true` unconditionally, while protein groups
went through `ProteinGroupIsWritten`, which honours `WriteContaminants`. With the box unticked the
quantified set was wider than the written set at the PSM and peptide levels but not the protein
level: contaminant peptides appeared in `RawQuantification.tsv` and `PeptideQuantification.tsv`
while their groups were absent from `ProteinGroupQuantification.tsv`.

The PSM filter now follows `WriteContaminants` too.

One consequence worth naming, found by @acesnik: `SpectralMatch.IsContaminant` is true when *any*
best match's parent is a contaminant, so a peptide shared between a contaminant and a target protein
is dropped by this filter too. No number moves — mzLib's engine already excluded such a match, since
`SingleIdentifiedBioPolymerOrNull` keeps one only when `Distinct()` yields exactly one element and
`PeptideWithSetModifications.Equals` compares `Parent?.Accession`, which
`PeptideSharedBetweenTwoProteins_WarnsThatMatchesWereExcluded` already pins at one excluded match.
What changes is the row set: `PeptideQuantification.tsv` also loses the target-side row of such a
peptide, and those rows were all-zero.

That created a second way to reach an empty quantifiable set, and the existing guard reported it
wrongly: with every reporter-bearing match flagged contaminant, the user was told "No spectral
matches carried reporter ion intensities" when they had, and the filter one line above was what
removed them. The guard now names the filter that emptied the set. The contaminant-inclusive filter
it asks for is evaluated only once the set is already empty, so a run that quantifies never pays
for it.

## Tests

`MultiplexQuantificationTests.cs`, whose guard helper now takes `writeContaminants` alongside the
`writeDecoys` it already had — without it, `Contaminant` did not appear in the file at all and every
test ran the default `true`, so the coverage on that argument was of the arm that does not change.

| Test | Pins |
|---|---|
| `UnreadableDesign_WarnsAndSkips` (extended) | a design that could not be read is not archived |
| `NoPsmCarriesReporterIons_WarnsAndSkips` (existing) | one that *could* be read still is |
| `DesignNamingNoFileInThisRun_WarnsAndSkips` (extended) | nor is one that names no file in this run, which reports through the same `designErrors` |
| `DesignCopyFailure_WarnsAndKeepsGoing` (existing) | the named failure still matches, and does not stop the analysis |
| `ContaminantMatches_AreQuantifiedOnlyWhenTheirGroupsAreWritten` | both directions: ticked, a contaminant quantifies like anything else; unticked, its peptide leaves with its group |
| `EveryReporterIonMatchIsAContaminant_NamesTheFilterRatherThanTheData` | the guard names the filter rather than blaming the data |

All three new assertions were verified by reverting the production change under each:

- block order alone → `UnreadableDesign_WarnsAndSkips` and `DesignNamingNoFileInThisRun_WarnsAndSkips`
  both fail on their archive assertions, from opposite guards
- the contaminant filter alone → `ContaminantMatches_…(False)` fails at `Expected: False / But was:
  True` on the contaminant peptide, and the guard test drops to the protein-group guard's wording
- the guard message alone → `EveryReporterIonMatchIsAContaminant_…` fails with the sentence it
  replaces

Full suite **1983 passed / 0 failed / 1 skipped**.

## Scope

The label-free path has the same asymmetry — two unconditional `includeContaminants: true` filters
feeding tables whose protein groups are written through the same `ProteinGroupIsWritten` — and it is
**not** fixed here. It is not the same change: the write-facing one of the two feeds FlashLFQ's
`peptideSequencesToQuantify`, which mzLib consults
inside peak filtering and MBR peak selection (`FlashLfqEngine.cs:711`, `:948`, `:996`, `:1116`,
`:1400-1428`), so narrowing it can move target peptide intensities rather than only dropping
contaminant rows. That needs its own PR with a measured before/after on a real search.

Filed as #2805, which carries the three candidate fixes and the question they have to settle.

## Credit

The bare-`catch` fix is @pcruzparri's: his review of #2776 flags the three `catch { /* ignore */ }`
blocks in `MainWindow.xaml.cs`, and this is the same swallowed exception one file over. The archive
ordering and the contaminant filter came from reading #2755 back after it merged. The guard wording,
the missing `writeContaminants` coverage and the label-free scope note are all @acesnik's, from his
review of this PR.

Sits alongside #2802, which fixes the individual-file column regression #2755 also shipped — the one
@pcruzparri found. No overlap: that one touches the subset loop, this one the design archive and the
PSM filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9P6YK6VyQJkgdj63KS4he
