### PR TITLE
Name the modifications in the index cache key instead of counting them

### DIFF
--- a/MetaMorpheus/EngineLayer/Indexing/IndexingEngine.cs
+++ b/MetaMorpheus/EngineLayer/Indexing/IndexingEngine.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 using Omics;
@@ -64,8 +65,12 @@ namespace EngineLayer.Indexing
             sb.AppendLine("Precursor Index: " + GeneratePrecursorIndex);
             sb.AppendLine("Search Decoys: " + DecoyType);
             sb.AppendLine("Number of proteins: " + ProteinList.Count);
-            sb.AppendLine("Number of fixed mods: " + FixedModifications.Count);
-            sb.AppendLine("Number of variable mods: " + VariableModifications.Count);
+            sb.AppendLine("Fixed mods: " + DescribeModifications(FixedModifications));
+            sb.AppendLine("Variable mods: " + DescribeModifications(VariableModifications));
+            sb.AppendLine("Silac labels: " + DescribeSilacLabels(SilacLabels));
+            sb.AppendLine("Turnover labels: " + (TurnoverLabels == null
+                ? "none"
+                : DescribeSilacLabel(TurnoverLabels.Value.StartLabel) + ">" + DescribeSilacLabel(TurnoverLabels.Value.EndLabel)));
             sb.AppendLine("Dissociation Type: " + CommonParameters.DissociationType);
             sb.AppendLine("Contaminant Handling: " + TcAmbiguity);
 
@@ -85,6 +90,102 @@ namespace EngineLayer.Indexing
 
             sb.Append("Localizeable mods: " + ProteinList.Select(b => b.OneBasedPossibleLocalizedModifications.Count).Sum());
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// The identity of a modification list, for the index cache key.
+        /// </summary>
+        /// <remarks>
+        /// This names every modification instead of counting them. Counting was the defect: the cache key
+        /// is compared as literal text by <c>MetaMorpheusTask.SameSettings</c>, so two searches whose
+        /// modification lists differed but happened to be the same length produced the same key, and the
+        /// second search silently reused a peptide index built for the first one's modifications. The
+        /// index stores decorated <c>PeptideWithSetModifications</c>, so that index is wrong rather than
+        /// merely incomplete: a variable-mod swap loses every peptide bearing the new modification, and a
+        /// fixed-mod swap puts wrong masses in every entry.
+        ///
+        /// Each entry is the readable id followed by a short hash of the modification's complete definition
+        /// (<see cref="Modification.ToString"/>, i.e. its mods.txt record: target, location restriction,
+        /// chemical formula, monoisotopic mass, neutral losses, diagnostic ions). The id alone would miss
+        /// a user who edited a custom modification file in place, keeping the name and changing the mass;
+        /// the hash covers every field, and keeps covering fields added to Modification later.
+        ///
+        /// The list order is deliberately preserved rather than sorted. Modification enumeration is
+        /// truncated at MaxModificationIsoforms by a yield break in
+        /// <c>ProteolyticPeptide.GetModifiedPeptides</c>, so which isoforms survive can depend on the
+        /// order the modifications arrive in. Sorting here would let two orders share one key and reuse
+        /// each other's index. Preserving order can only cost a needless rebuild, never a wrong reuse.
+        /// </remarks>
+        internal static string DescribeModifications(IEnumerable<Modification> modifications)
+        {
+            if (modifications == null)
+            {
+                return "none";
+            }
+
+            return string.Join(",", modifications.Select(m =>
+                (m?.IdWithMotif ?? "unnamed") + "[" + ShortHash(m?.ToString()) + "]"));
+        }
+
+        /// <summary>
+        /// The identity of the SILAC label list, for the index cache key. Labels reach
+        /// <c>Protein.Digest</c> alongside the modifications and change which peptides land in the index,
+        /// but appeared nowhere in the key. <see cref="SilacLabel"/> does not override ToString, so the
+        /// fields are named here. Order is preserved for the same reason as the modifications.
+        /// </summary>
+        internal static string DescribeSilacLabels(IEnumerable<SilacLabel> labels)
+        {
+            if (labels == null)
+            {
+                return "none";
+            }
+
+            return string.Join(",", labels.Select(DescribeSilacLabel));
+        }
+
+        internal static string DescribeSilacLabel(SilacLabel label)
+        {
+            if (label == null)
+            {
+                return "none";
+            }
+
+            var sb = new StringBuilder();
+            sb.Append(label.OriginalAminoAcid).Append('>').Append(label.AminoAcidLabel)
+                .Append('(').Append(label.LabelChemicalFormula).Append(',').Append(label.MassDifference).Append(')');
+
+            if (label.AdditionalLabels != null)
+            {
+                foreach (SilacLabel additionalLabel in label.AdditionalLabels)
+                {
+                    sb.Append('+').Append(DescribeSilacLabel(additionalLabel));
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// A short, stable hash of a definition string, for use inside the index cache key.
+        /// </summary>
+        /// <remarks>
+        /// Line endings are normalised first. <see cref="Modification.ToString"/> builds its text with
+        /// AppendLine, which emits the writing machine's line ending, so the same modification would
+        /// otherwise hash differently on Windows and Linux and force a rebuild on nothing.
+        ///
+        /// Eight bytes separates the handful of modifications in a search many times over, and keeps the
+        /// key readable next to the id it qualifies. This is a cache key, not a security boundary.
+        /// </remarks>
+        internal static string ShortHash(string definition)
+        {
+            if (string.IsNullOrEmpty(definition))
+            {
+                return "none";
+            }
+
+            string normalized = definition.Replace("\r\n", "\n").Replace('\r', '\n');
+            byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(normalized));
+            return Convert.ToHexString(hash, 0, 8).ToLowerInvariant();
         }
 
         protected override MetaMorpheusEngineResults RunSpecific()

--- a/MetaMorpheus/Test/IndexCacheKeyTest.cs
+++ b/MetaMorpheus/Test/IndexCacheKeyTest.cs
@@ -1,0 +1,335 @@
+﻿using EngineLayer;
+using EngineLayer.Indexing;
+using NUnit.Framework;
+using Omics.Modifications;
+using Proteomics;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UsefulProteomicsDatabases;
+
+namespace Test
+{
+    /// <summary>
+    /// The peptide index is cached on disk and reused whenever <see cref="IndexingEngine.ToString"/>
+    /// matches the params file written beside it (MetaMorpheusTask.SameSettings compares the two as
+    /// literal text). These tests pin the property that makes reuse safe: anything that changes which
+    /// peptides land in the index must change the key.
+    ///
+    /// The key used to carry modification *counts* only ("Number of variable mods: 1"). Two searches
+    /// whose modification lists differed but happened to be the same length therefore shared a key, and
+    /// the second silently reused an index built for the first one's modifications. Because the index
+    /// stores decorated PeptideWithSetModifications, that index is wrong and not merely incomplete.
+    /// </summary>
+    [TestFixture]
+    public static class IndexCacheKeyTest
+    {
+        private const char CarriageReturn = (char)13;
+        private const char LineFeed = (char)10;
+
+        private static Modification Mod(string id, string motifString, double mass, string locationRestriction = "Anywhere.")
+        {
+            ModificationMotif.TryGetMotif(motifString, out ModificationMotif motif);
+            return new Modification(_originalId: id, _modificationType: "Test", _target: motif,
+                _locationRestriction: locationRestriction, _monoisotopicMass: mass);
+        }
+
+        private static Modification Oxidation => Mod("Oxidation on M", "M", 15.994915);
+        private static Modification Phospho => Mod("Phospho on S", "S", 79.966331);
+        private static Modification Carbamidomethyl => Mod("Carbamidomethyl on C", "C", 57.021464);
+        private static Modification Iodoacetamide => Mod("Iodoacetamide derivative on C", "C", 58.005479);
+
+        private static string KeyFor(List<Modification> variableMods = null, List<Modification> fixedMods = null,
+            List<SilacLabel> silacLabels = null, SilacLabel startLabel = null, SilacLabel endLabel = null)
+        {
+            CommonParameters commonParameters = new CommonParameters();
+            var fileSpecificParameters = new List<(string, CommonParameters)> { ("", commonParameters) };
+
+            var engine = new IndexingEngine(
+                new List<Protein> { new Protein("MNNNKQQQSTC", "accession") },
+                variableMods ?? new List<Modification>(),
+                fixedMods ?? new List<Modification>(),
+                silacLabels, startLabel, endLabel, 1, DecoyType.None, commonParameters, fileSpecificParameters,
+                30000, false, new List<FileInfo>(), TargetContaminantAmbiguity.RemoveContaminant, new List<string>());
+
+            return engine.ToString();
+        }
+
+        private static string LineStartingWith(string key, string prefix) =>
+            key.Split(LineFeed).Select(line => line.TrimEnd(CarriageReturn)).Single(line => line.StartsWith(prefix));
+
+        // ----- the defect this change exists to fix -----
+
+        [Test]
+        public static void SwappingOneVariableModForAnotherChangesTheKey()
+        {
+            string withOxidation = KeyFor(variableMods: new List<Modification> { Oxidation });
+            string withPhospho = KeyFor(variableMods: new List<Modification> { Phospho });
+
+            Assert.That(withPhospho, Is.Not.EqualTo(withOxidation),
+                "Same number of variable mods, different mods. A shared key here reuses an index that " +
+                "contains no phospho peptides at all.");
+        }
+
+        [Test]
+        public static void SwappingOneFixedModForAnotherChangesTheKey()
+        {
+            string withCarbamidomethyl = KeyFor(fixedMods: new List<Modification> { Carbamidomethyl });
+            string withIodoacetamide = KeyFor(fixedMods: new List<Modification> { Iodoacetamide });
+
+            Assert.That(withIodoacetamide, Is.Not.EqualTo(withCarbamidomethyl),
+                "Same number of fixed mods, different mods. A shared key here reuses an index whose " +
+                "every peptide mass is wrong.");
+        }
+
+        [Test]
+        public static void SwappingModsWithinAMultiModListChangesTheKey()
+        {
+            string first = KeyFor(variableMods: new List<Modification> { Oxidation, Phospho });
+            string second = KeyFor(variableMods: new List<Modification> { Oxidation, Mod("Acetyl on K", "K", 42.010565) });
+
+            Assert.That(second, Is.Not.EqualTo(first));
+        }
+
+        [Test]
+        public static void TheKeyNoLongerCountsModifications()
+        {
+            string key = KeyFor(variableMods: new List<Modification> { Oxidation });
+
+            Assert.That(key, Does.Not.Contain("Number of variable mods"));
+            Assert.That(key, Does.Not.Contain("Number of fixed mods"));
+        }
+
+        // ----- reuse must still happen when nothing relevant changed -----
+
+        [Test]
+        public static void IdenticalModificationsGiveTheSameKey()
+        {
+            string first = KeyFor(variableMods: new List<Modification> { Oxidation, Phospho },
+                fixedMods: new List<Modification> { Carbamidomethyl });
+            string second = KeyFor(variableMods: new List<Modification> { Oxidation, Phospho },
+                fixedMods: new List<Modification> { Carbamidomethyl });
+
+            Assert.That(second, Is.EqualTo(first),
+                "Equal inputs must reuse the cached index, or every search re-indexes for nothing.");
+        }
+
+        [Test]
+        public static void TheKeyIsStableAcrossRepeatedCalls()
+        {
+            string key = KeyFor(variableMods: new List<Modification> { Oxidation });
+
+            Assert.That(KeyFor(variableMods: new List<Modification> { Oxidation }), Is.EqualTo(key));
+        }
+
+        // ----- identity is the whole definition, not just the name -----
+
+        [Test]
+        public static void EditingAModificationsMassInPlaceChangesTheKey()
+        {
+            // A user editing a custom mods file, keeping the name and changing the mass. Keying on the
+            // id alone would reuse an index built with the old mass.
+            string original = KeyFor(variableMods: new List<Modification> { Mod("Custom on M", "M", 15.994915) });
+            string edited = KeyFor(variableMods: new List<Modification> { Mod("Custom on M", "M", 16.994915) });
+
+            Assert.That(edited, Is.Not.EqualTo(original));
+        }
+
+        [Test]
+        public static void ChangingOnlyTheLocationRestrictionChangesTheKey()
+        {
+            string anywhere = KeyFor(variableMods: new List<Modification> { Mod("Acetyl on K", "K", 42.010565, "Anywhere.") });
+            string nTerminal = KeyFor(variableMods: new List<Modification> { Mod("Acetyl on K", "K", 42.010565, "N-terminal.") });
+
+            Assert.That(nTerminal, Is.Not.EqualTo(anywhere),
+                "Same name and mass, different placement, so different peptides.");
+        }
+
+        [Test]
+        public static void TheKeyNamesEachModificationAndQualifiesItWithAShortHash()
+        {
+            string line = LineStartingWith(KeyFor(variableMods: new List<Modification> { Oxidation, Phospho }), "Variable mods: ");
+
+            Assert.That(line, Is.EqualTo("Variable mods: " +
+                "Oxidation on M[" + IndexingEngine.ShortHash(Oxidation.ToString()) + "]," +
+                "Phospho on S[" + IndexingEngine.ShortHash(Phospho.ToString()) + "]"),
+                "Readable id first, so a human can diff two params files and see what changed.");
+        }
+
+        // ----- order is deliberately significant -----
+
+        [Test]
+        public static void ReorderingTheVariableModListChangesTheKey()
+        {
+            // Not cosmetic. GetVariableModificationPatterns is truncated at MaxModificationIsoforms by a
+            // yield break, so which isoforms survive can depend on the order the mods arrive in. Sorting
+            // the key would let two orders reuse each other's index.
+            string forward = KeyFor(variableMods: new List<Modification> { Oxidation, Phospho });
+            string reversed = KeyFor(variableMods: new List<Modification> { Phospho, Oxidation });
+
+            Assert.That(reversed, Is.Not.EqualTo(forward));
+        }
+
+        // ----- SILAC labels also decide the peptides, and were absent from the key entirely -----
+
+        [Test]
+        public static void SwappingSilacLabelsChangesTheKey()
+        {
+            string lysine = KeyFor(silacLabels: new List<SilacLabel> { new SilacLabel('K', 'a', "C{13}6", 6.020129) });
+            string arginine = KeyFor(silacLabels: new List<SilacLabel> { new SilacLabel('R', 'b', "C{13}6", 6.020129) });
+
+            Assert.That(arginine, Is.Not.EqualTo(lysine));
+        }
+
+        [Test]
+        public static void ChangingASilacLabelMassChangesTheKey()
+        {
+            string light = KeyFor(silacLabels: new List<SilacLabel> { new SilacLabel('K', 'a', "C{13}6", 6.020129) });
+            string heavy = KeyFor(silacLabels: new List<SilacLabel> { new SilacLabel('K', 'a', "C{13}6", 8.014199) });
+
+            Assert.That(heavy, Is.Not.EqualTo(light));
+        }
+
+        [Test]
+        public static void AnAdditionalSilacLabelChangesTheKey()
+        {
+            SilacLabel plain = new SilacLabel('K', 'a', "C{13}6", 6.020129);
+
+            SilacLabel compound = new SilacLabel('K', 'a', "C{13}6", 6.020129);
+            compound.AddAdditionalSilacLabel(new SilacLabel('R', 'b', "C{13}6", 6.020129));
+
+            Assert.That(KeyFor(silacLabels: new List<SilacLabel> { compound }),
+                Is.Not.EqualTo(KeyFor(silacLabels: new List<SilacLabel> { plain })));
+        }
+
+        [Test]
+        public static void TurnoverLabelsChangeTheKey()
+        {
+            SilacLabel start = new SilacLabel('K', 'a', "C{13}6", 6.020129);
+            SilacLabel end = new SilacLabel('K', 'b', "N{15}2", 2.004);
+
+            string none = KeyFor();
+            string withTurnover = KeyFor(startLabel: start, endLabel: end);
+            string swapped = KeyFor(startLabel: end, endLabel: start);
+
+            Assert.That(withTurnover, Is.Not.EqualTo(none));
+            Assert.That(swapped, Is.Not.EqualTo(withTurnover), "Start and end are not interchangeable.");
+        }
+
+        [Test]
+        public static void MultipleSilacLabelsAreSeparated()
+        {
+            // Pins the separator. Without it two labels run together into one token, and a pair of lists
+            // that differ only in where one label ends and the next begins would share a key.
+            SilacLabel first = new SilacLabel('K', 'a', "C{13}6", 6.020129);
+            SilacLabel second = new SilacLabel('R', 'b', "C{13}6", 6.020129);
+
+            string line = LineStartingWith(KeyFor(silacLabels: new List<SilacLabel> { first, second }), "Silac labels: ");
+
+            Assert.That(line, Is.EqualTo("Silac labels: " +
+                IndexingEngine.DescribeSilacLabel(first) + "," + IndexingEngine.DescribeSilacLabel(second)));
+        }
+
+        [Test]
+        public static void NoTurnoverLabelsRendersAsNoneRatherThanAPair()
+        {
+            // The constructor only builds TurnoverLabels when at least one label is given. If that guard
+            // inverted, "no labels" would render as a pair of empties and stop being distinguishable from
+            // a real pair that happens to be empty.
+            string line = LineStartingWith(KeyFor(), "Turnover labels: ");
+
+            Assert.That(line, Is.EqualTo("Turnover labels: none"));
+        }
+
+        [Test]
+        public static void OneTurnoverLabelIsDistinguishableFromNone()
+        {
+            SilacLabel start = new SilacLabel('K', 'a', "C{13}6", 6.020129);
+
+            Assert.That(KeyFor(startLabel: start), Is.Not.EqualTo(KeyFor()));
+        }
+
+        // ----- degenerate inputs must be described, not thrown on -----
+
+        [Test]
+        public static void NullAndEmptyModificationListsAreDescribedAndDistinct()
+        {
+            Assert.That(IndexingEngine.DescribeModifications(null), Is.EqualTo("none"));
+            Assert.That(IndexingEngine.DescribeModifications(new List<Modification>()), Is.Empty);
+        }
+
+        [Test]
+        public static void NullSilacLabelsAreDescribedAndDistinct()
+        {
+            Assert.That(IndexingEngine.DescribeSilacLabels(null), Is.EqualTo("none"));
+            Assert.That(IndexingEngine.DescribeSilacLabels(new List<SilacLabel>()), Is.Empty);
+            Assert.That(IndexingEngine.DescribeSilacLabel(null), Is.EqualTo("none"));
+        }
+
+        [Test]
+        public static void AModificationWithNoIdIsStillDescribed()
+        {
+            // Modification.IdWithMotif is null when the mod was built without an id; ValidModification
+            // rejects those, but the key must not throw on the way to finding that out.
+            string described = IndexingEngine.DescribeModifications(new List<Modification> { new Modification() });
+
+            Assert.That(described, Does.StartWith("unnamed["));
+        }
+
+        [Test]
+        public static void ANullEntryInTheModificationListIsStillDescribed()
+        {
+            Assert.That(() => IndexingEngine.DescribeModifications(new List<Modification> { null }), Throws.Nothing);
+        }
+
+        // ----- the short hash itself -----
+
+        [Test]
+        public static void ShortHashIgnoresLineEndings()
+        {
+            // Modification.ToString builds its text with AppendLine, which emits the writing machine's
+            // line ending. Spelled out as char codes so the test cannot be confused by its own source
+            // file's line endings.
+            string windowsStyle = "MM   15.994915" + CarriageReturn + LineFeed + "TG   M";
+            string unixStyle = "MM   15.994915" + LineFeed + "TG   M";
+            string oldMacStyle = "MM   15.994915" + CarriageReturn + "TG   M";
+
+            Assert.That(IndexingEngine.ShortHash(unixStyle), Is.EqualTo(IndexingEngine.ShortHash(windowsStyle)));
+            Assert.That(IndexingEngine.ShortHash(oldMacStyle), Is.EqualTo(IndexingEngine.ShortHash(windowsStyle)));
+        }
+
+        [Test]
+        public static void ShortHashSeparatesDifferentDefinitions()
+        {
+            Assert.That(IndexingEngine.ShortHash("MM   15.994915"), Is.Not.EqualTo(IndexingEngine.ShortHash("MM   15.994916")));
+        }
+
+        [Test]
+        public static void ShortHashIsSixteenLowercaseHexCharacters()
+        {
+            string shortHash = IndexingEngine.ShortHash(Oxidation.ToString());
+
+            Assert.That(shortHash, Has.Length.EqualTo(16));
+            Assert.That(shortHash.All(c => (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')), Is.True,
+                "Expected lowercase hex, got: " + shortHash);
+        }
+
+        [Test]
+        public static void ShortHashOfNothingIsNone()
+        {
+            Assert.That(IndexingEngine.ShortHash(null), Is.EqualTo("none"));
+            Assert.That(IndexingEngine.ShortHash(string.Empty), Is.EqualTo("none"));
+        }
+
+        // ----- guard the lines that were already correct -----
+
+        [Test]
+        public static void AddingAModificationStillChangesTheKey()
+        {
+            string one = KeyFor(variableMods: new List<Modification> { Oxidation });
+            string two = KeyFor(variableMods: new List<Modification> { Oxidation, Phospho });
+
+            Assert.That(two, Is.Not.EqualTo(one));
+        }
+    }
+}


### PR DESCRIPTION
<!-- project-of-origin -->
> **Project of origin:** `cleavageRules`

## The bug

The peptide index is cached beside the protein database and reused whenever `IndexingEngine.ToString()` matches the `indexEngine.params` file stored next to it — `MetaMorpheusTask.SameSettings` compares the two as literal text.

That key carried only the *counts* of the modifications:

```csharp
sb.AppendLine("Number of fixed mods: " + FixedModifications.Count);
sb.AppendLine("Number of variable mods: " + VariableModifications.Count);
```

So two searches whose modification lists differ but happen to be the same length share a key. The cached index stores decorated `PeptideWithSetModifications`, so the reuse is **wrong, not merely incomplete**:

- swap one variable mod for another of the same count and the run gets a cache hit on an index that contains **no peptides bearing the new modification at all**;
- swap a fixed mod and **every peptide mass in the index is wrong**.

Both complete and report success. And because the cache lives under `<database dir>/DatabaseIndex/`, a poisoned index is shared by every task, every run, and every user of that database on that disk.

### Demonstrated

Two searches over the same database — fixed Carbamidomethyl→Iodoacetamide, variable Oxidation→Phospho:

**Before** (the two keys are byte-identical):

```
Number of fixed mods: 1              Number of fixed mods: 1
Number of variable mods: 1           Number of variable mods: 1

Keys identical? YES — search B silently reuses search A's index
```

**After:**

```
Fixed mods: Carbamidomethyl on C[a4a360dcf322504a]     Fixed mods: Iodoacetamide derivative on C[2669692cb67f9f70]
Variable mods: Oxidation on M[2107fdafa9ba527f]        Variable mods: Phospho on S[84b5ba97ee180fcd]
Silac labels: none                                     Silac labels: none
Turnover labels: none                                  Turnover labels: none

Keys identical? NO — search B rebuilds, correctly
```

## The change

Each modification is rendered as its readable id followed by a short hash of its complete definition (`Modification.ToString()`, i.e. the mods.txt record: target, location restriction, chemical formula, monoisotopic mass, neutral losses, diagnostic ions).

Three decisions worth a look in review:

**Why a hash and not just the id.** A user who edits a custom modification file in place — keeping the name, changing the mass — would otherwise still get a cache hit. The hash covers every field, and keeps covering fields added to `Modification` later. The readable id stays in front of it so a human diffing two params files can see what actually changed.

**Why the list order is preserved rather than sorted.** Sorting looks tempting, so that reordering the list in the GUI does not force a needless rebuild. It is wrong. `GetVariableModificationPatterns` is truncated at `MaxModificationIsoforms` by a `yield break`, so *which* isoforms survive can depend on the order the modifications arrive in. Sorting would let two orders share one key and reuse each other's index — the same bug in a subtler form. Preserving order can only cost a needless rebuild, never a wrong reuse.

**Why SILAC labels are in here too.** `SilacLabels` and `TurnoverLabels` are handed to `Protein.Digest` alongside the modifications and change which peptides land in the index, but appeared nowhere in the key at all. Same defect class.

### Deliberately out of scope

- `Localizeable mods:` is still a sum of counts across proteins. Weaker than it looks, but the `Databases:` line already carries name + `CreationTime`, so a changed database file is caught.
- `CommonParameters.FragmentationParameters` is absent from the key and affects the *fragment* index rather than the peptide list. A separate surface.

### Migration cost

Every cached index on disk misses once and rebuilds. That is the point — those caches were keyed by a predicate that did not determine their contents. Nothing parses `indexEngine.params` (it is only ever compared whole), so unlike `DigestionParams.ToString()` there is no positional-field trap and lines can be replaced freely.

## Tests

`MetaMorpheus/Test/IndexCacheKeyTest.cs`, 26 cases. The helpers are `internal`, reached through the `InternalsVisibleTo("Test")` already declared on EngineLayer.

**Run against unmodified master to confirm they bite: 12 of the 15 that compile there fail.** The three that pass are the ones that should — `IdenticalModificationsGiveTheSameKey`, `TheKeyIsStableAcrossRepeatedCalls`, `AddingAModificationStillChangesTheKey` — because equal inputs must still reuse the cached index, or every search re-indexes for nothing.

Full suite green: **2026 passed, 0 failed, 1 skipped.**

### Mutation testing

Stryker.NET 4.16 over `IndexingEngine.cs`, test set scoped to this fixture. For the four new helper methods: **21 killed, 0 survived, 0 timeout.**

It found a real gap on the first pass — the `,` separator in `DescribeSilacLabels` could be deleted without any test noticing, because no test used more than one label. Three of the 26 tests exist because of that run.

Remaining, all pre-existing and untouched here: one survivor on `CurrentPartition = currentPartition + 1`, and four timeouts on the `WaterMonoisotopicMass` static initializer. Note also that Stryker's safe mode discards every mutant inside `ToString` itself, because a pre-existing untyped `Select` on the `Localizeable mods:` line makes its own mutant uncompilable (`CS0411`) — so the four changed lines in `ToString` are covered by the tests and the before/after above, but not by mutation score.

## Coordination

#2742 rewrites `CheckFiles`/`SameSettings` on the same cache-hit path and documents `ToString()` as "the cache key", but never touches these lines. Whichever lands second may need a small textual rebase inside `IndexingEngine.cs`; there is no semantic conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQW1W2eic6fPz5YgUtYE2u

