### PR TITLE
Key the index cache on database content, and stop abandoning the lookup early

### DIFF
--- a/MetaMorpheus/EngineLayer/Indexing/IndexingEngine.cs
+++ b/MetaMorpheus/EngineLayer/Indexing/IndexingEngine.cs
@@ -4,6 +4,7 @@ using Proteomics;
 using Omics.Fragmentation;
 using Proteomics.ProteolyticDigestion;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -22,6 +23,9 @@ namespace EngineLayer.Indexing
         private static readonly double WaterMonoisotopicMass = PeriodicTable.GetElement("H").PrincipalIsotope.AtomicMass * 2 + PeriodicTable.GetElement("O").PrincipalIsotope.AtomicMass;
 
         private const int FragmentBinsPerDalton = 1000;
+
+        // keyed on a file's path, length and last write time; see ContentHash
+        private static readonly ConcurrentDictionary<string, string> ContentHashes = new();
         private readonly List<Protein> ProteinList;
         private readonly List<Modification> FixedModifications;
         private readonly List<Modification> VariableModifications;
@@ -60,7 +64,7 @@ namespace EngineLayer.Indexing
         public override string ToString()
         {
             var sb = new StringBuilder();
-            sb.AppendLine("Databases: " + string.Join(",", ProteinDatabases.OrderBy(p => p.Name).Select(p => p.Name + ":" + p.CreationTime)));
+            sb.AppendLine("Databases: " + DescribeDatabases(ProteinDatabases));
             sb.AppendLine("Partitions: " + CurrentPartition + "/" + CommonParameters.TotalPartitions);
             sb.AppendLine("Precursor Index: " + GeneratePrecursorIndex);
             sb.AppendLine("Search Decoys: " + DecoyType);
@@ -186,6 +190,95 @@ namespace EngineLayer.Indexing
             string normalized = definition.Replace("\r\n", "\n").Replace('\r', '\n');
             byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(normalized));
             return Convert.ToHexString(hash, 0, 8).ToLowerInvariant();
+        }
+
+        /// <summary>
+        /// The identity of the database list, for the index cache key.
+        /// </summary>
+        /// <remarks>
+        /// Each database is named and then qualified by a hash of its content. The key previously used
+        /// the file name and its CreationTime, and CreationTime does not move when a file is edited in
+        /// place: regenerate or hand-edit a FASTA at the same path and every byte of the key stays the
+        /// same, so the search reuses an index built from the old proteins. The name on its own is not
+        /// an identity either, being a bare file name rather than a path.
+        ///
+        /// Hashing is gated on (path, length, last write time) and memoised, because ToString is called
+        /// once per candidate index folder per database per partition and hashing on every call would
+        /// cost minutes on a large proteome. Content still decides the key, so touching a database
+        /// without changing it re-hashes but does not invalidate the cache. Within one process a file
+        /// edited to exactly its former length and write time would keep its old hash; across processes
+        /// the memo starts empty.
+        ///
+        /// The list order is preserved rather than sorted, for the same reason the modification list is.
+        /// DatabaseLoadingEngine.LoadBioPolymers appends each database's entries in list order and
+        /// SearchTask slices that list by index to build partitions, so with more than one partition a
+        /// reordered database list puts different proteins in partition k. Sorting here, as the key used
+        /// to, lets those two orders share one key.
+        /// </remarks>
+        internal static string DescribeDatabases(IEnumerable<FileInfo> databases)
+        {
+            if (databases == null)
+            {
+                return "none";
+            }
+
+            return string.Join(",", databases.Select(DescribeDatabase));
+        }
+
+        internal static string DescribeDatabase(FileInfo database)
+        {
+            if (database == null)
+            {
+                return "none";
+            }
+
+            return database.Name + "[" + ContentHash(database) + "]";
+        }
+
+        /// <summary>
+        /// A short hash of a file's content, memoised so a database is read at most once per edit.
+        /// </summary>
+        /// <remarks>
+        /// A file that cannot be read falls back to hashing its stamp, which still moves when the file
+        /// is edited. Throwing would take down a cache-key comparison over a database the search is
+        /// about to fail on anyway, and returning a constant would let two unreadable files share a key.
+        /// </remarks>
+        internal static string ContentHash(FileInfo database)
+        {
+            // FileInfo caches its metadata from construction, and the same instance is used for every
+            // candidate folder, so an edit mid-run would otherwise go unnoticed.
+            database.Refresh();
+
+            if (!database.Exists)
+            {
+                return "missing";
+            }
+
+            // The separators are load-bearing: without them "<dir>/x1.fasta" of length 23 and
+            // "<dir>/x1.fasta2" of length 3 produce the same stamp, and the second file would be handed
+            // the first one's hash.
+            string stamp = database.FullName + "|" + database.Length + "|" + database.LastWriteTimeUtc.ToBinary();
+
+            if (ContentHashes.TryGetValue(stamp, out string cached))
+            {
+                return cached;
+            }
+
+            string hash;
+            try
+            {
+                using FileStream stream = database.OpenRead();
+                hash = Convert.ToHexString(SHA256.HashData(stream), 0, 8).ToLowerInvariant();
+            }
+            catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+            {
+                // Deliberately not memoised. A database locked by another process for a moment must not
+                // pin its stamp to the fallback for the life of the process.
+                return ShortHash(stamp);
+            }
+
+            ContentHashes[stamp] = hash;
+            return hash;
         }
 
         protected override MetaMorpheusEngineResults RunSpecific()

--- a/MetaMorpheus/EngineLayer/Indexing/IndexingEngine.cs
+++ b/MetaMorpheus/EngineLayer/Indexing/IndexingEngine.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 using Omics;
@@ -64,8 +65,12 @@ namespace EngineLayer.Indexing
             sb.AppendLine("Precursor Index: " + GeneratePrecursorIndex);
             sb.AppendLine("Search Decoys: " + DecoyType);
             sb.AppendLine("Number of proteins: " + ProteinList.Count);
-            sb.AppendLine("Number of fixed mods: " + FixedModifications.Count);
-            sb.AppendLine("Number of variable mods: " + VariableModifications.Count);
+            sb.AppendLine("Fixed mods: " + DescribeModifications(FixedModifications));
+            sb.AppendLine("Variable mods: " + DescribeModifications(VariableModifications));
+            sb.AppendLine("Silac labels: " + DescribeSilacLabels(SilacLabels));
+            sb.AppendLine("Turnover labels: " + (TurnoverLabels == null
+                ? "none"
+                : DescribeSilacLabel(TurnoverLabels.Value.StartLabel) + ">" + DescribeSilacLabel(TurnoverLabels.Value.EndLabel)));
             sb.AppendLine("Dissociation Type: " + CommonParameters.DissociationType);
             sb.AppendLine("Contaminant Handling: " + TcAmbiguity);
 
@@ -85,6 +90,102 @@ namespace EngineLayer.Indexing
 
             sb.Append("Localizeable mods: " + ProteinList.Select(b => b.OneBasedPossibleLocalizedModifications.Count).Sum());
             return sb.ToString();
+        }
+
+        /// <summary>
+        /// The identity of a modification list, for the index cache key.
+        /// </summary>
+        /// <remarks>
+        /// This names every modification instead of counting them. Counting was the defect: the cache key
+        /// is compared as literal text by <c>MetaMorpheusTask.SameSettings</c>, so two searches whose
+        /// modification lists differed but happened to be the same length produced the same key, and the
+        /// second search silently reused a peptide index built for the first one's modifications. The
+        /// index stores decorated <c>PeptideWithSetModifications</c>, so that index is wrong rather than
+        /// merely incomplete: a variable-mod swap loses every peptide bearing the new modification, and a
+        /// fixed-mod swap puts wrong masses in every entry.
+        ///
+        /// Each entry is the readable id followed by a short hash of the modification's complete definition
+        /// (<see cref="Modification.ToString"/>, i.e. its mods.txt record: target, location restriction,
+        /// chemical formula, monoisotopic mass, neutral losses, diagnostic ions). The id alone would miss
+        /// a user who edited a custom modification file in place, keeping the name and changing the mass;
+        /// the hash covers every field, and keeps covering fields added to Modification later.
+        ///
+        /// The list order is deliberately preserved rather than sorted. Modification enumeration is
+        /// truncated at MaxModificationIsoforms by a yield break in
+        /// <c>ProteolyticPeptide.GetModifiedPeptides</c>, so which isoforms survive can depend on the
+        /// order the modifications arrive in. Sorting here would let two orders share one key and reuse
+        /// each other's index. Preserving order can only cost a needless rebuild, never a wrong reuse.
+        /// </remarks>
+        internal static string DescribeModifications(IEnumerable<Modification> modifications)
+        {
+            if (modifications == null)
+            {
+                return "none";
+            }
+
+            return string.Join(",", modifications.Select(m =>
+                (m?.IdWithMotif ?? "unnamed") + "[" + ShortHash(m?.ToString()) + "]"));
+        }
+
+        /// <summary>
+        /// The identity of the SILAC label list, for the index cache key. Labels reach
+        /// <c>Protein.Digest</c> alongside the modifications and change which peptides land in the index,
+        /// but appeared nowhere in the key. <see cref="SilacLabel"/> does not override ToString, so the
+        /// fields are named here. Order is preserved for the same reason as the modifications.
+        /// </summary>
+        internal static string DescribeSilacLabels(IEnumerable<SilacLabel> labels)
+        {
+            if (labels == null)
+            {
+                return "none";
+            }
+
+            return string.Join(",", labels.Select(DescribeSilacLabel));
+        }
+
+        internal static string DescribeSilacLabel(SilacLabel label)
+        {
+            if (label == null)
+            {
+                return "none";
+            }
+
+            var sb = new StringBuilder();
+            sb.Append(label.OriginalAminoAcid).Append('>').Append(label.AminoAcidLabel)
+                .Append('(').Append(label.LabelChemicalFormula).Append(',').Append(label.MassDifference).Append(')');
+
+            if (label.AdditionalLabels != null)
+            {
+                foreach (SilacLabel additionalLabel in label.AdditionalLabels)
+                {
+                    sb.Append('+').Append(DescribeSilacLabel(additionalLabel));
+                }
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// A short, stable hash of a definition string, for use inside the index cache key.
+        /// </summary>
+        /// <remarks>
+        /// Line endings are normalised first. <see cref="Modification.ToString"/> builds its text with
+        /// AppendLine, which emits the writing machine's line ending, so the same modification would
+        /// otherwise hash differently on Windows and Linux and force a rebuild on nothing.
+        ///
+        /// Eight bytes separates the handful of modifications in a search many times over, and keeps the
+        /// key readable next to the id it qualifies. This is a cache key, not a security boundary.
+        /// </remarks>
+        internal static string ShortHash(string definition)
+        {
+            if (string.IsNullOrEmpty(definition))
+            {
+                return "none";
+            }
+
+            string normalized = definition.Replace("\r\n", "\n").Replace('\r', '\n');
+            byte[] hash = SHA256.HashData(Encoding.UTF8.GetBytes(normalized));
+            return Convert.ToHexString(hash, 0, 8).ToLowerInvariant();
         }
 
         protected override MetaMorpheusEngineResults RunSpecific()

--- a/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
+++ b/MetaMorpheus/TaskLayer/MetaMorpheusTask.cs
@@ -1,4 +1,4 @@
-using Chemistry;
+﻿using Chemistry;
 using EngineLayer;
 using EngineLayer.Indexing;
 using MassSpectrometry;
@@ -31,6 +31,8 @@ using EngineLayer.Util;
 using EngineLayer.DIA;
 using EngineLayer.SpectrumMatch;
 using Omics.Fragmentation;
+
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Test")]
 
 namespace TaskLayer
 {
@@ -1333,7 +1335,7 @@ namespace TaskLayer
             }
         }
 
-        private static string GetExistingFolderWithIndices(IndexingEngine indexEngine, List<DbForTask> dbFilenameList)
+        internal static string GetExistingFolderWithIndices(IndexingEngine indexEngine, List<DbForTask> dbFilenameList)
         {
             foreach (var database in dbFilenameList)
             {
@@ -1342,7 +1344,9 @@ namespace TaskLayer
 
                 if (!Directory.Exists(indexDirectory.FullName))
                 {
-                    return null;
+                    // Keep looking. The index for a multi-database search is written beside the FIRST
+                    // database only, so returning here strands a usable cache sitting under a later one.
+                    continue;
                 }
 
                 // all directories in the same directory as the bioPolymer database

--- a/MetaMorpheus/Test/IndexCacheDatabaseKeyTest.cs
+++ b/MetaMorpheus/Test/IndexCacheDatabaseKeyTest.cs
@@ -1,0 +1,360 @@
+using EngineLayer;
+using EngineLayer.DatabaseLoading;
+using EngineLayer.Indexing;
+using NUnit.Framework;
+using Omics.Modifications;
+using Proteomics;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using TaskLayer;
+using UsefulProteomicsDatabases;
+
+namespace Test
+{
+    /// <summary>
+    /// The database half of the index cache key, and the lookup that consumes it.
+    ///
+    /// The key used to identify a database by file name and CreationTime. CreationTime does not move
+    /// when a file is edited in place, so regenerating or hand-editing a FASTA at the same path left
+    /// every byte of the key unchanged and the search reused an index built from the old proteins.
+    /// The key now carries a hash of the file's content.
+    /// </summary>
+    [TestFixture]
+    public static class IndexCacheDatabaseKeyTest
+    {
+        private static string _scratch;
+
+        [OneTimeSetUp]
+        public static void SetUp()
+        {
+            _scratch = Path.Combine(TestContext.CurrentContext.TestDirectory, "IndexCacheDatabaseKeyTest", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_scratch);
+        }
+
+        [OneTimeTearDown]
+        public static void TearDown()
+        {
+            try
+            {
+                if (Directory.Exists(_scratch)) Directory.Delete(_scratch, recursive: true);
+            }
+            catch (IOException)
+            {
+                // a leftover scratch directory is not worth failing a test run over
+            }
+        }
+
+        private static FileInfo WriteDatabase(string relativePath, string contents)
+        {
+            string full = Path.Combine(_scratch, relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(full));
+            File.WriteAllText(full, contents);
+            return new FileInfo(full);
+        }
+
+        private const string OneProtein = ">sp|P00001|ONE_HUMAN Protein one\nPEPTIDEKMNNNK\n";
+        private const string OtherProtein = ">sp|P00002|TWO_HUMAN Protein two\nCOMPLETELYDIFFERENTSEQVENCEK\n";
+
+        private static IndexingEngine EngineFor(params FileInfo[] databases)
+        {
+            CommonParameters commonParameters = new CommonParameters();
+            var fileSpecificParameters = new List<(string, CommonParameters)> { ("", commonParameters) };
+
+            return new IndexingEngine(
+                new List<Protein> { new Protein("MNNNKQQQSTC", "accession") },
+                new List<Modification>(), new List<Modification>(),
+                null, null, null, 1, DecoyType.None, commonParameters, fileSpecificParameters,
+                30000, false, databases.ToList(), TargetContaminantAmbiguity.RemoveContaminant, new List<string>());
+        }
+
+        private static string KeyFor(params FileInfo[] databases) => EngineFor(databases).ToString();
+
+        private static string LineStartingWith(string key, string prefix) =>
+            key.Split((char)10).Select(line => line.TrimEnd((char)13)).Single(line => line.StartsWith(prefix));
+
+        // ----- the defect this change exists to fix -----
+
+        [Test]
+        public static void EditingADatabaseInPlaceChangesTheKey()
+        {
+            FileInfo database = WriteDatabase("edited/proteins.fasta", OneProtein);
+            string before = KeyFor(database);
+
+            File.WriteAllText(database.FullName, OtherProtein);
+            string after = KeyFor(database);
+
+            Assert.That(after, Is.Not.EqualTo(before),
+                "Same path, different proteins. A shared key here reuses an index built from the old database.");
+        }
+
+        [Test]
+        public static void CreationTimeAloneWouldNotHaveCaughtThat()
+        {
+            // Pins the reason the old key failed, so nobody reintroduces it. Editing content leaves
+            // CreationTime untouched; only LastWriteTime and Length move, and neither was in the key.
+            FileInfo database = WriteDatabase("ctime/proteins.fasta", OneProtein);
+            DateTime creationBefore = database.CreationTimeUtc;
+
+            File.WriteAllText(database.FullName, OtherProtein);
+            database.Refresh();
+
+            Assert.That(database.CreationTimeUtc, Is.EqualTo(creationBefore),
+                "If this ever fails, CreationTime became a content signal and this test can go.");
+        }
+
+        [Test]
+        public static void TouchingADatabaseWithoutChangingItKeepsTheKey()
+        {
+            // Content decides the key, not the timestamp. A naive (length, last write time) key would
+            // rebuild the index here for nothing.
+            FileInfo database = WriteDatabase("touched/proteins.fasta", OneProtein);
+            string before = KeyFor(database);
+
+            File.SetLastWriteTimeUtc(database.FullName, DateTime.UtcNow.AddMinutes(5));
+
+            Assert.That(KeyFor(database), Is.EqualTo(before));
+        }
+
+        [Test]
+        public static void TwoDatabasesWithTheSameNameInDifferentFoldersGiveDifferentKeys()
+        {
+            // The key names a bare file name, not a path, so content is what separates these.
+            FileInfo first = WriteDatabase("samename/a/proteins.fasta", OneProtein);
+            FileInfo second = WriteDatabase("samename/b/proteins.fasta", OtherProtein);
+
+            Assert.That(first.Name, Is.EqualTo(second.Name));
+            Assert.That(KeyFor(second), Is.Not.EqualTo(KeyFor(first)));
+        }
+
+        // ----- reuse must still happen when nothing changed -----
+
+        [Test]
+        public static void TheSameDatabaseGivesTheSameKey()
+        {
+            FileInfo database = WriteDatabase("stable/proteins.fasta", OneProtein);
+
+            Assert.That(KeyFor(database), Is.EqualTo(KeyFor(database)),
+                "Equal inputs must reuse the cached index, or every search re-indexes.");
+        }
+
+        [Test]
+        public static void IdenticalContentUnderDifferentNamesHashesTheSame()
+        {
+            FileInfo first = WriteDatabase("copies/one.fasta", OneProtein);
+            FileInfo second = WriteDatabase("copies/two.fasta", OneProtein);
+
+            Assert.That(IndexingEngine.ContentHash(second), Is.EqualTo(IndexingEngine.ContentHash(first)),
+                "The hash is over content, so two copies agree...");
+            Assert.That(KeyFor(second), Is.Not.EqualTo(KeyFor(first)),
+                "...while the name still separates them in the key.");
+        }
+
+        // ----- multiple databases, including contaminants -----
+
+        [Test]
+        public static void AddingAContaminantDatabaseChangesTheKey()
+        {
+            FileInfo sample = WriteDatabase("multi/sample.fasta", OneProtein);
+            FileInfo contaminants = WriteDatabase("multi/contaminants.fasta", OtherProtein);
+
+            Assert.That(KeyFor(sample, contaminants), Is.Not.EqualTo(KeyFor(sample)));
+        }
+
+        [Test]
+        public static void EditingOnlyTheContaminantDatabaseChangesTheKey()
+        {
+            FileInfo sample = WriteDatabase("multi2/sample.fasta", OneProtein);
+            FileInfo contaminants = WriteDatabase("multi2/contaminants.fasta", OtherProtein);
+            string before = KeyFor(sample, contaminants);
+
+            File.WriteAllText(contaminants.FullName, OtherProtein + ">sp|P00003|THREE\nMORECONTAMINANTK\n");
+
+            Assert.That(KeyFor(sample, contaminants), Is.Not.EqualTo(before));
+        }
+
+        [Test]
+        public static void ReorderingDatabasesChangesTheKey()
+        {
+            // Not cosmetic, and a change from the old sorted key. LoadBioPolymers appends each database's
+            // entries in list order and SearchTask slices that list by index to build partitions, so with
+            // more than one partition a reordered list puts different proteins in partition k.
+            FileInfo first = WriteDatabase("order/a.fasta", OneProtein);
+            FileInfo second = WriteDatabase("order/b.fasta", OtherProtein);
+
+            Assert.That(KeyFor(second, first), Is.Not.EqualTo(KeyFor(first, second)));
+        }
+
+        [Test]
+        public static void TheKeyNamesEachDatabaseAndQualifiesItWithAContentHash()
+        {
+            FileInfo first = WriteDatabase("render/a.fasta", OneProtein);
+            FileInfo second = WriteDatabase("render/b.fasta", OtherProtein);
+
+            string line = LineStartingWith(KeyFor(first, second), "Databases: ");
+
+            Assert.That(line, Is.EqualTo("Databases: " +
+                "a.fasta[" + IndexingEngine.ContentHash(first) + "]," +
+                "b.fasta[" + IndexingEngine.ContentHash(second) + "]"));
+        }
+
+        // ----- degenerate inputs -----
+
+        [Test]
+        public static void AMissingDatabaseIsDescribedNotThrown()
+        {
+            FileInfo missing = new FileInfo(Path.Combine(_scratch, "gone", "never-written.fasta"));
+
+            Assert.That(IndexingEngine.ContentHash(missing), Is.EqualTo("missing"));
+            Assert.That(() => KeyFor(missing), Throws.Nothing);
+        }
+
+        [Test]
+        public static void ADatabaseThatAppearsLaterIsNoticed()
+        {
+            // FileInfo caches its metadata from construction, and the same instance is reused across
+            // candidate folders, so ContentHash refreshes before reading.
+            FileInfo database = new FileInfo(Path.Combine(_scratch, "appears", "proteins.fasta"));
+            string whileMissing = IndexingEngine.ContentHash(database);
+
+            Directory.CreateDirectory(Path.GetDirectoryName(database.FullName));
+            File.WriteAllText(database.FullName, OneProtein);
+
+            Assert.That(whileMissing, Is.EqualTo("missing"));
+            Assert.That(IndexingEngine.ContentHash(database), Is.Not.EqualTo("missing"));
+        }
+
+        [Test]
+        public static void NullDatabaseListsAndEntriesAreDescribed()
+        {
+            Assert.That(IndexingEngine.DescribeDatabases(null), Is.EqualTo("none"));
+            Assert.That(IndexingEngine.DescribeDatabases(new List<FileInfo>()), Is.Empty);
+            Assert.That(IndexingEngine.DescribeDatabase(null), Is.EqualTo("none"));
+        }
+
+        [Test]
+        public static void TheStampSeparatesPathFromLengthFromWriteTime()
+        {
+            // The memo is keyed on path|length|write time. Drop the separators and "x1.fasta" of length
+            // 23 collides with "x1.fasta2" of length 3, handing the second file the first one's hash.
+            FileInfo first = WriteDatabase("stamp/x1.fasta", new string('A', 23));
+            FileInfo second = WriteDatabase("stamp/x1.fasta2", new string('B', 3));
+
+            Assert.That(first.Length, Is.EqualTo(23));
+            Assert.That(second.Length, Is.EqualTo(3));
+
+            DateTime shared = DateTime.UtcNow.AddMinutes(-1);
+            File.SetLastWriteTimeUtc(first.FullName, shared);
+            File.SetLastWriteTimeUtc(second.FullName, shared);
+
+            Assert.That(IndexingEngine.ContentHash(second), Is.Not.EqualTo(IndexingEngine.ContentHash(first)));
+        }
+
+        [Test]
+        public static void AnUnreadableDatabaseFallsBackInsteadOfThrowing()
+        {
+            FileInfo database = WriteDatabase("locked/proteins.fasta", OneProtein);
+
+            string whileLocked;
+            using (File.Open(database.FullName, FileMode.Open, FileAccess.Read, FileShare.None))
+            {
+                whileLocked = IndexingEngine.ContentHash(database);
+            }
+
+            Assert.That(whileLocked, Has.Length.EqualTo(16), "the fallback still has to look like a hash");
+
+            // The fallback must not be memoised, or a momentary lock would pin this database's key for
+            // the life of the process.
+            Assert.That(IndexingEngine.ContentHash(database), Is.Not.EqualTo(whileLocked));
+        }
+
+        [Test]
+        public static void ContentHashIsSixteenLowercaseHexCharacters()
+        {
+            FileInfo database = WriteDatabase("hexshape/proteins.fasta", OneProtein);
+            string hash = IndexingEngine.ContentHash(database);
+
+            Assert.That(hash, Has.Length.EqualTo(16));
+            Assert.That(hash.All(c => (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')), Is.True,
+                "Expected lowercase hex, got: " + hash);
+        }
+
+        // ----- the lookup that consumes the key -----
+
+        private static void PlantIndexFolder(FileInfo besideDatabase, IndexingEngine engine)
+        {
+            string folder = Path.Combine(besideDatabase.DirectoryName, MetaMorpheusTask.IndexFolderName, "2026-09-10-00-00-00");
+            Directory.CreateDirectory(folder);
+
+            File.WriteAllText(Path.Combine(folder, MetaMorpheusTask.IndexEngineParamsFileName), engine.ToString());
+            File.WriteAllText(Path.Combine(folder, MetaMorpheusTask.PeptideIndexFileName), string.Empty);
+            File.WriteAllText(Path.Combine(folder, MetaMorpheusTask.FragmentIndexFileName), string.Empty);
+        }
+
+        [Test]
+        public static void AnIndexUnderALaterDatabaseIsFoundWhenTheFirstHasNoIndexFolder()
+        {
+            // The index of a multi-database search is written beside the FIRST database only. Reorder the
+            // databases and the cache now sits under a later one; the lookup used to give up at the first
+            // database without an index folder and rebuild from scratch.
+            FileInfo first = WriteDatabase("lookup/first/a.fasta", OneProtein);
+            FileInfo second = WriteDatabase("lookup/second/b.fasta", OtherProtein);
+
+            IndexingEngine engine = EngineFor(first, second);
+            PlantIndexFolder(second, engine);
+
+            Assert.That(Directory.Exists(Path.Combine(first.DirectoryName, MetaMorpheusTask.IndexFolderName)), Is.False,
+                "the first database must have no index folder for this to test anything");
+
+            string found = MetaMorpheusTask.GetExistingFolderWithIndices(engine,
+                new List<DbForTask> { new DbForTask(first.FullName, false), new DbForTask(second.FullName, false) });
+
+            Assert.That(found, Is.Not.Null, "a usable index under the second database was stranded");
+            Assert.That(Directory.GetParent(found).Parent.FullName, Is.EqualTo(second.DirectoryName));
+        }
+
+        [Test]
+        public static void AnIndexUnderTheFirstDatabaseIsStillFound()
+        {
+            FileInfo first = WriteDatabase("lookupfirst/first/a.fasta", OneProtein);
+            FileInfo second = WriteDatabase("lookupfirst/second/b.fasta", OtherProtein);
+
+            IndexingEngine engine = EngineFor(first, second);
+            PlantIndexFolder(first, engine);
+
+            string found = MetaMorpheusTask.GetExistingFolderWithIndices(engine,
+                new List<DbForTask> { new DbForTask(first.FullName, false), new DbForTask(second.FullName, false) });
+
+            Assert.That(found, Is.Not.Null);
+            Assert.That(Directory.GetParent(found).Parent.FullName, Is.EqualTo(first.DirectoryName));
+        }
+
+        [Test]
+        public static void AnIndexBuiltForADifferentDatabaseIsNotReused()
+        {
+            FileInfo first = WriteDatabase("mismatch/first/a.fasta", OneProtein);
+            FileInfo second = WriteDatabase("mismatch/second/b.fasta", OtherProtein);
+
+            PlantIndexFolder(second, EngineFor(first, second));
+
+            // now the search asks for the second database only, so the planted key must not match
+            string found = MetaMorpheusTask.GetExistingFolderWithIndices(EngineFor(second),
+                new List<DbForTask> { new DbForTask(second.FullName, false) });
+
+            Assert.That(found, Is.Null);
+        }
+
+        [Test]
+        public static void NoIndexAnywhereReturnsNull()
+        {
+            FileInfo first = WriteDatabase("empty/first/a.fasta", OneProtein);
+            FileInfo second = WriteDatabase("empty/second/b.fasta", OtherProtein);
+
+            string found = MetaMorpheusTask.GetExistingFolderWithIndices(EngineFor(first, second),
+                new List<DbForTask> { new DbForTask(first.FullName, false), new DbForTask(second.FullName, false) });
+
+            Assert.That(found, Is.Null);
+        }
+    }
+}

--- a/MetaMorpheus/Test/IndexCacheKeyTest.cs
+++ b/MetaMorpheus/Test/IndexCacheKeyTest.cs
@@ -1,0 +1,335 @@
+﻿using EngineLayer;
+using EngineLayer.Indexing;
+using NUnit.Framework;
+using Omics.Modifications;
+using Proteomics;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UsefulProteomicsDatabases;
+
+namespace Test
+{
+    /// <summary>
+    /// The peptide index is cached on disk and reused whenever <see cref="IndexingEngine.ToString"/>
+    /// matches the params file written beside it (MetaMorpheusTask.SameSettings compares the two as
+    /// literal text). These tests pin the property that makes reuse safe: anything that changes which
+    /// peptides land in the index must change the key.
+    ///
+    /// The key used to carry modification *counts* only ("Number of variable mods: 1"). Two searches
+    /// whose modification lists differed but happened to be the same length therefore shared a key, and
+    /// the second silently reused an index built for the first one's modifications. Because the index
+    /// stores decorated PeptideWithSetModifications, that index is wrong and not merely incomplete.
+    /// </summary>
+    [TestFixture]
+    public static class IndexCacheKeyTest
+    {
+        private const char CarriageReturn = (char)13;
+        private const char LineFeed = (char)10;
+
+        private static Modification Mod(string id, string motifString, double mass, string locationRestriction = "Anywhere.")
+        {
+            ModificationMotif.TryGetMotif(motifString, out ModificationMotif motif);
+            return new Modification(_originalId: id, _modificationType: "Test", _target: motif,
+                _locationRestriction: locationRestriction, _monoisotopicMass: mass);
+        }
+
+        private static Modification Oxidation => Mod("Oxidation on M", "M", 15.994915);
+        private static Modification Phospho => Mod("Phospho on S", "S", 79.966331);
+        private static Modification Carbamidomethyl => Mod("Carbamidomethyl on C", "C", 57.021464);
+        private static Modification Iodoacetamide => Mod("Iodoacetamide derivative on C", "C", 58.005479);
+
+        private static string KeyFor(List<Modification> variableMods = null, List<Modification> fixedMods = null,
+            List<SilacLabel> silacLabels = null, SilacLabel startLabel = null, SilacLabel endLabel = null)
+        {
+            CommonParameters commonParameters = new CommonParameters();
+            var fileSpecificParameters = new List<(string, CommonParameters)> { ("", commonParameters) };
+
+            var engine = new IndexingEngine(
+                new List<Protein> { new Protein("MNNNKQQQSTC", "accession") },
+                variableMods ?? new List<Modification>(),
+                fixedMods ?? new List<Modification>(),
+                silacLabels, startLabel, endLabel, 1, DecoyType.None, commonParameters, fileSpecificParameters,
+                30000, false, new List<FileInfo>(), TargetContaminantAmbiguity.RemoveContaminant, new List<string>());
+
+            return engine.ToString();
+        }
+
+        private static string LineStartingWith(string key, string prefix) =>
+            key.Split(LineFeed).Select(line => line.TrimEnd(CarriageReturn)).Single(line => line.StartsWith(prefix));
+
+        // ----- the defect this change exists to fix -----
+
+        [Test]
+        public static void SwappingOneVariableModForAnotherChangesTheKey()
+        {
+            string withOxidation = KeyFor(variableMods: new List<Modification> { Oxidation });
+            string withPhospho = KeyFor(variableMods: new List<Modification> { Phospho });
+
+            Assert.That(withPhospho, Is.Not.EqualTo(withOxidation),
+                "Same number of variable mods, different mods. A shared key here reuses an index that " +
+                "contains no phospho peptides at all.");
+        }
+
+        [Test]
+        public static void SwappingOneFixedModForAnotherChangesTheKey()
+        {
+            string withCarbamidomethyl = KeyFor(fixedMods: new List<Modification> { Carbamidomethyl });
+            string withIodoacetamide = KeyFor(fixedMods: new List<Modification> { Iodoacetamide });
+
+            Assert.That(withIodoacetamide, Is.Not.EqualTo(withCarbamidomethyl),
+                "Same number of fixed mods, different mods. A shared key here reuses an index whose " +
+                "every peptide mass is wrong.");
+        }
+
+        [Test]
+        public static void SwappingModsWithinAMultiModListChangesTheKey()
+        {
+            string first = KeyFor(variableMods: new List<Modification> { Oxidation, Phospho });
+            string second = KeyFor(variableMods: new List<Modification> { Oxidation, Mod("Acetyl on K", "K", 42.010565) });
+
+            Assert.That(second, Is.Not.EqualTo(first));
+        }
+
+        [Test]
+        public static void TheKeyNoLongerCountsModifications()
+        {
+            string key = KeyFor(variableMods: new List<Modification> { Oxidation });
+
+            Assert.That(key, Does.Not.Contain("Number of variable mods"));
+            Assert.That(key, Does.Not.Contain("Number of fixed mods"));
+        }
+
+        // ----- reuse must still happen when nothing relevant changed -----
+
+        [Test]
+        public static void IdenticalModificationsGiveTheSameKey()
+        {
+            string first = KeyFor(variableMods: new List<Modification> { Oxidation, Phospho },
+                fixedMods: new List<Modification> { Carbamidomethyl });
+            string second = KeyFor(variableMods: new List<Modification> { Oxidation, Phospho },
+                fixedMods: new List<Modification> { Carbamidomethyl });
+
+            Assert.That(second, Is.EqualTo(first),
+                "Equal inputs must reuse the cached index, or every search re-indexes for nothing.");
+        }
+
+        [Test]
+        public static void TheKeyIsStableAcrossRepeatedCalls()
+        {
+            string key = KeyFor(variableMods: new List<Modification> { Oxidation });
+
+            Assert.That(KeyFor(variableMods: new List<Modification> { Oxidation }), Is.EqualTo(key));
+        }
+
+        // ----- identity is the whole definition, not just the name -----
+
+        [Test]
+        public static void EditingAModificationsMassInPlaceChangesTheKey()
+        {
+            // A user editing a custom mods file, keeping the name and changing the mass. Keying on the
+            // id alone would reuse an index built with the old mass.
+            string original = KeyFor(variableMods: new List<Modification> { Mod("Custom on M", "M", 15.994915) });
+            string edited = KeyFor(variableMods: new List<Modification> { Mod("Custom on M", "M", 16.994915) });
+
+            Assert.That(edited, Is.Not.EqualTo(original));
+        }
+
+        [Test]
+        public static void ChangingOnlyTheLocationRestrictionChangesTheKey()
+        {
+            string anywhere = KeyFor(variableMods: new List<Modification> { Mod("Acetyl on K", "K", 42.010565, "Anywhere.") });
+            string nTerminal = KeyFor(variableMods: new List<Modification> { Mod("Acetyl on K", "K", 42.010565, "N-terminal.") });
+
+            Assert.That(nTerminal, Is.Not.EqualTo(anywhere),
+                "Same name and mass, different placement, so different peptides.");
+        }
+
+        [Test]
+        public static void TheKeyNamesEachModificationAndQualifiesItWithAShortHash()
+        {
+            string line = LineStartingWith(KeyFor(variableMods: new List<Modification> { Oxidation, Phospho }), "Variable mods: ");
+
+            Assert.That(line, Is.EqualTo("Variable mods: " +
+                "Oxidation on M[" + IndexingEngine.ShortHash(Oxidation.ToString()) + "]," +
+                "Phospho on S[" + IndexingEngine.ShortHash(Phospho.ToString()) + "]"),
+                "Readable id first, so a human can diff two params files and see what changed.");
+        }
+
+        // ----- order is deliberately significant -----
+
+        [Test]
+        public static void ReorderingTheVariableModListChangesTheKey()
+        {
+            // Not cosmetic. GetVariableModificationPatterns is truncated at MaxModificationIsoforms by a
+            // yield break, so which isoforms survive can depend on the order the mods arrive in. Sorting
+            // the key would let two orders reuse each other's index.
+            string forward = KeyFor(variableMods: new List<Modification> { Oxidation, Phospho });
+            string reversed = KeyFor(variableMods: new List<Modification> { Phospho, Oxidation });
+
+            Assert.That(reversed, Is.Not.EqualTo(forward));
+        }
+
+        // ----- SILAC labels also decide the peptides, and were absent from the key entirely -----
+
+        [Test]
+        public static void SwappingSilacLabelsChangesTheKey()
+        {
+            string lysine = KeyFor(silacLabels: new List<SilacLabel> { new SilacLabel('K', 'a', "C{13}6", 6.020129) });
+            string arginine = KeyFor(silacLabels: new List<SilacLabel> { new SilacLabel('R', 'b', "C{13}6", 6.020129) });
+
+            Assert.That(arginine, Is.Not.EqualTo(lysine));
+        }
+
+        [Test]
+        public static void ChangingASilacLabelMassChangesTheKey()
+        {
+            string light = KeyFor(silacLabels: new List<SilacLabel> { new SilacLabel('K', 'a', "C{13}6", 6.020129) });
+            string heavy = KeyFor(silacLabels: new List<SilacLabel> { new SilacLabel('K', 'a', "C{13}6", 8.014199) });
+
+            Assert.That(heavy, Is.Not.EqualTo(light));
+        }
+
+        [Test]
+        public static void AnAdditionalSilacLabelChangesTheKey()
+        {
+            SilacLabel plain = new SilacLabel('K', 'a', "C{13}6", 6.020129);
+
+            SilacLabel compound = new SilacLabel('K', 'a', "C{13}6", 6.020129);
+            compound.AddAdditionalSilacLabel(new SilacLabel('R', 'b', "C{13}6", 6.020129));
+
+            Assert.That(KeyFor(silacLabels: new List<SilacLabel> { compound }),
+                Is.Not.EqualTo(KeyFor(silacLabels: new List<SilacLabel> { plain })));
+        }
+
+        [Test]
+        public static void TurnoverLabelsChangeTheKey()
+        {
+            SilacLabel start = new SilacLabel('K', 'a', "C{13}6", 6.020129);
+            SilacLabel end = new SilacLabel('K', 'b', "N{15}2", 2.004);
+
+            string none = KeyFor();
+            string withTurnover = KeyFor(startLabel: start, endLabel: end);
+            string swapped = KeyFor(startLabel: end, endLabel: start);
+
+            Assert.That(withTurnover, Is.Not.EqualTo(none));
+            Assert.That(swapped, Is.Not.EqualTo(withTurnover), "Start and end are not interchangeable.");
+        }
+
+        [Test]
+        public static void MultipleSilacLabelsAreSeparated()
+        {
+            // Pins the separator. Without it two labels run together into one token, and a pair of lists
+            // that differ only in where one label ends and the next begins would share a key.
+            SilacLabel first = new SilacLabel('K', 'a', "C{13}6", 6.020129);
+            SilacLabel second = new SilacLabel('R', 'b', "C{13}6", 6.020129);
+
+            string line = LineStartingWith(KeyFor(silacLabels: new List<SilacLabel> { first, second }), "Silac labels: ");
+
+            Assert.That(line, Is.EqualTo("Silac labels: " +
+                IndexingEngine.DescribeSilacLabel(first) + "," + IndexingEngine.DescribeSilacLabel(second)));
+        }
+
+        [Test]
+        public static void NoTurnoverLabelsRendersAsNoneRatherThanAPair()
+        {
+            // The constructor only builds TurnoverLabels when at least one label is given. If that guard
+            // inverted, "no labels" would render as a pair of empties and stop being distinguishable from
+            // a real pair that happens to be empty.
+            string line = LineStartingWith(KeyFor(), "Turnover labels: ");
+
+            Assert.That(line, Is.EqualTo("Turnover labels: none"));
+        }
+
+        [Test]
+        public static void OneTurnoverLabelIsDistinguishableFromNone()
+        {
+            SilacLabel start = new SilacLabel('K', 'a', "C{13}6", 6.020129);
+
+            Assert.That(KeyFor(startLabel: start), Is.Not.EqualTo(KeyFor()));
+        }
+
+        // ----- degenerate inputs must be described, not thrown on -----
+
+        [Test]
+        public static void NullAndEmptyModificationListsAreDescribedAndDistinct()
+        {
+            Assert.That(IndexingEngine.DescribeModifications(null), Is.EqualTo("none"));
+            Assert.That(IndexingEngine.DescribeModifications(new List<Modification>()), Is.Empty);
+        }
+
+        [Test]
+        public static void NullSilacLabelsAreDescribedAndDistinct()
+        {
+            Assert.That(IndexingEngine.DescribeSilacLabels(null), Is.EqualTo("none"));
+            Assert.That(IndexingEngine.DescribeSilacLabels(new List<SilacLabel>()), Is.Empty);
+            Assert.That(IndexingEngine.DescribeSilacLabel(null), Is.EqualTo("none"));
+        }
+
+        [Test]
+        public static void AModificationWithNoIdIsStillDescribed()
+        {
+            // Modification.IdWithMotif is null when the mod was built without an id; ValidModification
+            // rejects those, but the key must not throw on the way to finding that out.
+            string described = IndexingEngine.DescribeModifications(new List<Modification> { new Modification() });
+
+            Assert.That(described, Does.StartWith("unnamed["));
+        }
+
+        [Test]
+        public static void ANullEntryInTheModificationListIsStillDescribed()
+        {
+            Assert.That(() => IndexingEngine.DescribeModifications(new List<Modification> { null }), Throws.Nothing);
+        }
+
+        // ----- the short hash itself -----
+
+        [Test]
+        public static void ShortHashIgnoresLineEndings()
+        {
+            // Modification.ToString builds its text with AppendLine, which emits the writing machine's
+            // line ending. Spelled out as char codes so the test cannot be confused by its own source
+            // file's line endings.
+            string windowsStyle = "MM   15.994915" + CarriageReturn + LineFeed + "TG   M";
+            string unixStyle = "MM   15.994915" + LineFeed + "TG   M";
+            string oldMacStyle = "MM   15.994915" + CarriageReturn + "TG   M";
+
+            Assert.That(IndexingEngine.ShortHash(unixStyle), Is.EqualTo(IndexingEngine.ShortHash(windowsStyle)));
+            Assert.That(IndexingEngine.ShortHash(oldMacStyle), Is.EqualTo(IndexingEngine.ShortHash(windowsStyle)));
+        }
+
+        [Test]
+        public static void ShortHashSeparatesDifferentDefinitions()
+        {
+            Assert.That(IndexingEngine.ShortHash("MM   15.994915"), Is.Not.EqualTo(IndexingEngine.ShortHash("MM   15.994916")));
+        }
+
+        [Test]
+        public static void ShortHashIsSixteenLowercaseHexCharacters()
+        {
+            string shortHash = IndexingEngine.ShortHash(Oxidation.ToString());
+
+            Assert.That(shortHash, Has.Length.EqualTo(16));
+            Assert.That(shortHash.All(c => (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')), Is.True,
+                "Expected lowercase hex, got: " + shortHash);
+        }
+
+        [Test]
+        public static void ShortHashOfNothingIsNone()
+        {
+            Assert.That(IndexingEngine.ShortHash(null), Is.EqualTo("none"));
+            Assert.That(IndexingEngine.ShortHash(string.Empty), Is.EqualTo("none"));
+        }
+
+        // ----- guard the lines that were already correct -----
+
+        [Test]
+        public static void AddingAModificationStillChangesTheKey()
+        {
+            string one = KeyFor(variableMods: new List<Modification> { Oxidation });
+            string two = KeyFor(variableMods: new List<Modification> { Oxidation, Phospho });
+
+            Assert.That(two, Is.Not.EqualTo(one));
+        }
+    }
+}


### PR DESCRIPTION
<!-- project-of-origin -->
> **Project of origin:** `cleavageRules`

> **Stacked on #2807.** That PR's commit is included here because GitHub cannot base a PR on a branch that lives in a fork. Review/merge #2807 first; this one is the second commit, `Key the index cache on database content...`. Once #2807 lands this rebases to a single commit.

Follow-up to #2807, same defect class on a different axis: the index cache key has to name everything that determines the cache's contents.

## Problem 1 — `CreationTime` does not change when a database is edited in place

The key identified each database by file name and `CreationTime`:

```csharp
"Databases: " + string.Join(",", ProteinDatabases.OrderBy(p => p.Name).Select(p => p.Name + ":" + p.CreationTime))
```

Editing a file changes `LastWriteTime` and `Length`. It does **not** change `CreationTime`, and neither of the two that do move was in the key. Demonstrated:

```
BEFORE edit: Creation=2026-09-10T11:16:57.6909407  LastWrite=...57.69  Len=20
AFTER  edit: Creation=2026-09-10T11:16:57.6909407  LastWrite=...58.58  Len=40
```

So regenerate a FASTA, re-run GPTMD onto the same path, or hand-edit an entry, and every byte of the key stays the same — the search reuses an index built from the **old proteins** and reports success.

The bare file name is not an identity either. Two databases called `proteins.fasta` in different folders were separated only by a creation timestamp, and the test for this **fails on the parent commit**: two files written moments apart landed on an identical `CreationTime`, so they collided outright.

### Fix

Each database is named and qualified by a hash of its content:

```
Databases: sample.fasta[3f2a9c1e4b7d8a06],contaminants.fasta[91be04c7de52a3f8]
```

Hashing is gated on `(path, length, last write time)` and memoised. That matters: `ToString()` is called once per candidate index folder per database per partition, so hashing on every call would cost minutes on a large proteome. Measured 925 MB/s here, so a 1 GB UniProt XML costs ~1.1 s once, against an indexing step that runs for minutes.

Content still decides the key, so **touching a database without changing it does not invalidate the cache** — a plain `(length, mtime)` key would rebuild there for nothing. A read failure falls back to hashing the stamp and is deliberately **not** memoised, so a momentary file lock cannot pin a database's key for the life of the process.

## Problem 2 — the database list was sorted, and must not be

`DatabaseLoadingEngine.LoadBioPolymers` appends each database's entries in list order, and `SearchTask` slices that list **by index** to build partitions. So with `TotalPartitions > 1`, reordering the databases puts different proteins in partition *k* — while `OrderBy(p => p.Name)` handed both orders the same key. Same reasoning as the modification list in #2807: preserving order can only cost a needless rebuild, never a wrong reuse.

## Problem 3 — the lookup gave up at the first database without an index folder

```csharp
foreach (var database in dbFilenameList) {
    ...
    if (!Directory.Exists(indexDirectory.FullName))
        return null;        // <-- should be continue
```

`GenerateOutputFolderForIndices` writes the index beside `dbFilenameList.First()` **only**, while the lookup walks every database's folder. So reorder your databases and the cache now sits under a later one — and this `return null` abandoned the whole search at the first database that had no `DatabaseIndex` directory, forcing a full rebuild. Wasted work rather than a wrong answer, but it is the multi-database case that trips it.

## Tests

`MetaMorpheus/Test/IndexCacheDatabaseKeyTest.cs`, 20 cases, covering in-place edits, touch-without-change, same-name-different-folder, contaminant databases, database reordering, missing and unreadable files, and the lookup itself. `GetExistingFolderWithIndices` is now `internal` with `InternalsVisibleTo("Test")` on TaskLayer, matching what EngineLayer and GuiFunctions already do.

- **Against the parent commit, 4 of the 8 that compile there fail:** `EditingADatabaseInPlaceChangesTheKey`, `EditingOnlyTheContaminantDatabaseChangesTheKey`, `ReorderingDatabasesChangesTheKey`, `TwoDatabasesWithTheSameNameInDifferentFoldersGiveDifferentKeys`.
- **Reverting only the `continue` fix fails exactly one test**, the one written for it.
- One test (`CreationTimeAloneWouldNotHaveCaughtThat`) pins the filesystem behaviour that caused the bug, so nobody reintroduces a timestamp key.
- Full suite: **2046 passed, 0 failed, 1 skipped.**

### Mutation testing

Stryker.NET over `IndexingEngine.cs` with the test set scoped to these fixtures: **12 killed in the new database helpers, 1 survivor.**

The first pass had two survivors, both on the memo stamp's `"|"` separators, and chasing them was worth it — it turned up that the original `GetOrAdd` memoised read failures too, which is the process-lifetime pinning described above. That is now fixed and tested.

The remaining survivor is **equivalent**, not a coverage gap: it deletes the separator between `Length` and `LastWriteTimeUtc.ToBinary()`. For any `DateTime` with `Kind == Utc`, `ToBinary()` is `ticks | (1L << 62)`, which is always exactly 19 digits for every representable date — so that boundary is unambiguous with or without the separator and no input can distinguish the mutant. The first separator, between path and length, *is* ambiguous and is pinned by `TheStampSeparatesPathFromLengthFromWriteTime`. The separator stays in as defence against the stamp's shape changing.

`MetaMorpheusTask.cs` is in a different project from the one Stryker was pointed at, so the `continue` fix is not mutation-covered; the revert check above stands in for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQW1W2eic6fPz5YgUtYE2u

