### PR TITLE
Withhold contaminants from the FlashLFQ tables at the writer, not at the engine

### DIFF
--- a/MetaMorpheus/TaskLayer/SearchTask/PostSearchAnalysisTask.cs
+++ b/MetaMorpheus/TaskLayer/SearchTask/PostSearchAnalysisTask.cs
@@ -1512,10 +1512,72 @@ namespace TaskLayer
             }
         }
 
+        /// <summary>
+        /// Removes contaminant rows from the FlashLFQ-authored tables when the user asked not to write
+        /// contaminants, so AllQuantifiedPeptides.tsv and AllQuantifiedPeaks.tsv agree with the tables
+        /// beside them instead of contradicting them. WriteContaminants already reaches the protein
+        /// table (ProteinGroupIsWritten) and MetaMorpheus's own PSM and peptide tables; these two are
+        /// written by mzLib from FlashLfqResults, which has no contaminant concept, so the filter has
+        /// to be applied here.
+        ///
+        /// A sequence is dropped only when EVERY spectral match carrying it is a contaminant. One
+        /// shared with a target protein keeps its row, because SpectralMatch.IsContaminant is
+        /// Any(parent.IsContaminant) and the peptide tables beside these apply the same rule.
+        ///
+        /// DELIBERATELY AT WRITE TIME, not by narrowing peptideSequencesForQuantification above.
+        /// That list becomes FlashLfqEngine.PeptideModifiedSequencesToQuantify, which mzLib consults
+        /// INSIDE quantification rather than only on the way out - peak filtering at
+        /// FlashLfqEngine.cs:711, :948, :996, :1116, and MBR peak selection at :1400-1428, where set
+        /// membership decides which of two peaks sharing an apex survives. Narrowing it can therefore
+        /// move target intensities. Filtering here cannot: the engine sees exactly what it saw before.
+        ///
+        /// Safe to mutate the results object because every consumer that reads a NUMBER out of it has
+        /// already run - protein group intensities at QuantificationAnalysis (the IntensitiesByFile
+        /// assignment), DistributeQuantifiedIntensities, and WriteProteinResults all precede this in
+        /// Run(). Nothing after this reads FlashLfqResults.
+        /// </summary>
+        private void RemoveContaminantsFromQuantificationTables()
+        {
+            if (Parameters.SearchParameters.WriteContaminants)
+            {
+                return;
+            }
+
+            var sequencesWithATargetMatch = new HashSet<string>(Parameters.AllSpectralMatches
+                .Where(psm => !psm.IsContaminant && psm.FullSequence != null)
+                .Select(psm => psm.FullSequence));
+
+            var contaminantOnlySequences = new HashSet<string>(Parameters.AllSpectralMatches
+                .Where(psm => psm.IsContaminant && psm.FullSequence != null)
+                .Select(psm => psm.FullSequence)
+                .Where(sequence => !sequencesWithATargetMatch.Contains(sequence)));
+
+            if (contaminantOnlySequences.Count == 0)
+            {
+                return;
+            }
+
+            foreach (string sequence in contaminantOnlySequences)
+            {
+                Parameters.FlashLfqResults.PeptideModifiedSequences.Remove(sequence);
+            }
+
+            // A peak carries every identification that resolved to it, so it is a contaminant row only
+            // when none of them is a sequence still being written.
+            foreach (var file in Parameters.FlashLfqResults.Peaks.Keys.ToList())
+            {
+                Parameters.FlashLfqResults.Peaks[file].RemoveAll(peak =>
+                    peak.Identifications.Count > 0
+                    && peak.Identifications.All(id => contaminantOnlySequences.Contains(id.ModifiedSequence)));
+            }
+        }
+
         private void WriteFlashLFQResults()
         {
             if (Parameters.SearchParameters.DoLabelFreeQuantification && Parameters.FlashLfqResults != null)
             {
+                RemoveContaminantsFromQuantificationTables();
+
                 // write peaks
                 WritePeakQuantificationResultsToTsv(Parameters.FlashLfqResults, Parameters.OutputFolder, "AllQuantifiedPeaks", new List<string> { Parameters.SearchTaskId });
 

--- a/MetaMorpheus/Test/PostSearchAnalysisTaskTests.cs
+++ b/MetaMorpheus/Test/PostSearchAnalysisTaskTests.cs
@@ -1157,6 +1157,196 @@ namespace Test
         /// scans span the identifications' retention time (10.0) so the peak has a shape to integrate
         /// across rather than a single point.
         /// </summary>
+        /// <summary>
+        /// WriteContaminants reaches AllProteinGroups.tsv and MetaMorpheus's own PSM and peptide tables,
+        /// but the FlashLFQ-authored ones are written by mzLib from FlashLfqResults, which has no
+        /// contaminant concept -- so before this filter a user who unticked the box got a peptide
+        /// quantification table listing peptides whose proteins were absent from the protein table of
+        /// the same run. Both directions are asserted: a filter that dropped everything, or nothing,
+        /// would pass one of them.
+        /// </summary>
+        [Test]
+        public static void ContaminantRowsLeaveTheQuantifiedTablesOnlyWhenContaminantsAreNotWritten()
+        {
+            var written = RunQuantificationAndWriteTables("ContamWritten", writeContaminants: true);
+            var withheld = RunQuantificationAndWriteTables("ContamWithheld", writeContaminants: false);
+
+            Assert.That(written.Peptides, Does.Contain(TargetSequence));
+            Assert.That(written.Peptides, Does.Contain(ContaminantSequence));
+            Assert.That(written.Peaks, Does.Contain(ContaminantSequence));
+
+            Assert.That(withheld.Peptides, Does.Contain(TargetSequence));
+            Assert.That(withheld.Peptides, Does.Not.Contain(ContaminantSequence));
+            Assert.That(withheld.Peaks, Does.Not.Contain(ContaminantSequence));
+        }
+
+        /// <summary>
+        /// Feed wide, write narrow -- the pattern the decoy argument one line above
+        /// peptideSequencesForQuantification already establishes, now applied to contaminants.
+        ///
+        /// This is the assertion that distinguishes filtering at the writers from the one-line
+        /// alternative of narrowing peptideSequencesForQuantification. That list becomes
+        /// FlashLfqEngine.PeptideModifiedSequencesToQuantify, which mzLib consults INSIDE
+        /// quantification -- peak filtering at FlashLfqEngine.cs:711, :948, :996, :1116, and MBR peak
+        /// selection at :1400-1428, where set membership decides which of two peaks sharing an apex
+        /// survives. Under that alternative the contaminant is never quantified at all and its
+        /// intensity here would be zero; under this one the engine quantifies it exactly as before and
+        /// only the writer withholds the row. So the greater-than-zero assertion is what goes red if
+        /// this is ever "simplified" into the narrowing version, and the equality is the claim that
+        /// the target's number did not move.
+        /// </summary>
+        [Test]
+        public static void ContaminantsAreStillQuantifiedWhenTheyAreNotWritten()
+        {
+            var written = RunQuantificationAndWriteTables("ContamIntensityWritten", writeContaminants: true);
+            var withheld = RunQuantificationAndWriteTables("ContamIntensityWithheld", writeContaminants: false);
+
+            Assert.That(withheld.ContaminantIntensityInEngine, Is.GreaterThan(0),
+                "the engine must still see and quantify the contaminant; only the writer withholds it");
+            Assert.That(withheld.ContaminantIntensityInEngine, Is.EqualTo(written.ContaminantIntensityInEngine),
+                "withholding the row must not change what the engine computed for it either");
+
+            Assert.That(written.TargetIntensity, Is.GreaterThan(0),
+                "precondition: the target must actually be quantified, or the equality below is two zeroes");
+            Assert.That(withheld.TargetIntensity, Is.EqualTo(written.TargetIntensity),
+                "filtering at the writers must not move a target intensity");
+        }
+
+        private const string TargetSequence = "PEPTIDEK";
+        private const string ContaminantSequence = "ACDEFGHIK";
+
+        /// <summary>
+        /// Drives QuantificationAnalysis and then WriteFlashLFQResults over one target protein and one
+        /// contaminant protein, and returns what the two FlashLFQ tables say plus the target's intensity
+        /// as the engine computed it.
+        /// </summary>
+        private static (string Peptides, string Peaks, double TargetIntensity, double ContaminantIntensityInEngine)
+            RunQuantificationAndWriteTables(string folderName, bool writeContaminants)
+        {
+            CommonParameters commonParameters = new();
+            string outputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, folderName);
+            if (Directory.Exists(outputFolder))
+            {
+                Directory.Delete(outputFolder, true);
+            }
+            Directory.CreateDirectory(outputFolder);
+
+            try
+            {
+                string mzmlPath = Path.Combine(outputFolder, "fake.mzML");
+                var digestionParams = new DigestionParams(protease: "trypsin", minPeptideLength: 1);
+
+                var target = new Protein(TargetSequence, "TARGET_ACC");
+                var contaminant = new Protein(ContaminantSequence, "CONTAM_ACC", isContaminant: true);
+
+                SpectralMatch targetPsm = ContaminantTestPsm(target, digestionParams, commonParameters, mzmlPath, 1);
+                SpectralMatch contaminantPsm = ContaminantTestPsm(contaminant, digestionParams, commonParameters, mzmlPath, 2);
+
+                // The flag is what the filter reads; if it ever stops being set, the assertions in the
+                // tests above would pass while measuring nothing.
+                Assert.That(contaminantPsm.IsContaminant, Is.True, "precondition: the contaminant PSM is flagged");
+                Assert.That(targetPsm.IsContaminant, Is.False, "precondition: the target PSM is not");
+
+                WriteMs1FixtureFor(mzmlPath, TargetSequence, ContaminantSequence);
+
+                PostSearchAnalysisParameters parameters = new()
+                {
+                    SearchParameters = new SearchParameters
+                    {
+                        DoLabelFreeQuantification = true,
+                        DoMultiplexQuantification = false,
+                        MatchBetweenRuns = false,
+                        Normalize = false,
+                        WriteContaminants = writeContaminants,
+                        WriteIndividualFiles = false,
+                    },
+                    OutputFolder = outputFolder,
+                    IndividualResultsOutputFolder = outputFolder,
+                    SearchTaskId = "TestTask",
+                    AllSpectralMatches = new List<SpectralMatch> { targetPsm, contaminantPsm },
+                    CurrentRawFileList = new List<string> { mzmlPath },
+                    MyFileManager = new MyFileManager(true),
+                    FixedModifications = new List<Modification>(),
+                    VariableModifications = new List<Modification>(),
+                    ListOfDigestionParams = new HashSet<IDigestionParams> { digestionParams },
+                    DatabaseFilenameList = new List<DbForTask>(),
+                    FileSettingsList = new FileSpecificParameters[] { null },
+                };
+
+                PostSearchAnalysisTask task = new()
+                {
+                    Parameters = parameters,
+                    CommonParameters = commonParameters,
+                    FileSpecificParameters = new List<(string, CommonParameters)> { (mzmlPath, commonParameters) },
+                };
+
+                InvokePrivate(task, "QuantificationAnalysis");
+
+                // Read the target's intensity BEFORE the writers run, so it is what the engine produced
+                // rather than what survived the filter.
+                var quantFile = parameters.FlashLfqResults.SpectraFiles.Single();
+                double targetIntensity = parameters.FlashLfqResults.PeptideModifiedSequences[TargetSequence]
+                    .GetIntensity(quantFile);
+                double contaminantIntensityInEngine =
+                    parameters.FlashLfqResults.PeptideModifiedSequences.TryGetValue(ContaminantSequence, out var contaminantPeptide)
+                        ? contaminantPeptide.GetIntensity(quantFile)
+                        : 0;
+
+                InvokePrivate(task, "WriteFlashLFQResults");
+
+                string peptidesPath = Path.Combine(outputFolder, "AllQuantified" + GlobalVariables.AnalyteType + "s.tsv");
+                string peaksPath = Path.Combine(outputFolder, "AllQuantifiedPeaks.tsv");
+                Assert.That(File.Exists(peptidesPath), Is.True, peptidesPath + " was not written");
+                Assert.That(File.Exists(peaksPath), Is.True, peaksPath + " was not written");
+
+                return (File.ReadAllText(peptidesPath), File.ReadAllText(peaksPath), targetIntensity,
+                    contaminantIntensityInEngine);
+            }
+            finally
+            {
+                if (Directory.Exists(outputFolder))
+                {
+                    Directory.Delete(outputFolder, true);
+                }
+            }
+        }
+
+        /// <summary>
+        /// A resolved, passing PSM on the whole of a one-peptide protein, carrying PEPTIDE-level FDR
+        /// info as well as PSM-level. The peptide-level half matters here and nowhere else in this
+        /// fixture: peptideSequencesForQuantification is built with filterAtPeptideLevel, so without
+        /// PeptideFdrInfo the filter yields nothing, FlashLFQ reads the empty list as "no restriction"
+        /// (FlashLfqEngine's peptideSequencesToQuantify.IsNotNullOrEmpty() check) and quantifies every
+        /// identification. A fixture missing it measures that fallback instead of the filter, and the
+        /// contaminant would then be quantified whatever the call site said.
+        /// </summary>
+        private static SpectralMatch ContaminantTestPsm(Protein protein, DigestionParams digestionParams,
+            CommonParameters commonParameters, string mzmlPath, int scanNumber)
+        {
+            var digestionProduct = protein.Digest(digestionParams, new List<Modification>(), new List<Modification>())
+                .Cast<PeptideWithSetModifications>()
+                .First(p => p.BaseSequence == protein.BaseSequence);
+
+            SpectralMatch psm = ResolvedPsm(digestionProduct, mzmlPath, commonParameters, scanNumber);
+            psm.PeptideFdrInfo = new EngineLayer.FdrAnalysis.FdrInfo
+            {
+                CumulativeTarget = 1,
+                CumulativeDecoy = 0,
+                QValue = 0,
+                CumulativeTargetNotch = 1,
+                CumulativeDecoyNotch = 0,
+                QValueNotch = 0,
+                PEP = 0,
+                PEP_QValue = 0
+            };
+            return psm;
+        }
+
+        private static void InvokePrivate(PostSearchAnalysisTask task, string methodName) =>
+            typeof(PostSearchAnalysisTask)
+                .GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance)!
+                .Invoke(task, null);
+
         private static void WriteMs1FixtureFor(string mzmlPath, params string[] baseSequences)
         {
             var envelopes = baseSequences


### PR DESCRIPTION
<!-- project-of-origin -->
> **Project of origin:** `QuantProject`

Closes #2805.

`WriteContaminants` reached `AllProteinGroups.tsv` and MetaMorpheus's own PSM and peptide tables, but not the FlashLFQ-authored ones. So unticking the box produced `AllQuantifiedPeptides.tsv` and `AllQuantifiedPeaks.tsv` listing peptides whose proteins were absent from the protein table of the same run.

Raised by @acesnik reviewing #2804, which fixed the same asymmetry on the multiplex path.

## What changes

`RemoveContaminantsFromQuantificationTables()`, called at the top of `WriteFlashLFQResults()`. It drops a full sequence from `FlashLfqResults.PeptideModifiedSequences`, and the peaks carrying only such sequences, when the user asked not to write contaminants.

A sequence is dropped only when **every** spectral match carrying it is a contaminant. That is the rule `AllPeptides.tsv` already applies — `SpectralMatch.IsContaminant` is `Any(parent.IsContaminant)` — so a peptide shared with a target protein is treated identically in both tables, and the two agree by construction rather than by review.

## Why at the writer and not at the filter

The obvious one-line alternative is to pass `WriteContaminants` to the `peptideSequencesForQuantification` filter, whose own comment says *"Only these peptides will be written to the AllQuantifiedPeptides.tsv output file."* That comment is wrong about what the list does, and #2805 was filed rather than folded into #2804 to find out how wrong.

I built that version and ran it against the same fixture. It fails twice.

**It stops the engine quantifying the contaminant rather than withholding its row.** The list becomes `FlashLfqEngine.PeptideModifiedSequencesToQuantify`, and `FlashLfqResults`' constructor filters identifications through it (`FlashLFQResults.cs:46`) before anything is quantified. Measured, as a test assertion:

```
ContaminantsAreStillQuantifiedWhenTheyAreNotWritten
   the engine must still see and quantify the contaminant; only the writer withholds it
   Expected: greater than 0
   But was:  0.0d
```

That is the coupling #2805 warned about, observed rather than argued. The same set decides which of two peaks sharing an apex survives at `FlashLfqEngine.cs:1400-1428`, and is read in peak filtering at `:711`, `:948`, `:996`, `:1116` — which is the route by which a **target** intensity moves. Nothing here needs to speculate about how often that happens: a change that alters the engine's input cannot be justified by a table that only needed different rows.

**It also fixes only half of what was reported.** Under that version the contaminant leaves `AllQuantifiedPeptides.tsv` and stays in `AllQuantifiedPeaks.tsv`.

Feeding the engine wide and writing narrow is the pattern already set one line above, by `includeDecoys: Parameters.SearchParameters.MatchBetweenRuns` — *"Decoys are required for PIP-ECHO, but are not written to the output file."* This applies the same answer to contaminants.

## Safety of mutating the results object

Every consumer that reads a **number** out of `FlashLfqResults` has already run by the time `WriteFlashLFQResults()` is called: the protein-group `IntensitiesByFile` assignment and `DistributeQuantifiedIntensities` are both inside `QuantificationAnalysis`, and `WriteProteinResults()` precedes it in `Run()`. Nothing after it reads `FlashLfqResults`. That is stated in the method's own comment so the next reader does not have to re-derive it.

## Tests

| Test | Pins |
|---|---|
| `ContaminantRowsLeaveTheQuantifiedTablesOnlyWhenContaminantsAreNotWritten` | both directions — the contaminant is present with the box ticked, absent from both tables without it |
| `ContaminantsAreStillQuantifiedWhenTheyAreNotWritten` | the engine's own number for the contaminant is unchanged and non-zero, and the target's intensity does not move |

Falsified in both directions rather than merely passing:

- Reverting the production change alone: `Expected: not String containing "ACDEFGHIK" / But was: <the peptide table>`.
- Swapping in the filter-side alternative: the engine assertion goes red at `Expected: greater than 0 / But was: 0.0d`, and the row test fails on the **peaks** file instead of the peptides file.

**One fixture detail worth reading before writing another test in this file.** `ContaminantTestPsm` sets peptide-level `FdrInfo` as well as PSM-level, deliberately. `peptideSequencesForQuantification` is built with `filterAtPeptideLevel: true`, and `SetFdrValues` populates only `PsmFdrInfo` — so without it the filter yields an empty list, FlashLFQ reads an empty `peptideSequencesToQuantify` as "no restriction", and quantifies every identification. My first run of the alternative measured that fallback and looked like the alternative did nothing at all. The comment on the helper says so.

## Scope

Not included, and to be filed separately once this lands: `PostGlycoSearchAnalysisTask` writes the same tables through its own copies of these two writers. It is **not** the same bug — that task deletes contaminant PSMs at `:41`, before FDR analysis rather than at the writer, so its FlashLFQ tables are already contaminant-free for a different and more consequential reason. It deserves its own issue rather than a paragraph here.

Full suite **1999 passed / 0 failed / 1 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0184BpVmNb66uexzAmi6gDkR

